### PR TITLE
Only run composer update --lock to prevent updating other dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation in Composer project (method 2)
 },
 
 ```
-* Run `composer update` to install both phpcs and PHPCompatibility coding standard.
+* Run `composer update --lock` to install both phpcs and PHPCompatibility coding standard.
 * Use the coding standard with `./vendor/bin/phpcs --standard=PHPCompatibility`
 
 


### PR DESCRIPTION
Recommend to run 'composer update --lock' instead of 'composer update'. This will update unmeant dependencies, but leaves any other dependencies at it version.