### PR TITLE
Fix for issue #39

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -85,6 +85,16 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
     }
 
     /**
+     * testCallTimePassByReferenceGlobal
+     *
+     * @return void
+     */
+    public function testCallTimePassByReferenceGlobal()
+    {
+        $this->assertError($this->_sniffFile, 44, 'Using a call-time pass-by-reference is prohibited since php 5.4');
+    }
+
+    /**
      * testBitwiseOperationsAsParameter
      *
      * @return void
@@ -96,6 +106,8 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 26);
         $this->assertNoViolation($this->_sniffFile, 27);
         $this->assertNoViolation($this->_sniffFile, 28);
+        $this->assertNoViolation($this->_sniffFile, 40);
+        $this->assertNoViolation($this->_sniffFile, 41);
     }
 
     /**

--- a/Tests/sniff-examples/call_time_pass_by_reference.php
+++ b/Tests/sniff-examples/call_time_pass_by_reference.php
@@ -27,3 +27,21 @@ foobar($b[0] & $a); // square bracket + &
 foobar(($a) & $b); // parenthesis + &
 foobar(intval(3) & $b); // function + &
 foobar(& $b);
+
+define('MY_CONST', 0);
+
+class MoreRefs
+{
+    const MYCONST = 1;
+    private $attribute = 2;
+
+    public function bar($arg)
+    {
+        $a = sprintf(
+            '%s %s %s'
+            , self::MYCONST & $arg ? 1 : 2
+            , $this->attribute & $arg ? 5 : 6
+            , MY_CONST & $arg ? 7 : 8
+        );
+    }
+}


### PR DESCRIPTION
This shall fix the problem with false positives when a bitwise and is mistaken for a call time pass-by-reference.
https://github.com/wimg/PHPCompatibility/issues/39