### PR TITLE
Fix version number for instanceof keyword

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -47,7 +47,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff implemen
         T_GOTO => '5.3',
         T_IMPLEMENTS => '5.0',
         T_INTERFACE => '5.0',
-        T_INSTANCEOF => '5.4',
+        T_INSTANCEOF => '5.0',
         T_INSTEADOF => '5.4',
         T_NAMESPACE => '5.3',
         T_PRIVATE => '5.0',

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -132,7 +132,7 @@ class ForbiddenNamesAsInvokedFunctionsSniffTest extends BaseSniffTest
      */
     public function testInstanceOf()
     {
-        $this->assertError($this->_sniffFile, 15, "'instanceof' is a reserved keyword introduced in PHP version 5.4 and cannot be invoked as a function");
+        $this->assertError($this->_sniffFile, 15, "'instanceof' is a reserved keyword introduced in PHP version 5.0 and cannot be invoked as a function");
     }
 
     /**


### PR DESCRIPTION
The instanceof operator was introduced in PHP 5.0.  Most tests list this correctly, but one test had it incorrectly pegged at 5.4, which I have fixed.