### PR TITLE
Improve PCRE `e` modifier sniff

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -82,6 +82,9 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
 
                 $doublesSeparators = array(
                     '{' => '}',
+                    '[' => ']',
+                    '(' => ')',
+                    '<' => '>',
                 );
 
                 $regex = substr($regex, 1, -1);

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -30,6 +30,16 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
     public $error = false;
 
     /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $functions = array(
+        'preg_replace' => true,
+        'preg_filter'  => true,
+    );
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -53,7 +63,10 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
         if ($this->supportsAbove('5.5')) {
             $tokens = $phpcsFile->getTokens();
 
-            if ($tokens[$stackPtr]['content'] == "preg_replace") {
+            if ( isset($this->functions[$tokens[$stackPtr]['content']]) === false ) {
+                return;
+            } else {
+
                 $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
                 if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -156,8 +156,14 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 101);
         $this->assertNoViolation($this->_sniffFile, 102);
         $this->assertNoViolation($this->_sniffFile, 103);
-        
-        
+        $this->assertNoViolation($this->_sniffFile, 104);
+        $this->assertNoViolation($this->_sniffFile, 105);
+        $this->assertNoViolation($this->_sniffFile, 106);
+        $this->assertNoViolation($this->_sniffFile, 107);
+        $this->assertNoViolation($this->_sniffFile, 108);
+        $this->assertNoViolation($this->_sniffFile, 109);
+
+
         $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php', '5.5');
         $error = "preg_replace() - /e modifier is deprecated in PHP 5.5";
         $this->assertError($this->_sniffFile, 99, $error);
@@ -165,7 +171,13 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 101);
         $this->assertNoViolation($this->_sniffFile, 102);
         $this->assertNoViolation($this->_sniffFile, 103);
-        
+        $this->assertError($this->_sniffFile, 104, $error);
+        $this->assertNoViolation($this->_sniffFile, 105);
+        $this->assertError($this->_sniffFile, 106, $error);
+        $this->assertNoViolation($this->_sniffFile, 107);
+        $this->assertError($this->_sniffFile, 108, $error);
+        $this->assertNoViolation($this->_sniffFile, 109);
+
         $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php', '7.0');
         $error = "preg_replace() - /e modifier is forbidden in PHP 7.0";
         $this->assertError($this->_sniffFile, 99, $error);
@@ -173,6 +185,12 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 101);
         $this->assertNoViolation($this->_sniffFile, 102);
         $this->assertNoViolation($this->_sniffFile, 103);
+        $this->assertError($this->_sniffFile, 104, $error);
+        $this->assertNoViolation($this->_sniffFile, 105);
+        $this->assertError($this->_sniffFile, 106, $error);
+        $this->assertNoViolation($this->_sniffFile, 107);
+        $this->assertError($this->_sniffFile, 108, $error);
+        $this->assertNoViolation($this->_sniffFile, 109);
     }
 
 }

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -193,4 +193,50 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($this->_sniffFile, 109);
     }
 
