### PR TITLE
Remove duplication from the travis matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,31 +19,22 @@ matrix:
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.5
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
-
     - php: 5.5
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
-    - php: 5.5
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
 
     - php: 5.6
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.6
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
-
     - php: 5.6
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
-    - php: 5.6
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
 
     - php: 7.0
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 7.0
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
-
     - php: 7.0
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
-    - php: 7.0
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
 
 before_script:
   - phpenv rehash


### PR DESCRIPTION
After the travis build was fixed, it now contains duplicates within the matrix making it effectively run the same check twice. This PR fixes that.