### PR TITLE
Updating unit tests so that skipped tests are marked as such

### DIFF
--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -80,6 +80,25 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Causes phpunit to skip the test if we are running on a PHP version older than
+     * the one specified.  Should be called at the start of any test that will fail
+     * if running on an older version of PHP, e.g. in situations where the sniff
+     * relies on the parser generating tokens that are not available in that version.
+     *
+     * @param string $version
+     * @return bool
+     */
+    public function requiresPHPVersion($version)
+    {
+        if (version_compare(PHP_VERSION, $version, "<")) {
+            $this->markTestSkipped("Test cannot be run on PHP < " . $version);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    /**
      * Assert a PHPCS error on a particular line number
      *
      * @param PHP_CodeSniffer_File $file Codesniffer file object

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -80,25 +80,6 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Causes phpunit to skip the test if we are running on a PHP version older than
-     * the one specified.  Should be called at the start of any test that will fail
-     * if running on an older version of PHP, e.g. in situations where the sniff
-     * relies on the parser generating tokens that are not available in that version.
-     *
-     * @param string $version
-     * @return bool
-     */
-    public function requiresPHPVersion($version)
-    {
-        if (version_compare(PHP_VERSION, $version, "<")) {
-            $this->markTestSkipped("Test cannot be run on PHP < " . $version);
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    /**
      * Assert a PHPCS error on a particular line number
      *
      * @param PHP_CodeSniffer_File $file Codesniffer file object

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -30,12 +30,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test insteadof
      *
+     * @requires PHP 5.4
      * @return void
      */
     public function testInsteadOf()
     {
-        $this->requiresPHPVersion("5.4");
-
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
         $this->assertError($file, 15, "\"insteadof\" keyword (for traits) is not present in PHP version 5.3 or earlier");
@@ -80,12 +79,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test trait keyword
      *
+     * @requires PHP 5.4
      * @return void
      */
     public function testTraitKeyword()
     {
-        $this->requiresPHPVersion("5.4");
-
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
         $this->assertError($file, 26, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
@@ -94,12 +92,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test trait magic constant
      *
+     * @requires PHP 5.4
      * @return void
      */
     public function testTraitConstant()
     {
-        $this->requiresPHPVersion("5.4");
-
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
         $this->assertError($file, 28, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
@@ -120,12 +117,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test yield
      *
+     * @requires PHP 5.5
      * @return void
      */
     public function testYield()
     {
-        $this->requiresPHPVersion("5.5");
-
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
 
         $this->assertError($file, 35, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
@@ -134,12 +130,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testFinally
      *
+     * @requires PHP 5.5
      * @return void
      */
     public function testFinally()
     {
-        $this->requiresPHPVersion("5.5");
-
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
 
         $this->assertError($file, 9, "\"finally\" keyword (in exception handling) is not present in PHP version 5.4 or earlier");

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -34,11 +34,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
      */
     public function testInsteadOf()
     {
+        $this->requiresPHPVersion("5.4");
+
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            $this->assertError($file, 15, "\"insteadof\" keyword (for traits) is not present in PHP version 5.3 or earlier");
-        }
+        $this->assertError($file, 15, "\"insteadof\" keyword (for traits) is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -84,11 +84,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
      */
     public function testTraitKeyword()
     {
+        $this->requiresPHPVersion("5.4");
+
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            $this->assertError($file, 26, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
-        }
+        $this->assertError($file, 26, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -98,11 +98,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
      */
     public function testTraitConstant()
     {
+        $this->requiresPHPVersion("5.4");
+
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
-        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
-            $this->assertError($file, 28, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
-        }
+        $this->assertError($file, 28, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -124,11 +124,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
      */
     public function testYield()
     {
-        // Note: cannot test this when running PHP version 5.4 because the
-        // token doesn't register with phpcs
-        //$file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
+        $this->requiresPHPVersion("5.5");
 
-        //$this->assertError($file, 35, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
+        $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
+
+        $this->assertError($file, 35, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -138,11 +138,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
      */
     public function testFinally()
     {
-        // Note: cannot test this when running PHP version 5.4 because the
-        // token doesn't register with phpcs
-        //$file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
+        $this->requiresPHPVersion("5.5");
 
-        //$this->assertError($file, 9, "\"finally\" keyword (in exception handling) is not present in PHP version 5.4 or earlier");
+        $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
+
+        $this->assertError($file, 9, "\"finally\" keyword (in exception handling) is not present in PHP version 5.4 or earlier");
     }
 
 }


### PR DESCRIPTION
I've added a helper function for unit-testing, called requiresPHPVersion() to the BaseSniffTest class, and updated code to use it.

This function marks the test as skipped if it is running on a version of PHP for which the test will incorrectly fail (e.g. because the tokenizer won't generate the correct tokens).

Previously there were some tests which used a version_compare() to bypass their functionality on unsupported versions, and others where the body of the test was simply commented out (so it wasn't running on any PHP version) and in both cases the result is that these tests incorrectly appear to pass.  I have updated these tests to use the new function instead, so they are now correctly reported as skipped, which gives a more accurate reflection of the passing state of the test-suite.