### PR TITLE
Add ability to whitelist functions from a custom ruleset to the removedExtensions sniff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,50 @@ Using the compatibility sniffs
 
 More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 
+Using a custom ruleset
+------------------------------
+Alternatively, you can add PHPCompatibility to a custom PHPCS ruleset.
+
+```xml
+<?xml version="1.0"?>
+<ruleset name="Custom ruleset">
+	<description>My rules for PHP_CodeSniffer</description>
+
+	<!-- Run against the PHPCompatibility ruleset -->
+	<rule ref="PHPCompatibility" />
+	
+	<!-- Run against a second ruleset -->
+	<rule ref="PSR2" />
+
+</ruleset>
+```
+
+You can also set the `testVersion` from within the ruleset:
+```xml
+	<arg name="testVersion" value="5.3-5.5"/>
+```
+
+Other advanced options, such as changing the message type or severity, as described in the [PHPCS Annotated ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) wiki page are, of course, also supported.
+
+
+##### PHPCompatibility specific options
+
+At this moment, there is one sniff which has a property which can be set via the ruleset. More custom properties may become available in the future.
+
+The `PHPCompatibility.PHP.RemovedExtensions` sniff checks for removed extensions based on the function prefix used for these extensions.
+This might clash with userland function using the same function prefix.
+
+To whitelist userland functions, you can pass a comma-delimited list of function names to the sniff.
+```xml
+	<!-- Whitelist the mysql_to_rfc3339() and mysql_another_function() functions. -->
+	<rule ref="PHPCompatibility.PHP.RemovedExtensions">
+		<properties>
+			<property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
+		</properties>
+	</rule>
+```
+
+
 Running the Sniff Tests
 -----------------------
 All the sniffs are fully tested with PHPUnit tests. In order to run the tests

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -22,6 +22,22 @@
  */
 class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibility_Sniff
 {
+    /**
+     * A list of functions to whitelist, if any.
+     *
+     * This is intended for projects using functions which start with the same
+     * prefix as one of the removed extensions.
+     *
+     * This property can be set from the ruleset, like so:
+     * <rule ref="PHPCompatibility.PHP.RemovedExtensions">
+     *   <properties>
+     *     <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
+     *   </properties>
+     * </rule>
+     *
+     * @var array
+     */
+    public $functionWhitelist;
 
     /**
      * A list of removed extensions with their alternative, if any
@@ -327,6 +343,11 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
             return;
         }
 
+        if($this->isWhiteListed(strtolower($tokens[$stackPtr]['content'])) === true){
+            // Function is whitelisted.
+            return;
+        }
+
         foreach ($this->removedExtensions as $extension => $versionList) {
             if (strpos(strtolower($tokens[$stackPtr]['content']), strtolower($extension)) === 0) {
                 $error = '';
@@ -364,5 +385,36 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
         }
 
     }//end process()
+
+    /**
+     * Is the current function being checked whitelisted ?
+     *
+     * Parsing the list late as it may be provided as a property, but also inline.
+     *
+     * @param string $content Content of the current token.
+     *
+     * @return bool
+     */
+    protected function isWhiteListed($content) {
+        if (isset($this->functionWhitelist) === false) {
+            return false;
+        }
+
+        if (is_string($this->functionWhitelist) === true) {
+            if (strpos($this->functionWhitelist, ',') !== false) {
+                $this->functionWhitelist = explode(',', $this->functionWhitelist);
+            } else {
+                $this->functionWhitelist = (array) $this->functionWhitelist;
+            }
+        }
+
+        if (is_array($this->functionWhitelist) === true) {
+            $this->functionWhitelist = array_map('strtolower',$this->functionWhitelist);
+            return in_array($content, $this->functionWhitelist, true);
+        }
+
+        return false;
+
+    }//end isWhiteListed()
 
 }//end class

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -204,9 +204,11 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
      */
     public function testMysql()
     {
+        $this->assertNoViolation($this->_sniffFile, 67);
+
         $file = $this->sniffFile('sniff-examples/removed_extensions.php', '5.4');
         $this->assertNoViolation($file, 38);
-        
+
         $file = $this->sniffFile('sniff-examples/removed_extensions.php', '5.5');
         $this->assertWarning($file, 38, "Extension 'mysql_' is deprecated since PHP 5.5");
     }

--- a/Tests/sniff-examples/removed_extensions.php
+++ b/Tests/sniff-examples/removed_extensions.php
@@ -63,3 +63,5 @@ mssql_bind();
 
 ereg();
 
+// @codingStandardsChangeSetting PHPCompatibility.PHP.RemovedExtensions functionWhitelist mysql_to_rfc3339
+mysql_to_rfc3339();


### PR DESCRIPTION
This PR will allow for whitelisting userland functions which have names which overlap with deprecated extensions through a custom ruleset:
```xml
<rule ref="PHPCompatibility.PHP.RemovedExtensions">
    <properties>
        <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function" />
    </properties>
</rule>
```

Fixes #123

@octalmage What do think ? Will this work for you ?