### PR TITLE
Allow version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Installation (method 1)
 * Checkout this repository as `PHPCompatibility` into the `PHP/CodeSniffer/Standards` directory.
 * Use the coding standard with `phpcs --standard=PHPCompatibility`
 * You can specify which PHP version you want to test against by specifying `--runtime-set testVersion 5.5`.
+* You can also specify a range of PHP versions that your code needs to support.  In this situation, compatibility issues that affect any of the PHP versions in that range will be reported:
+`--runtime-set testVersion 5.3-5.5`
 
 Installation in Composer project (method 2)
 -------------------------------------------

--- a/Sniff.php
+++ b/Sniff.php
@@ -38,8 +38,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         $testVersion = $this->getTestVersion();
 
         if (is_null($testVersion)
-            || (!is_null($testVersion)
-                && version_compare($testVersion, $phpVersion) >= 0)
+            || version_compare($testVersion, $phpVersion) >= 0
         ) {
             return true;
         } else {

--- a/Sniff.php
+++ b/Sniff.php
@@ -24,13 +24,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
     private function getTestVersion()
     {
-        static $testVersion;
-
-        if (!isset($testVersion)) {
-            $testVersion = PHP_CodeSniffer::getConfigData('testVersion');
-        }
-
-        return $testVersion;
+        return PHP_CodeSniffer::getConfigData('testVersion');
     }
 
     public function supportsAbove($phpVersion)

--- a/Sniff.php
+++ b/Sniff.php
@@ -22,15 +22,29 @@
 abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 {
 
+    private function getTestVersion()
+	{
+        static $testVersion;
+
+        if (!isset($testVersion)) {
+            $testVersion = PHP_CodeSniffer::getConfigData('testVersion');
+        }
+
+        return $testVersion;
+    }
+
     public function supportsAbove($phpVersion)
     {
+
+		$testVersion = $this->getTestVersion();
+
         if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+            is_null($testVersion)
             ||
             (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+                !is_null($testVersion)
                 &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $phpVersion) >= 0
+                version_compare($testVersion, $phpVersion) >= 0
             )
         ) {
             return true;
@@ -41,10 +55,13 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
     public function supportsBelow($phpVersion)
     {
+
+		$testVersion = $this->getTestVersion();
+
         if (
-            !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
+            !is_null($testVersion)
             &&
-            version_compare(PHP_CodeSniffer::getConfigData('testVersion'), $phpVersion) <= 0
+            version_compare($testVersion, $phpVersion) <= 0
         ) {
             return true;
         } else {

--- a/Sniff.php
+++ b/Sniff.php
@@ -22,14 +22,63 @@
 abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 {
 
+/* The testVersion configuration variable may be in any of the following formats:
+ * 1) Omitted/empty, in which case no version is specified.  This effectively
+ *    disables all the checks provided by this standard.
+ * 2) A single PHP version number, e.g. "5.4" in which case the standard checks that
+ *    the code will run on that version of PHP (no deprecated features or newer
+ *    features being used).
+ * 3) A range, e.g. "5.0-5.5", in which case the standard checks the code will run
+ *    on all PHP versions in that range, and that it doesn't use any features that
+ *    were deprecated by the final version in the list, or which were not available
+ *    for the first version in the list.
+ * PHP version numbers should always be in Major.Minor format.  Both "5", "5.3.2"
+ * would be treated as invalid, and ignored.
+ * This standard doesn't support checking against PHP4, so the minimum version that
+ * is recognised is "5.0".
+ */
+
     private function getTestVersion()
     {
-        return PHP_CodeSniffer::getConfigData('testVersion');
+        /**
+         * var $testVersion will hold an array containing min/max version of PHP
+         *   that we are checking against (see above).  If only a single version
+         *   number is specified, then this is used as both the min and max.
+         */
+        static $arrTestVersions;
+
+        if (!isset($testVersion)) {
+            $testVersion = PHP_CodeSniffer::getConfigData('testVersion');
+            $testVersion = trim($testVersion);
+
+            $arrTestVersions = null;
+            if (preg_match('/^\d+\.\d+$/', $testVersion)) {
+                $arrTestVersions = array($testVersion, $testVersion);
+            }
+            elseif (preg_match('/^(\d+\.\d+)\s*-\s*(\d+\.\d+)$/', $testVersion,
+                               $matches))
+            {
+                if (version_compare($matches[1], $matches[2], ">")) {
+                    trigger_error("Invalid range in testVersion setting: '"
+                                  . $testVersion . "'", E_USER_WARNING);
+                }
+                else {
+                    $arrTestVersions = array($matches[1], $matches[2]);
+                }
+            }
+            elseif (!$testVersion == "") {
+                trigger_error("Invalid testVersion setting: '" . $testVersion
+                              . "'", E_USER_WARNING);
+            }
+        }
+
+        return $arrTestVersions;
     }
 
     public function supportsAbove($phpVersion)
     {
         $testVersion = $this->getTestVersion();
+        $testVersion = $testVersion[1];
 
         if (is_null($testVersion)
             || version_compare($testVersion, $phpVersion) >= 0
@@ -43,6 +92,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     public function supportsBelow($phpVersion)
     {
         $testVersion = $this->getTestVersion();
+        $testVersion = $testVersion[0];
 
         if (!is_null($testVersion)
             && version_compare($testVersion, $phpVersion) <= 0

--- a/Sniff.php
+++ b/Sniff.php
@@ -23,7 +23,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 {
 
     private function getTestVersion()
-	{
+    {
         static $testVersion;
 
         if (!isset($testVersion)) {
@@ -35,17 +35,11 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
     public function supportsAbove($phpVersion)
     {
+        $testVersion = $this->getTestVersion();
 
-		$testVersion = $this->getTestVersion();
-
-        if (
-            is_null($testVersion)
-            ||
-            (
-                !is_null($testVersion)
-                &&
-                version_compare($testVersion, $phpVersion) >= 0
-            )
+        if (is_null($testVersion)
+            || (!is_null($testVersion)
+                && version_compare($testVersion, $phpVersion) >= 0)
         ) {
             return true;
         } else {
@@ -55,13 +49,10 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
     public function supportsBelow($phpVersion)
     {
+        $testVersion = $this->getTestVersion();
 
-		$testVersion = $this->getTestVersion();
-
-        if (
-            !is_null($testVersion)
-            &&
-            version_compare($testVersion, $phpVersion) <= 0
+        if (!is_null($testVersion)
+            && version_compare($testVersion, $phpVersion) <= 0
         ) {
             return true;
         } else {

--- a/Sniff.php
+++ b/Sniff.php
@@ -51,7 +51,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             $testVersion = PHP_CodeSniffer::getConfigData('testVersion');
             $testVersion = trim($testVersion);
 
-            $arrTestVersions = null;
+            $arrTestVersions = array(null, null);
             if (preg_match('/^\d+\.\d+$/', $testVersion)) {
                 $arrTestVersions = array($testVersion, $testVersion);
             }


### PR DESCRIPTION
This allows a range of PHP versions to be specified via the testVersion config setting (e.g. "5.0-5.4").

This is based off PR #98, so that should be merged first.