### PR TITLE
Tweaks to PregReplaceEModifier unit tests.

### DIFF
--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -86,11 +86,11 @@ preg_replace('/\/e/e', $Replace, $Source);
 ///////////// Untestable - should not generate an error.
 
 $Regex = "/anything/";
-X_REGEX_Xe = "/anything/";
-function GetRegex() {
+define("X_REGEX_Xe", "/anything/");
+function XRegeXe() {
     return "/anything/";
 }
 
 preg_replace($Regex, $Replace, $Source);
-preg_replace(GetRegex(), $Replace, $Source);
+preg_replace(XRegeXe(), $Replace, $Source);
 preg_replace(X_REGEX_Xe, $Replace, $Source);


### PR DESCRIPTION
 Some minor improvements to the unit tests for the PregReplaceEModifierSniff:

* I defined a constant in a random broken way, that isn't actually PHP code, due to a momentary brain-fade.  Have updated it to use define() as intended.
* I've changed the name of the example function to something that might trigger the notice if it were an actual regex string, to make it a more complete test.  We can't do this for the variable (we can't have a variable like $MyVar$e) and the constant is already defined in this manner.
