### PR TITLE
Fix false alarm by PregReplaceEModifierSniff

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -80,16 +80,24 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
                     $firstParam++;
                 }
 
+                $doublesSeparators = array(
+                    '{' => '}',
+                );
+
                 $regex = substr($regex, 1, -1);
 
                 $regexFirstChar = substr($regex, 0, 1);
-                $regexEndPos = strrpos($regex, $regexFirstChar);
+                $regexEndPos = (array_key_exists($regexFirstChar, $doublesSeparators)) ?
+                                    strrpos($regex, $doublesSeparators[$regexFirstChar])
+                                    : strrpos($regex, $regexFirstChar);
 
-                $modifiers = substr($regex, $regexEndPos + 1);
+                if($regexEndPos) {
+                    $modifiers = substr($regex, $regexEndPos + 1);
 
-                if (strpos($modifiers, "e") !== false) {
-                    $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
-                    $phpcsFile->addError($error, $stackPtr);
+                    if (strpos($modifiers, "e") !== false) {
+                        $error = 'preg_replace() - /e modifier is deprecated in PHP 5.5';
+                        $phpcsFile->addError($error, $stackPtr);
+                    }
                 }
             }
         }

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -86,4 +86,18 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 96);
     }
 
+    /**
+     * @throws Exception
+     */
+    public function testUsingBracketDelimitersPregReplace()
+    {
+        $error = "preg_replace() - /e modifier is deprecated in PHP 5.5";
+
+        $this->assertError($this->_sniffFile, 99, $error);
+        $this->assertError($this->_sniffFile, 100, $error);
+        $this->assertNoViolation($this->_sniffFile, 101);
+        $this->assertNoViolation($this->_sniffFile, 102);
+        $this->assertNoViolation($this->_sniffFile, 103);
+    }
+
 }

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -94,3 +94,10 @@ function XRegeXe() {
 preg_replace($Regex, $Replace, $Source);
 preg_replace(XRegeXe(), $Replace, $Source);
 preg_replace(X_REGEX_Xe, $Replace, $Source);
+
+// Using bracket delimiters
+preg_replace('{\d}e', $Replace, $Source); //bad
+preg_replace('{\d{2}}e', $Replace, $Source); //bad
+preg_replace('{\d{2}e}', $Replace, $Source); //good
+preg_replace('\d{2}e', $Replace, $Source); // good
+preg_replace('{^fopen(.*?): }', $Replace, $Source); //good - monolog example


### PR DESCRIPTION
> prev: https://github.com/wimg/PHPCompatibility/pull/89
False alarm on patterns without border chars or with doubles separators. Add tests for such cases.