### PR TITLE
Allow for class instantiation without parenthesis.

### DIFF
--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -233,6 +233,8 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
                     &&
                     $tokens[$stackPtr + 4]['type'] == 'T_OPEN_PARENTHESIS'
                 )
+                ||
+                $tokens[$stackPtr + 3]['type'] == 'T_SEMICOLON'
             )
         ) {
             $className = $tokens[$stackPtr + 2]['content'];

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -31,9 +31,11 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.1');
         $this->assertError($file, 3, "The built-in class DateTime is not present in PHP version 5.1 or earlier");
+        $this->assertError($file, 43, "The built-in class DateTime is not present in PHP version 5.1 or earlier");
 
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, 43);
     }
 
     /**

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -39,3 +39,5 @@ $test = new IntlRuleBasedBreakIterator();
 $test = new IntlCodePointBreakIterator();
 
 $okay = new StdClass();
+
+$test = new DateTime;


### PR DESCRIPTION
For classes where the constructor has no required parameters, the sniff could fail. This PR fixes that.

Includes unit test demonstrating the issue.