### PR TITLE
Correct ruleset name

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 
-<ruleset name="PHPCompatibility_CodeSniffer">
+<ruleset name="PHPCompatibility">
  <description>Coding Standard that checks for PHP version compatibility.</description>
 </ruleset>


### PR DESCRIPTION
Might just be me, but this looked inconsistent with the real ruleset name, so I checked with the rulesets within PHPCS itself and none of them use the `_CodeSniffer` suffix.