### PR TITLE
Updated to PregReplaceEModifierSniff to handle mult-line regular expressions.

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -72,7 +72,14 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
                 /**
                  * Regex is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes
                  */
-                $regex = $tokens[$firstParam]['content'];
+                $regex = "";
+                while (isset($tokens[$firstParam]) && $tokens[$firstParam]['code'] != T_COMMA) {
+                    if ($tokens[$firstParam]['code'] == T_CONSTANT_ENCAPSED_STRING) {
+                        $regex .= $tokens[$firstParam]['content'];
+                    }
+                    $firstParam++;
+                }
+
                 $regex = substr($regex, 1, -1);
 
                 $regexFirstChar = substr($regex, 0, 1);

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -48,6 +48,9 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 17);
         $this->assertNoViolation($this->_sniffFile, 18);
         $this->assertNoViolation($this->_sniffFile, 21);
+        $this->assertNoViolation($this->_sniffFile, 24);
+        $this->assertNoViolation($this->_sniffFile, 39);
+        $this->assertNoViolation($this->_sniffFile, 45);
     }
 
     /**
@@ -59,13 +62,16 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
     {
         $error = "preg_replace() - /e modifier is deprecated in PHP 5.5";
 
-        $this->assertError($this->_sniffFile, 26, $error);
-        $this->assertError($this->_sniffFile, 27, $error);
-        $this->assertError($this->_sniffFile, 30, $error);
-        $this->assertError($this->_sniffFile, 31, $error);
-        $this->assertError($this->_sniffFile, 34, $error);
-        $this->assertError($this->_sniffFile, 35, $error);
-        $this->assertError($this->_sniffFile, 36, $error);
+        $this->assertError($this->_sniffFile, 50, $error);
+        $this->assertError($this->_sniffFile, 51, $error);
+        $this->assertError($this->_sniffFile, 54, $error);
+        $this->assertError($this->_sniffFile, 55, $error);
+        $this->assertError($this->_sniffFile, 58, $error);
+        $this->assertError($this->_sniffFile, 59, $error);
+        $this->assertError($this->_sniffFile, 60, $error);
+        $this->assertError($this->_sniffFile, 63, $error);
+        $this->assertError($this->_sniffFile, 78, $error);
+        $this->assertError($this->_sniffFile, 84, $error);
     }
 
     /**
@@ -75,9 +81,9 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
      */
     public function testUntestablePregReplace()
     {
-        $this->assertNoViolation($this->_sniffFile, 46);
-        $this->assertNoViolation($this->_sniffFile, 47);
-        $this->assertNoViolation($this->_sniffFile, 48);
+        $this->assertNoViolation($this->_sniffFile, 94);
+        $this->assertNoViolation($this->_sniffFile, 95);
+        $this->assertNoViolation($this->_sniffFile, 96);
     }
 
 }

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -20,6 +20,30 @@ preg_replace('#some text#gi', $Replace, $Source);
 // E modifier doesn't exist, but should not trigger error.
 preg_replace('//E', $Replace, $Source);
 
+// Multi-line example (issue #83)
+$text = preg_replace(
+    '/(?<!\\\\)     # not preceded by a backslash
+      <             # an open bracket
+      (             # start capture
+        \/?         # optional backslash
+        collapse    # the string collapse
+        [^>]*       # everything up to the closing angle bracket; note that you cannot use one inside the tag!
+      )             # stop capture
+      >             # close bracket
+    /ix',
+    '[$1]',
+    $text
+  );
+
+// Multi-line with /e in comments.
+preg_replace(
+        '/.*     # /e in a comment
+        /x',
+    $Replace, $Source);
+
+// Escaped /e
+preg_replace('/\/e/', $Replace, $Source);
+
 ///////////// Warning generated:
 
 // Different quote styles.
@@ -34,6 +58,30 @@ preg_replace('!exclamations (why not?!e', $Replace, $Source);
 preg_replace('/some text/emS', $Replace, $Source);
 preg_replace('/some text/meS', $Replace, $Source);
 preg_replace('/some text/mSe', $Replace, $Source);
+
+// Multi-line example (issue #83)
+$text = preg_replace(
+    '/(?<!\\\\)     # not preceded by a backslash
+      <             # an open bracket
+      (             # start capture
+        \/?         # optional backslash
+        collapse    # the string collapse
+        [^>]*       # everything up to the closing angle bracket; note that you cannot use one inside the tag!
+      )             # stop capture
+      >             # close bracket
+    /iex',
+    '[$1]',
+    $text
+  );
+
+// Multi-line with /e in comments.
+preg_replace(
+        '/.*     # /e in a comment
+        /xe',
+    $Replace, $Source);
+
+// Escaped /e
+preg_replace('/\/e/e', $Replace, $Source);
 
 ///////////// Untestable - should not generate an error.
 


### PR DESCRIPTION
This issue arose because CodeSniffer breaks multi-line strings into multiple fragments, therefore in order to treat these as a single string, you need to join the pieces back together.  This commit actually goes one-stage further, and should also support strings built-up by concatenation (though I it may also accept inappropriate syntax in some cases - it has not been rigorously designed).

I have added appropriate test cases - the one reported in issue #83 plus a couple of others that occurred to me, and all tests pass.

This fixes #83.