### PR TITLE
Fix test against use of the 'elvis operator'

### DIFF
--- a/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -47,9 +47,9 @@ class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3')) {
+        if (!$this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
-        
+
             // Get next non-whitespace token, and check it isn't the related inline else
             // symbol, which is not allowed prior to PHP 5.3.
             $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens,

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -31,7 +31,6 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     {
         parent::setUp();
 
-        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php');
     }
 
     /**
@@ -41,21 +40,32 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
      */
     public function testStandardTernaryOperators()
     {
+        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php');
         $this->assertNoViolation($this->_sniffFile, 5);
     }
 
     /**
-     * testHttpGetVars
+     * 5.2 doesn't support elvis operator.
      *
      * @return void
      */
-    public function testMissingMiddleExpression()
+    public function testMissingMiddleExpression5dot2()
     {
-        global $Foo;
-        $Foo = true;
+        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.2');
         $this->assertWarning($this->_sniffFile, 8,
                 "Middle may not be omitted from ternary operators in PHP < 5.3");
-        $Foo = false;
+    }
+
+    /**
+     * 5.3 does support elvis operator.
+     *
+     * @return void
+     */
+    public function testMissingMiddleExpression5dot3()
+    {
+        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.3');
+        $this->assertNoViolation($this->_sniffFile, 8,
+                "Middle may not be omitted from ternary operators in PHP < 5.3");
     }
 
 }


### PR DESCRIPTION
Use of the 'elvis operator', i.e. omitting the middle portion of a ternary operator expression is allowed in PHP 5.3 and up. The sniff enforcing presence of the middle portion only executed for versions 5.3+.
Eg the following example is wrong, and this pull request fixes this issue:

    kguest@radagast $ sudo phpcs --config-set testVersion 5.4
    [sudo] password for kguest: 
    Config value "testVersion" updated successfully; old value was "5.5"
    kguest@radagast $ phpcscompat .
    
    FILE: ...s/testproject/application/controllers/OutputController.php
    ----------------------------------------------------------------------
    FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
    ----------------------------------------------------------------------
     75 | WARNING | Middle may not be omitted from ternary operators in
        |         | PHP < 5.3
    ----------------------------------------------------------------------
    
    Time: 1.15 secs; Memory: 3.25Mb
    
