### PR TITLE
Moving namespace separator checks into NewLanguageConstructsSniff

### DIFF
--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -61,11 +61,6 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
                                             '5.3' => true,
                                             'description' => '__NAMESPACE__ magic constant'
                                         ),
-                                        'T_NS_SEPARATOR' => array(
-                                            '5.2' => false,
-                                            '5.3' => true,
-                                            'description' => 'the \ operator (for namespaces)'
-                                        ),
                                         'T_USE' => array(
                                             '5.2' => false,
                                             '5.3' => true,

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -31,6 +31,11 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
      * @var array(string => array(string => int|string|null))
      */
     protected $newConstructs = array(
+                                        'T_NS_SEPARATOR' => array(
+                                            '5.2' => false,
+                                            '5.3' => true,
+                                            'description' => 'the \ operator (for namespaces)'
+                                        ),
                                         'T_POW' => array(
                                             '5.5' => false,
                                             '5.6' => true,

--- a/Tests/Sniffs/PHP/NewConstructsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstructsSniffTest.php
@@ -16,6 +16,18 @@
 class NewConstructsSniffTest extends BaseSniffTest
 {
     /**
+     * testNamespaceSeparator
+     *
+     * @return void
+     */
+    public function testNamespaceSeparator()
+    {
+        $file = $this->sniffFile('sniff-examples/new_constructs.php', '5.2');
+
+        $this->assertError($file, 3, "the \ operator (for namespaces) is not present in PHP version 5.2 or earlier");
+    }
+
+    /**
      * testPow
      *
      * @requires PHP 5.6
@@ -25,7 +37,7 @@ class NewConstructsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_constructs.php', '5.5');
 
-        $this->assertError($file, 3, "power operator (**) is not present in PHP version 5.5 or earlier");
+        $this->assertError($file, 5, "power operator (**) is not present in PHP version 5.5 or earlier");
     }
 
     /**
@@ -38,7 +50,7 @@ class NewConstructsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_constructs.php', '5.5');
 
-        $this->assertError($file, 4, "power assignment operator (**=) is not present in PHP version 5.5 or earlier");
+        $this->assertError($file, 6, "power assignment operator (**=) is not present in PHP version 5.5 or earlier");
     }
 
 }

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -65,18 +65,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     }
 
     /**
-     * testNamespaceSeparator
-     *
-     * @return void
-     */
-    public function testNamespaceSeparator()
-    {
-        $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.2');
-
-        $this->assertError($file, 24, "the \ operator (for namespaces) is not present in PHP version 5.2 or earlier");
-    }
-
-    /**
      * Test trait keyword
      *
      * @requires PHP 5.4
@@ -86,7 +74,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
-        $this->assertError($file, 26, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 24, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -99,7 +87,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.3');
 
-        $this->assertError($file, 28, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 26, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -124,7 +112,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.4');
 
-        $this->assertError($file, 35, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 33, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
     }
 
     /**

--- a/Tests/sniff-examples/new_constructs.php
+++ b/Tests/sniff-examples/new_constructs.php
@@ -1,4 +1,6 @@
 <?php
 
+$foobar = new \Foobar();
+
 $x = 5 ** 10;
 $x **= 10;

--- a/Tests/sniff-examples/new_keywords.php
+++ b/Tests/sniff-examples/new_keywords.php
@@ -21,8 +21,6 @@ namespace Foobar;
 
 $namespace = __NAMESPACE__;
 
-$foobar = new \Foobar();
-
 trait FoobarTrait {
     public function foobar() {
         $name = __TRAIT__;


### PR DESCRIPTION
I've moved the check for T_NAMESPACE_SEPARATOR out of NewKeywordsSniff and into NewLanguageConstructsSniff as this is a more appropriate location (now that this separate file exists).

The unit tests were updated accordingly.