### PR TITLE
Sniff for missing middle of ternary operators in PHP < 5.3.

### DIFF
--- a/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff.
+ *
+ * PHP version 5.3
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Ben Selby <bselby@plus.net>
+ * @copyright 2012 Ben Selby
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff.
+ *
+ * Performs checks on ternary operators, specifically that the middle expression
+ * is not omitted for versions that don't support this.
+ *
+ * PHP version 5.3
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Ben Selby <bselby@plus.net>
+ * @copyright 2012 Ben Selby
+ */
+class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_INLINE_THEN);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('5.3')) {
+            $tokens = $phpcsFile->getTokens();
+        
+            // Get next non-whitespace token, and check it isn't the related inline else
+            // symbol, which is not allowed prior to PHP 5.3.
+            $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens,
+                                         ($stackPtr + 1), null, true);
+
+            if ($tokens[$next]['code'] == T_INLINE_ELSE) {
+                $error = sprintf(
+                    "Middle may not be omitted from ternary operators in PHP < 5.3"
+                );
+                $phpcsFile->addWarning($error, $stackPtr);
+            }
+        }
+    }
+}

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Ternary Operators Sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Ternary Operators Sniff tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ * @author Jansen Price <jansen.price@gmail.com>
+ */
+class TernaryOperatorsSniffTest extends BaseSniffTest
+{
+    /**
+     * Sniffed file
+     *
+     * @var PHP_CodeSniffer_File
+     */
+    protected $_sniffFile;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php');
+    }
+
+    /**
+     * Test ternary operators that are acceptable in all PHP versions.
+     *
+     * @return void
+     */
+    public function testStandardTernaryOperators()
+    {
+        $this->assertNoViolation($this->_sniffFile, 5);
+    }
+
+    /**
+     * testHttpGetVars
+     *
+     * @return void
+     */
+    public function testMissingMiddleExpression()
+    {
+        global $Foo;
+        $Foo = true;
+        $this->assertWarning($this->_sniffFile, 8,
+                "Middle may not be omitted from ternary operators in PHP < 5.3");
+        $Foo = false;
+    }
+
+}

--- a/Tests/sniff-examples/ternary_operator.php
+++ b/Tests/sniff-examples/ternary_operator.php
@@ -1,0 +1,8 @@
+<?php
+$a = $b = $c = 0;
+
+// Always OK:
+$a ? $b : $c;
+
+// Only in 5.3 and above:
+$a ?: $c;


### PR DESCRIPTION
Unit tests included.

Fixed #49.