### PR TITLE
Change the needle in strpos and fix the /e modifier problem.

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -80,7 +80,7 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
 
                 $modifiers = substr($regex, $regexEndPos + 1);
 
-                if (strpos($modifiers, "e") !== false) {
+                if (strpos($modifiers, "/e") !== false) {
                     $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
                     $phpcsFile->addError($error, $stackPtr);
                 }


### PR DESCRIPTION
This source code throws the preg_replace error but obviously it shouldn't do it:
```php
$text = preg_replace(
    '/(?<!\\\\)     # not preceded by a backslash
      <             # an open bracket
      (             # start capture
        \/?         # optional backslash
        collapse    # the string collapse
        [^>]*       # everything up to the closing angle bracket; note that you cannot use one inside the tag!
      )             # stop capture
      >             # close bracket
    /ix',
    '[$1]',
    $text
  );
```
