### PR TITLE
Fix for issue #42

### DIFF
--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -103,10 +103,12 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
             while (($nextSeparator = $phpcsFile->findNext(T_VARIABLE, ($nextSeparator + 1), $closeBracket)) !== false) {
                 // Make sure the variable belongs directly to this function call
                 // and is not inside a nested function call or array.
-                $brackets    = $tokens[$nextSeparator]['nested_parenthesis'];
-                $lastBracket = array_pop($brackets);
-                if ($lastBracket !== $closeBracket) {
-                    continue;
+                if (isset($tokens[$nextSeparator]['nested_parenthesis'])) {
+                    $brackets    = $tokens[$nextSeparator]['nested_parenthesis'];
+                    $lastBracket = array_pop($brackets);
+                    if ($lastBracket !== $closeBracket) {
+                        continue;
+                    }
                 }
 
                 // Checking this: $value = my_function(...[*]$arg...).


### PR DESCRIPTION
 (PHP notice error relating to 'nested_parenthesis' array index).

> Logs periodically show messages like the following while scanning a large tree:
> PHP Notice: Undefined index: nested_parenthesis in
> ~Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php on line 114

The issue is relating to the 'nested_parenthesis' property not being set in the token information in some situations.

This may be related to the following CodeSniffer bug: https://pear.php.net/bugs/bug.php?id=9274.  This indicates that there are a few token types do not include this property, but it is not clear whether this is something that was fixed (in which case this is only an issue for old versions) or wontfixed, in which case current versions are likely to still be affected.  It is also possible that that issue is not relvant to this one at all.

Either way, this commit fixes the problem by checking that the array key exists before doing anything with it.