### PR TITLE
Modifications to be able to work with PHP_CodeSniffer version 2.3.0 (stable)

### DIFF
--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -37,7 +37,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff implements PHP_CodeSn
      *
      * @var array(string => array(string => int|string|null))
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                         'call_user_method' => array(
                                             '5.3' => false,
                                             '5.4' => false,

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -37,7 +37,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff implements PHP_CodeSniffer_S
      *
      * @var array(string => array(string => int|string|null))
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                         'array_fill_keys' => array(
                                             '5.1' => false,
                                             '5.2' => true


### PR DESCRIPTION
$forbiddenFunctions declared public, if not, the following error happens with PHPCS 2.3.0:

```
PHP Fatal error:  Access level to PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff::$forbiddenFunctions 
must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in 
/usr/share/pear/PHP/CodeSniffer/Standards/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php on line 358
```