### PR TITLE
[TASK] Update PHP_CodeSniffer to from 2.0dev to 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 env:
   - PHPCS_VERSION=">=1.5.1,<2.0"
-  - PHPCS_VERSION="2.0.*@RC"
+  - PHPCS_VERSION="2.1.0"
 
 php:
   - 5.3


### PR DESCRIPTION
In the meantime, PHP_CodeSniffer 2.0 and 2.1 have been released.

This change updates the Travis configuration to use 2.1.