### PR TITLE
Support PHP CodeSniffer 2.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require" : {
     "php" : ">=5.1.2",
     "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : ">=1.5.1,<2.4"
+    "squizlabs/php_codesniffer" : ">=1.5.1,~2.0"
   },
   "require-dev" : {
     "satooshi/php-coveralls" : "dev-master"


### PR DESCRIPTION
PHP CodeSniffer 2.6.0 has been released. Let's support it.

The supported version of PHP CodeSniffer was limited to 2.4.x but it is not clear why 2.5.x or higher would be incompatible. PHP CodeSniffer uses semantic versioning so there should not be any backwards compatibility breaks in newer 2.x.x versions. I've changed it to support anything below 3.x.x now.