### PR TITLE
Review of visibility of all sniff properties and removing of some superfluous ones

### DIFF
--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -34,7 +34,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      *
      * @var array(string => array(string => int|string|null))
      */
-    public $forbiddenFunctions = array(
+    protected $forbiddenFunctions = array(
                                         'call_user_method' => array(
                                             '5.3' => false,
                                             '5.4' => false,
@@ -613,13 +613,6 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                                     );
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -717,7 +710,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         $previousVersionStatus = null;
         foreach ($this->forbiddenFunctions[$pattern] as $version => $forbidden) {
             if ($this->supportsAbove($version)) {
@@ -725,7 +718,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                     if ($previousVersionStatus !== $forbidden) {
                         $previousVersionStatus = $forbidden;
                         if ($forbidden === true) {
-                            $this->error = true;
+                            $isError = true;
                             $error .= 'forbidden';
                         } else {
                             $error .= 'discouraged';
@@ -743,7 +736,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                 $error .= '; use ' . $this->forbiddenFunctions[$pattern]['alternative'] . ' instead';
             }
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -26,13 +26,6 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompati
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -26,13 +26,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -30,13 +30,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -24,13 +24,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -26,13 +26,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends 
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * List of tokens to register
      *
      * @var array

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -114,13 +114,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
     );
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * targetedTokens
      *
      * @var array

--- a/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -22,13 +22,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff extends PHPComp
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -24,13 +24,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff 
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -191,14 +191,6 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -268,11 +260,11 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newClasses[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -280,7 +272,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
         if (strlen($error) > 0) {
             $error = 'The built-in class ' . $className . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -33,7 +33,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
      *
      * @var array
      */
-    public $newFunctionParameters = array(
+    protected $newFunctionParameters = array(
                                         'dirname' => array(
                                             1 => array(
                                                 'name' => 'depth',
@@ -65,13 +65,6 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
                                     );
 
 
-    /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
-    
     /**
      * 
      * @var array
@@ -165,11 +158,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
     {
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newFunctionParameters[$function][$parameterLocation] as $version => $present) {
             if ($version != 'name' && $this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -178,7 +171,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' does not have a parameter ' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . ' ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -32,7 +32,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      *
      * @var array(string => array(string => int|string|null))
      */
-    public $forbiddenFunctions = array(
+    protected $forbiddenFunctions = array(
                                         'array_fill_keys' => array(
                                             '5.1' => false,
                                             '5.2' => true
@@ -1176,13 +1176,6 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
-
-    /**
      * 
      * @var unknown
      */
@@ -1285,11 +1278,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->forbiddenFunctions[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -1297,7 +1290,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -110,14 +110,6 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -186,11 +178,11 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newKeywords[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -198,7 +190,7 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
         if (strlen($error) > 0) {
             $error = $this->newKeywords[$keywordName]['description'] . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -60,14 +60,6 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -119,11 +111,11 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newConstructs[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -131,7 +123,7 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
         if (strlen($error) > 0) {
             $error = $this->newConstructs[$keywordName]['description'] . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -50,14 +50,6 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -109,11 +101,11 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newTypes[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -121,7 +113,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
         if (strlen($error) > 0) {
             $error = $this->newTypes[$typeName]['description'] . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -50,14 +50,6 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
 
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = false;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
@@ -113,11 +105,11 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
 
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->newTypes[$pattern] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -125,7 +117,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
         if (strlen($error) > 0) {
             $error = $this->newTypes[$typeName]['description'] . ' is ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -23,13 +23,6 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
-
-    /**
      * Functions to check for.
      *
      * @var array

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -33,7 +33,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
      *
      * @var array
      */
-    public $removedFunctionParameters = array(
+    protected $removedFunctionParameters = array(
                                         'mktime' => array(
                                             6 => array(
                                                 'name' => 'is_dst',
@@ -50,13 +50,6 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
                                     );
 
 
-    /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    public $error = false;
-    
     /**
      * 
      * @var array
@@ -169,11 +162,11 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
     {
         $error = '';
 
-        $this->error = false;
+        $isError = false;
         foreach ($this->removedFunctionParameters[$function][$parameterLocation] as $version => $present) {
             if ($version != 'name' && $this->supportsAbove($version)) {
                 if ($present === false) {
-                    $this->error = true;
+                    $isError = true;
                     $error .= 'in PHP version ' . $version . ' or later';
                 }
             }
@@ -182,7 +175,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' does not have a parameter ' . $this->removedFunctionParameters[$function][$parameterLocation]['name'] . ' ' . $error;
 
-            if ($this->error === true) {
+            if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);
             } else {
                 $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -26,13 +26,6 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
 {
 
     /**
-     * If true, an error will be thrown; otherwise a warning.
-     *
-     * @var bool
-     */
-    protected $error = true;
-
-    /**
      * List of functions using the algorithm as parameter (always the first parameter)
      *
      * @var array


### PR DESCRIPTION
As with the readme change in #130, the ability to change public properties from a custom ruleset will become more well-known, it seemed prudent to verify that all `public` properties are properties which should be user-adjustable.

As most were not, I've changed the visibility of most `public` properties to `protected`.

Also a `public $error` property was available in a lot of classes, but was either not used at all or only used by one method in these classes and overruled within that method no matter what a user might have passed via a custom ruleset, so I've removed these properties in favour of a local method variable.