+    /**
+     * testDeprecatedPregFilter
+     *
+     * @return void
+     */
+    public function testDeprecatedPregFilter()
+    {
+        $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php', '5.4');
+        $this->assertNoViolation($this->_sniffFile, 114);
+        $this->assertNoViolation($this->_sniffFile, 115);
+        $this->assertNoViolation($this->_sniffFile, 118);
+        $this->assertNoViolation($this->_sniffFile, 119);
+        $this->assertNoViolation($this->_sniffFile, 122);
+        $this->assertNoViolation($this->_sniffFile, 123);
+        $this->assertNoViolation($this->_sniffFile, 124);
+        $this->assertNoViolation($this->_sniffFile, 127);
+        $this->assertNoViolation($this->_sniffFile, 142);
+        $this->assertNoViolation($this->_sniffFile, 148);
+
+        $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php', '5.5');
+        $error = "preg_replace() - /e modifier is deprecated in PHP 5.5";
+        $this->assertError($this->_sniffFile, 114, $error);
+        $this->assertError($this->_sniffFile, 115, $error);
+        $this->assertError($this->_sniffFile, 118, $error);
+        $this->assertError($this->_sniffFile, 119, $error);
+        $this->assertError($this->_sniffFile, 122, $error);
+        $this->assertError($this->_sniffFile, 123, $error);
+        $this->assertError($this->_sniffFile, 124, $error);
+        $this->assertError($this->_sniffFile, 127, $error);
+        $this->assertError($this->_sniffFile, 142, $error);
+        $this->assertError($this->_sniffFile, 148, $error);
+
+        $this->_sniffFile = $this->sniffFile('sniff-examples/preg_replace_e_modifier.php', '7.0');
+        $error = "preg_replace() - /e modifier is forbidden in PHP 7.0";
+        $this->assertError($this->_sniffFile, 114, $error);
+        $this->assertError($this->_sniffFile, 115, $error);
+        $this->assertError($this->_sniffFile, 118, $error);
+        $this->assertError($this->_sniffFile, 119, $error);
+        $this->assertError($this->_sniffFile, 122, $error);
+        $this->assertError($this->_sniffFile, 123, $error);
+        $this->assertError($this->_sniffFile, 124, $error);
+        $this->assertError($this->_sniffFile, 127, $error);
+        $this->assertError($this->_sniffFile, 142, $error);
+        $this->assertError($this->_sniffFile, 148, $error);
+    }
+
 }

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -95,9 +95,16 @@ preg_replace($Regex, $Replace, $Source);
 preg_replace(XRegeXe(), $Replace, $Source);
 preg_replace(X_REGEX_Xe, $Replace, $Source);
 
-// Using bracket delimiters
+///////////// Using bracket delimiters
 preg_replace('{\d}e', $Replace, $Source); //bad
 preg_replace('{\d{2}}e', $Replace, $Source); //bad
 preg_replace('{\d{2}e}', $Replace, $Source); //good
 preg_replace('\d{2}e', $Replace, $Source); // good
 preg_replace('{^fopen(.*?): }', $Replace, $Source); //good - monolog example
+preg_replace('[\d{2}]e', $Replace, $Source); //bad
+preg_replace('[\d{2}e]', $Replace, $Source); //good
+preg_replace('(\d{2})e', $Replace, $Source); //bad
+preg_replace('(\d{2}e)', $Replace, $Source); //good
+preg_replace('<\d{2}>e', $Replace, $Source); //bad
+preg_replace('<\d{2}e>', $Replace, $Source); //good
+

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -108,3 +108,41 @@ preg_replace('(\d{2}e)', $Replace, $Source); //good
 preg_replace('<\d{2}>e', $Replace, $Source); //bad
 preg_replace('<\d{2}e>', $Replace, $Source); //good
 
+///////////// Using preg_filter
+
+// Different quote styles.
+preg_filter("/double-quoted/e", $Replace, $Source);
+preg_filter('/single-quoted/e', $Replace, $Source);
+
+// Different regex markers.
+preg_filter('#hash-chars (common)#e', $Replace, $Source);
+preg_filter('!exclamations (why not?!e', $Replace, $Source);
+
+// Other modifiers with /e
+preg_filter('/some text/emS', $Replace, $Source);
+preg_filter('/some text/meS', $Replace, $Source);
+preg_filter('/some text/mSe', $Replace, $Source);
+
+// Multi-line example (issue #83)
+$text = preg_filter(
+    '/(?<!\\\\)     # not preceded by a backslash
+      <             # an open bracket
+      (             # start capture
+        \/?         # optional backslash
+        collapse    # the string collapse
+        [^>]*       # everything up to the closing angle bracket; note that you cannot use one inside the tag!
+      )             # stop capture
+      >             # close bracket
+    /iex',
+    '[$1]',
+    $text
+  );
+
+// Multi-line with /e in comments.
+preg_filter(
+        '/.*     # /e in a comment
+        /xe',
+    $Replace, $Source);
+
+// Escaped /e
+preg_filter('/\/e/e', $Replace, $Source);


### PR DESCRIPTION
I found two bugs/oversights in the  `PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff`.

First off, there are several bracket delimiters which are valid in PHP.
Up to now, only the `{}` bracket delimiters were accounted for, while the other valid bracket delimiters `()`, `[]` and `<>` were not.

Ref: http://php.net/manual/en/regexp.reference.delimiters.php

Secondly, while this is barely documented, the `preg_filter()` function actually applies the `e` modifier as well and should be checked for it too.

Ref: http://php.net/manual/en/function.preg-filter.php

The PR contains unit tests for both issues.