### PR TITLE
Support PHP CodeSniffer 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: false
 language: php
 
 env:
-  - PHPCS_VERSION=">=1.5.1,<2.0"
-  - PHPCS_VERSION=">=2.0"
+  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERION="~1.0"
+  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERION="dev-master"
+  - PHPCS_VERSION=">=2.0" COVERALLS_VERION="~1.0"
+  - PHPCS_VERSION=">=2.0" COVERALLS_VERION="dev-master"
 
 php:
   - 5.3
@@ -14,17 +16,17 @@ php:
   - 7.0
 
 matrix:
-  include:
+  exclude:
     - php: 5.3
-      env: COVERALLS_VERSION="~1.0"
+      env: COVERALLS_VERSION="dev-master"
     - php: 5.4
-      env: COVERALLS_VERSION="~1.0"
+      env: COVERALLS_VERSION="dev-master"
     - php: 5.5
-      env: COVERALLS_VERSION="dev-master"
+      env: COVERALLS_VERSION="~1.0"
     - php: 5.6
-      env: COVERALLS_VERSION="dev-master"
+      env: COVERALLS_VERSION="~1.0"
     - php: 7.0
-      env: COVERALLS_VERSION="dev-master"
+      env: COVERALLS_VERSION="~1.0"
 
 before_script:
   - phpenv rehash

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,26 @@ php:
   - 5.6
   - 7.0
 
+matrix:
+  include:
+    - php: 5.3
+      env: COVERALLS_VERSION="~1.0"
+    - php: 5.4
+      env: COVERALLS_VERSION="~1.0"
+    - php: 5.5
+      env: COVERALLS_VERSION="dev-master"
+    - php: 5.6
+      env: COVERALLS_VERSION="dev-master"
+    - php: 7.0
+      env: COVERALLS_VERSION="dev-master"
+
 before_script:
   - phpenv rehash
 
 install:
   - composer self-update
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
+  - composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - PHPCS_VERSION=">=1.5.1,~2.0"
   matrix:
     - COVERALLS_VERSION="~1.0"
-    - COVERALLS_VERSION="~dev-master"
+    - COVERALLS_VERSION="dev-master"
 
 php:
   - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 language: php
 
 env:
-  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERION="~1.0"
-  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERION="dev-master"
-  - PHPCS_VERSION=">=2.0" COVERALLS_VERION="~1.0"
-  - PHPCS_VERSION=">=2.0" COVERALLS_VERION="dev-master"
+  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
+  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+  - PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
+  - PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
 
 php:
   - 5.3
@@ -33,8 +33,8 @@ before_script:
 
 install:
   - composer self-update
-  - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}
+  - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - composer install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,28 @@ sudo: false
 
 language: php
 
-env:
-  global:
-    - PHPCS_VERSION=">=1.5.1,~2.0"
-  matrix:
-    - COVERALLS_VERSION="~1.0"
-    - COVERALLS_VERSION="dev-master"
-
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-
 matrix:
-  exclude:
+  include:
     - php: 5.3
-      env: COVERALLS_VERSION="dev-master"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.3
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
     - php: 5.4
-      env: COVERALLS_VERSION="dev-master"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.4
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
     - php: 5.5
-      env: COVERALLS_VERSION="~1.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.5
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
     - php: 5.6
-      env: COVERALLS_VERSION="~1.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.6
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
     - php: 7.0
-      env: COVERALLS_VERSION="~1.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 7.0
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
 
 before_script:
   - phpenv rehash

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,42 @@ language: php
 
 matrix:
   include:
+
     - php: 5.3
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.3
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+
     - php: 5.4
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.4
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+
+    - php: 5.5
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.5
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+
     - php: 5.5
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.5
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+
+    - php: 5.6
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 5.6
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+
     - php: 5.6
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.6
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+
+    - php: 7.0
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 7.0
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+
     - php: 7.0
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ sudo: false
 language: php
 
 env:
-  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
-  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
-  - PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
-  - PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
+  global:
+    - PHPCS_VERSION=">=1.5.1,~2.0"
+  matrix:
+    - COVERALLS_VERSION="~1.0"
+    - COVERALLS_VERSION="~dev-master"
 
 php:
   - 5.3

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -103,7 +103,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
      *
      * @var array
      */
-    protected $targetedTokens = array(T_CLASS, T_FUNCTION, T_NAMESPACE, T_STRING, T_CONST, T_USE, T_AS, T_EXTENDS, T_TRAIT);
+    protected $targetedTokens = array(T_ANON_CLASS, T_CLASS, T_FUNCTION, T_NAMESPACE, T_STRING, T_CONST, T_USE, T_AS, T_EXTENDS, T_TRAIT);
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -103,7 +103,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
      *
      * @var array
      */
-    protected $targetedTokens = array(T_ANON_CLASS, T_CLASS, T_FUNCTION, T_NAMESPACE, T_STRING, T_CONST, T_USE, T_AS, T_EXTENDS, T_TRAIT);
+    protected $targetedTokens = array(T_CLASS, T_FUNCTION, T_NAMESPACE, T_STRING, T_CONST, T_USE, T_AS, T_EXTENDS, T_TRAIT);
 
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -112,7 +112,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
      */
     public function register()
     {
-        return $this->targetedTokens;
+        $tokens = $this->targetedTokens;
+        if (defined('T_ANON_CLASS')) {
+            $tokens[] = constant('T_ANON_CLASS');
+        }
+        return $tokens;
     }//end register()
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "squizlabs/php_codesniffer" : "~2.0"
   },
   "require-dev" : {
-    "satooshi/php-coveralls" : "~1.0"
+    "satooshi/php-coveralls" : "dev-master"
   },
   "license" : "LGPL",
   "keywords" : [ "compatibility", "phpcs", "standards" ],

--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,10 @@
   "require" : {
     "php" : ">=5.1.2",
     "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : ">=1.5.1,~2.0"
+    "squizlabs/php_codesniffer" : "~2.0"
   },
   "require-dev" : {
-    "satooshi/php-coveralls" : "dev-master"
+    "satooshi/php-coveralls" : "~1.0"
   },
   "license" : "LGPL",
   "keywords" : [ "compatibility", "phpcs", "standards" ],

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require" : {
     "php" : ">=5.1.2",
     "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : ">=1.5.1,<2.4"
+    "squizlabs/php_codesniffer" : ">=1.5.1,~2.0"
   },
   "require-dev" : {
     "satooshi/php-coveralls" : "dev-master"


### PR DESCRIPTION
Build on previous PR for PHPCS 2.6.0, adding T_ANON_CLASS to targeted tokens for ForbiddenNamesSniff.