### PR TITLE
Encapsulated a load of duplicated code into a base class, which the individual sniffs extend.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * PHPCompatibility_Sniff.
+ *
+ * PHP version 5.6
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Wim Godden <wim.godden@cu.be>
+ * @copyright 2014 Cu.be Solutions bvba
+ */
+
+/**
+ * PHPCompatibility_Sniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Wim Godden <wim.godden@cu.be>
+ * @version   1.1.0
+ * @copyright 2014 Cu.be Solutions bvba
+ */
+abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
+{
+
+    public function supportsAbove($phpVersion)
+    {
+        if (
+            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+            ||
+            (
+                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+                &&
+                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $phpVersion) >= 0
+            )
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }//end supportsAbove()
+
+    public function supportsBelow($phpVersion)
+    {
+        if (
+            !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+            &&
+            version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $phpVersion) <= 0
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }//end supportsBelow()
+
+}//end class

--- a/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
+++ b/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
@@ -20,7 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DefaultTimeZoneRequiredSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_DefaultTimeZoneRequiredSniff extends PHPCompatibility_Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -45,15 +45,7 @@ class PHPCompatibility_Sniffs_PHP_DefaultTimeZoneRequiredSniff implements PHP_Co
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.4') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.4')) {
             if (ini_get('date.timezone') == false) {
                 $error = 'Default timezone is required since PHP 5.4';
                 $phpcsFile->addError($error, $stackPtr);

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -19,7 +19,7 @@
  * @version   1.1.0
  * @copyright 2014 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -386,15 +386,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff implements PHP_CodeSn
         $this->error = false;
         $previousVersionStatus = null;
         foreach ($this->forbiddenFunctions[$pattern] as $version => $forbidden) {
-            if (
-                is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                ||
-                (
-                    !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                    &&
-                    version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) >= 0
-                )
-            ) {
+            if ($this->supportsAbove($version)) {
                 if ($version != 'alternative') {
                     if ($previousVersionStatus !== $forbidden) {
                         $previousVersionStatus = $forbidden;

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -20,7 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompatibility_Sniff
 {
     /**
      * A list of deprecated INI directives
@@ -173,15 +173,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff implements PHP_Co
 
         foreach ($this->deprecatedIniDirectives[str_replace("'", "", $tokens[$iniToken]['content'])] as $version => $forbidden)
         {
-            if (
-                is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                ||
-                (
-                    !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                    &&
-                    version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) >= 0
-                )
-            ) {
+            if ($this->supportsAbove($version)) {
                 if ($forbidden === true) {
                     $error .= " forbidden";
                 } else {

--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -22,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -54,15 +54,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff implements PHP_Cod
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.3') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
             if ($tokens[$stackPtr - 1]['type'] == 'T_BITWISE_AND' || $tokens[$stackPtr - 2]['type'] == 'T_BITWISE_AND') {
                 $error = 'Assigning the return value of new by reference is deprecated in PHP 5.3';

--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -22,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -54,15 +54,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff i
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.4') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.4')) {
             $tokens = $phpcsFile->getTokens();
             $nextSemicolonToken = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr), null, false);
             for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -26,7 +26,7 @@
  * @copyright 2009 Florian Grandel
  * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -58,15 +58,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff implemen
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.4') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.4')) {
             $tokens = $phpcsFile->getTokens();
 
             // Skip tokens that are the names of functions or classes

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -22,7 +22,7 @@
  * @author    Jansen Price <jansen.price@gmail.com>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -143,15 +143,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff implemen
                 $version = $this->targetedTokens[$tokenCode];
             }
 
-            if (
-                is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                ||
-                (
-                    !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                    &&
-                    version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) >= 0
-                )
-            ) {
+            if ($this->supportsAbove($version)) {
                 $error = sprintf(
                     "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)",
                     $content,

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -22,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -155,15 +155,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff implements PHP_CodeSniffer
             return;
         }
 
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $this->invalidNames[strtolower($tokens[$stackPtr + 2]['content'])]) >= 0
-            )
-        ) {
+        if ($this->supportsAbove($this->invalidNames[strtolower($tokens[$stackPtr + 2]['content'])])) {
             $error = "Function name, class name, namespace name or constant name can not be reserved keyword '" . $tokens[$stackPtr + 2]['content'] . "' (since version " . $this->invalidNames[strtolower($tokens[$stackPtr + 2]['content'])] . ")";
             $phpcsFile->addError($error, $stackPtr);
         }

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -22,7 +22,7 @@
  * @author    Ben Selby <bselby@plus.net>
  * @copyright 2012 Ben Selby
  */
-class PHPCompatibility_Sniffs_PHP_LongArraysSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
 {
     /**
      * Array of HTTP_*_VARS that are now deprecated
@@ -60,15 +60,7 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff implements PHP_CodeSniffer_Sni
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.3') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
 
             if ($tokens[$stackPtr]['type'] == 'T_VARIABLE'

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -19,7 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewClassesSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -268,11 +268,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff implements PHP_CodeSniffer_Sni
 
         $this->error = false;
         foreach ($this->newClasses[$pattern] as $version => $present) {
-            if (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) <= 0
-            ) {
+            if ($this->supportsBelow($version)) {
                 if ($present === false) {
                     $this->error = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -19,7 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -1199,11 +1199,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff implements PHP_CodeSniffer_S
 
         $this->error = false;
         foreach ($this->forbiddenFunctions[$pattern] as $version => $present) {
-            if (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) <= 0
-            ) {
+            if ($this->supportsBelow($version)) {
                 if ($present === false) {
                     $this->error = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -20,7 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility_Sniff
 {
     /**
      * A list of new INI directives
@@ -190,11 +190,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff implements PHP_CodeSniff
         $error = '';
 
         foreach ($this->newIniDirectives[$filteredToken] as $version => $present) {
-            if (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) <= 0
-            ) {
+            if ($this->supportsBelow($version)) {
                 if ($present === true) {
                     $error .= " not available before version " . $version;
                 }

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -19,7 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -147,11 +147,7 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff implements PHP_CodeSniffer_Sn
 
         $this->error = false;
         foreach ($this->newKeywords[$pattern] as $version => $present) {
-            if (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) <= 0
-            ) {
+            if ($this->supportsBelow($version)) {
                 if ($present === false) {
                     $this->error = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';

--- a/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -20,7 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -59,15 +59,7 @@ class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff implements PHP_Code
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.3') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
 
             // Find all the functions in this class or interface

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -20,7 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -319,15 +319,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff implements PHP_CodeSnif
                 foreach ($versionList as $version => $status) {
                     if ($version != 'alternative') {
                         if ($status == -1 || $status == 0) {
-                            if (
-                                is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                                ||
-                                (
-                                    !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                                    &&
-                                    version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $version) >= 0
-                                )
-                            ) {
+                            if ($this->supportsAbove($version)) {
                                 switch ($status) {
                                     case -1:
                                         $error .= 'deprecated since PHP ' . $version . ' and ';

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -22,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff implements PHP_CodeSniffer_Sniff
+class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatibility_Sniff
 {
 
     /**
@@ -68,15 +68,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff implements PHP_Code
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.4') >= 0
-            )
-        ) {
+        if ($this->supportsAbove('5.4')) {
             $tokens = $phpcsFile->getTokens();
 
             if (in_array($tokens[$stackPtr]['content'], $this->algoFunctions) === true) {


### PR DESCRIPTION
Previously, each class was repeating the same rather lengthy version check, to decide whether a sniff error should be reported (based on the specified testVersion), which makes the code hard to read, increases the risk of errors when editing (particularly when new sniffs are added) and makes the logic harder to change in the future (e.g. to specify a range of versions that you need your code to support).

I have therefore created a base class, called PHPCompatibility_Sniff, which all the other sniffs in the project now extend.  This implements PHP_CodeSniffer_Sniff, so child classes no longer need to mention this.  It adds two helper methods, easily available to all sniffs:

* supportsAbove($phpVersion) - returns true if the version being tested against is >= $phpVersion or if no testVersion was specified.
* supportsBelow($phpVersion) - returns true if the version being tested against is <= $phpVersion (returns false if no testVersion was specified).

The logic is identical to the two tests that were previously duplicated all over the place, but it is now encapsulated in a much more easy-to-manage way.

All unit-tests pass: OK (245 tests, 955 assertions)