### PR TITLE
Added a new sniff to check for /e modifier in calls to preg_replace()

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff.
+ *
+ * PHP version 5.6
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Wim Godden <wim.godden@cu.be>
+ * @copyright 2014 Cu.be Solutions bvba
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Wim Godden <wim.godden@cu.be>
+ * @version   1.1.0
+ * @copyright 2014 Cu.be Solutions bvba
+ */
+class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * If true, an error will be thrown; otherwise a warning.
+     *
+     * @var bool
+     */
+    public $error = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STRING);
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.5')) {
+            $tokens = $phpcsFile->getTokens();
+
+            if ($tokens[$stackPtr]['content'] == "preg_replace") {
+                $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+
+                if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
+                    return;
+                }
+
+                $firstParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($openBracket + 1), null, true);
+
+                /**
+                 * If argument is not a string, then skip test (e.g. if variable passed in).
+                 */
+                if ($tokens[$firstParam]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+                    return;
+                }
+
+                /**
+                 * Regex is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes
+                 */
+                $regex = $tokens[$firstParam]['content'];
+                $regex = substr($regex, 1, -1);
+
+                $regexFirstChar = substr($regex, 0, 1);
+                $regexEndPos = strrpos($regex, $regexFirstChar);
+
+                $modifiers = substr($regex, $regexEndPos + 1);
+
+                if (strpos($modifiers, "e") !== false) {
+                    $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
+                    $phpcsFile->addError($error, $stackPtr);
+                }
+            }
+        }
+
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * preg_replace() /e modifier sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * preg_replace() /e modifier sniff tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ * @author Jansen Price <jansen.price@gmail.com>
+ */
+class PregReplaceEModifierSniffTest extends BaseSniffTest
+{
+    /**
+     * Sniffed file
+     *
+     * @var PHP_CodeSniffer_File
+     */
+    protected $_sniffFile;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php');
+    }
+
+    /**
+     * testNonDeprecatedPregReplace
+     *
+     * @return void
+     */
+    public function testNonDeprecatedPregReplace()
+    {
+        $this->assertNoViolation($this->_sniffFile, 9);
+        $this->assertNoViolation($this->_sniffFile, 10);
+        $this->assertNoViolation($this->_sniffFile, 13);
+        $this->assertNoViolation($this->_sniffFile, 14);
+        $this->assertNoViolation($this->_sniffFile, 17);
+        $this->assertNoViolation($this->_sniffFile, 18);
+        $this->assertNoViolation($this->_sniffFile, 21);
+    }
+
+    /**
+     * testDeprecatedPregReplace
+     *
+     * @return void
+     */
+    public function testDeprecatedPregReplace()
+    {
+        $error = "preg_replace() - /e modifier is deprecated in PHP 5.5";
+
+        $this->assertError($this->_sniffFile, 26, $error);
+        $this->assertError($this->_sniffFile, 27, $error);
+        $this->assertError($this->_sniffFile, 30, $error);
+        $this->assertError($this->_sniffFile, 31, $error);
+        $this->assertError($this->_sniffFile, 34, $error);
+        $this->assertError($this->_sniffFile, 35, $error);
+        $this->assertError($this->_sniffFile, 36, $error);
+    }
+
+    /**
+     * testUntestablePregReplace
+     *
+     * @return void
+     */
+    public function testUntestablePregReplace()
+    {
+        $this->assertNoViolation($this->_sniffFile, 46);
+        $this->assertNoViolation($this->_sniffFile, 47);
+        $this->assertNoViolation($this->_sniffFile, 48);
+    }
+
+}

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -1,0 +1,48 @@
+<?php
+
+$Source = "anything";
+$Replace = "anything";
+
+///////////// No warning generated:
+
+// Different quote styles.
+preg_replace("/double-quoted/", $Replace, $Source);
+preg_replace('/single-quoted/', $Replace, $Source);
+
+// Different regex markers.
+preg_replace('#hash-chars (common)#', $Replace, $Source);
+preg_replace('!exclamations (why not?!', $Replace, $Source);
+
+// Safe modifiers
+preg_replace('/some text/mS', $Replace, $Source);
+preg_replace('#some text#gi', $Replace, $Source);
+
+// E modifier doesn't exist, but should not trigger error.
+preg_replace('//E', $Replace, $Source);
+
+///////////// Warning generated:
+
+// Different quote styles.
+preg_replace("/double-quoted/e", $Replace, $Source);
+preg_replace('/single-quoted/e', $Replace, $Source);
+
+// Different regex markers.
+preg_replace('#hash-chars (common)#e', $Replace, $Source);
+preg_replace('!exclamations (why not?!e', $Replace, $Source);
+
+// Other modifiers with /e
+preg_replace('/some text/emS', $Replace, $Source);
+preg_replace('/some text/meS', $Replace, $Source);
+preg_replace('/some text/mSe', $Replace, $Source);
+
+///////////// Untestable - should not generate an error.
+
+$Regex = "/anything/";
+X_REGEX_Xe = "/anything/";
+function GetRegex() {
+    return "/anything/";
+}
+
+preg_replace($Regex, $Replace, $Source);
+preg_replace(GetRegex(), $Replace, $Source);
+preg_replace(X_REGEX_Xe, $Replace, $Source);


### PR DESCRIPTION
Added a new sniff to check for /e modifier in calls to preg_replace(), which is deprecated as of PHP 5.5.

Sniff is only able to detect this when a literal string is used, so won't detect when this is passed as a variable/constant/etc.

Unit tests written, all of which pass.

Fixes #71.