### PR TITLE
False alarm on patterns without border chars

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -84,12 +84,13 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
 
                 $regexFirstChar = substr($regex, 0, 1);
                 $regexEndPos = strrpos($regex, $regexFirstChar);
-
-                $modifiers = substr($regex, $regexEndPos + 1);
-
-                if (strpos($modifiers, "e") !== false) {
-                    $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
-                    $phpcsFile->addError($error, $stackPtr);
+                if($regexEndPos !== false) {
+                    $modifiers = substr($regex, $regexEndPos + 1);
+    
+                    if (strpos($modifiers, "e") !== false) {
+                        $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
+                        $phpcsFile->addError($error, $stackPtr);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This error blame a lot of libraries. For example monolog/monolog in Monolog/Handler/StreamHandler.php
> preg_replace('{^fopen\(.*?\): }', '', $msg)

In your check $regexEndPos = false and substr($regex, $regexEndPos + 1) = "^fopen\(.*?\): }" so it has "e" and causes error.