### PR TITLE
Fix a number of apparent bugs and minor clean-up.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -41,38 +41,43 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     private function getTestVersion()
     {
         /**
-         * var $testVersion will hold an array containing min/max version of PHP
+         * var $arrTestVersions will hold an array containing min/max version of PHP
          *   that we are checking against (see above).  If only a single version
          *   number is specified, then this is used as both the min and max.
          */
-        static $arrTestVersions;
+        static $arrTestVersions = array();
 
-        if (!isset($testVersion)) {
-            $testVersion = PHP_CodeSniffer::getConfigData('testVersion');
-            $testVersion = trim($testVersion);
+        $testVersion = trim(PHP_CodeSniffer::getConfigData('testVersion'));
 
-            $arrTestVersions = array(null, null);
+        if (!isset($arrTestVersions[$testVersion]) && !empty($testVersion)) {
+
+            $arrTestVersions[$testVersion] = array(null, null);
             if (preg_match('/^\d+\.\d+$/', $testVersion)) {
-                $arrTestVersions = array($testVersion, $testVersion);
+                $arrTestVersions[$testVersion] = array($testVersion, $testVersion);
             }
             elseif (preg_match('/^(\d+\.\d+)\s*-\s*(\d+\.\d+)$/', $testVersion,
                                $matches))
             {
-                if (version_compare($matches[1], $matches[2], ">")) {
+                if (version_compare($matches[1], $matches[2], '>')) {
                     trigger_error("Invalid range in testVersion setting: '"
                                   . $testVersion . "'", E_USER_WARNING);
                 }
                 else {
-                    $arrTestVersions = array($matches[1], $matches[2]);
+                    $arrTestVersions[$testVersion] = array($matches[1], $matches[2]);
                 }
             }
-            elseif (!$testVersion == "") {
+            elseif (!$testVersion == '') {
                 trigger_error("Invalid testVersion setting: '" . $testVersion
                               . "'", E_USER_WARNING);
             }
         }
 
-        return $arrTestVersions;
+        if (isset($arrTestVersions[$testVersion])) {
+            return $arrTestVersions[$testVersion];
+        }
+        else {
+			return array(null, null);
+        }
     }
 
     public function supportsAbove($phpVersion)

--- a/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -45,36 +45,36 @@ class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPComp
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        
+
         $ignore = array(
             T_DOUBLE_COLON,
             T_OBJECT_OPERATOR,
             T_FUNCTION,
             T_CONST,
         );
-        
+
         $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
         if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
             // Not a call to a PHP function.
             return;
         }
-        
+
         $function = strtolower($tokens[$stackPtr]['content']);
-        
+
         if ($function === 'define') {
             $openParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, null, null, true);
             if ($openParenthesis === false) {
                 return;
             }
-            
+
             $comma = $phpcsFile->findNext(T_COMMA, $openParenthesis, $tokens[$openParenthesis]['parenthesis_closer']);
-            
+
             if ($comma === false) {
                 return;
             }
 
             $array = $phpcsFile->findNext(array(T_ARRAY, T_OPEN_SHORT_ARRAY), $comma, $tokens[$openParenthesis]['parenthesis_closer']);
-            
+
             if ($array !== false) {
                 if ($this->supportsAbove('7.0')) {
                     return;

--- a/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -64,16 +64,20 @@ class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPComp
         if ($function === 'define') {
             $openParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, null, null, true);
             if ($openParenthesis === false) {
-                return false;
+                return;
             }
             
             $comma = $phpcsFile->findNext(T_COMMA, $openParenthesis, $tokens[$openParenthesis]['parenthesis_closer']);
             
+            if ($comma === false) {
+                return;
+            }
+
             $array = $phpcsFile->findNext(array(T_ARRAY, T_OPEN_SHORT_ARRAY), $comma, $tokens[$openParenthesis]['parenthesis_closer']);
             
             if ($array !== false) {
                 if ($this->supportsAbove('7.0')) {
-                    return false;
+                    return;
                 } else {
                     $phpcsFile->addError('Constant arrays using define are not allowed in PHP 5.6 or earlier', $array);
                 }

--- a/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
+++ b/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
@@ -46,7 +46,8 @@ class PHPCompatibility_Sniffs_PHP_DefaultTimeZoneRequiredSniff extends PHPCompat
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.4')) {
-            if (ini_get('date.timezone') == false) {
+            $ini_value = ini_get('date.timezone');
+            if (is_string($ini_value) === false || $ini_value === '') {
                 $error = 'Default timezone is required since PHP 5.4';
                 $phpcsFile->addError($error, $stackPtr);
             }

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -25,7 +25,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      * @var bool
      */
     protected $patternMatch = false;
-    
+
     /**
      * A list of forbidden functions with their alternatives.
      *
@@ -622,18 +622,18 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
         // Everyone has had a chance to figure out what forbidden functions
         // they want to check for, so now we can cache out the list.
         $this->forbiddenFunctionNames = array_keys($this->forbiddenFunctions);
-    
+
         if ($this->patternMatch === true) {
             foreach ($this->forbiddenFunctionNames as $i => $name) {
                 $this->forbiddenFunctionNames[$i] = '/'.$name.'/i';
             }
         }
-    
+
         return array(T_STRING);
-    
+
     }//end register()
-    
-    
+
+
     /**
      * Processes this test, when one of its tokens is encountered.
      *

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -692,7 +692,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
     }//end process()
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the forbidden function

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -156,7 +156,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        
+
         $isError = false;
 
         $ignore = array(

--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -17,6 +17,7 @@
  * @author    Koen Eelen <koen.eelen@cu.be>
  */
 class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends PHPCompatibility_Sniff {
+
     public function register()
     {
         return array(T_CLASS);
@@ -41,6 +42,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
         $nextFunc = $stackPtr;
         $newConstructorFound = false;
         $oldConstructorFound = false;
+        $oldConstructorPos   = false;
         while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
             $funcNamePos = $phpcsFile->findNext(T_STRING, $nextFunc);
             
@@ -51,12 +53,13 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
             if ($this->supportsAbove('7.0')) {
                 if ($funcNamePos !== false && $tokens[$funcNamePos]['content'] === $className) {
                     $oldConstructorFound = true;
+                    $oldConstructorPos   = $funcNamePos;
                 }
             }
         }
         
         if ($newConstructorFound === false && $oldConstructorFound === true) {
-            $phpcsFile->addError('Deprecated PHP4 style constructor are not supported since PHP7', $funcNamePos);
+            $phpcsFile->addError('Deprecated PHP4 style constructor are not supported since PHP7', $oldConstructorPos);
         }
     }
 }

--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -45,7 +45,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
         $oldConstructorPos   = false;
         while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
             $funcNamePos = $phpcsFile->findNext(T_STRING, $nextFunc);
-            
+
             if ($tokens[$funcNamePos]['content'] === '__construct') {
                 $newConstructorFound = true;
             }
@@ -57,7 +57,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
                 }
             }
         }
-        
+
         if ($newConstructorFound === false && $oldConstructorFound === true) {
             $phpcsFile->addError('Deprecated PHP4 style constructor are not supported since PHP7', $oldConstructorPos);
         }

--- a/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -49,14 +49,14 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPC
 
             $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false);
             $close = $phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr, null, false);
-            
+
             $error = true;
             for ($cnt = $open + 1; $cnt < $close; $cnt++) {
                 if ($tokens[$cnt]['type'] != 'T_WHITESPACE' && $tokens[$cnt]['type'] != 'T_COMMA') {
                     $error = false;
                 }
             }
-            
+
             if ($open !== false && $close !== false) {
                 if (
                     $close - $open == 1

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -53,9 +53,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
                 return;
             }
 
-            // Get function name.
-            $methodName = $phpcsFile->getDeclarationName($stackPtr);
-            
             // Get all parameters from method signature.
             $paramNames = array();
             foreach ($phpcsFile->getMethodParameters($stackPtr) as $param) {

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -58,7 +58,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
             foreach ($phpcsFile->getMethodParameters($stackPtr) as $param) {
                 $paramNames[] = strtolower($param['name']);
             }
-            
+
             if (count($paramNames) != count(array_unique($paramNames))) {
                 $phpcsFile->addError('Functions can not have multiple parameters with the same name since PHP 7.0', $stackPtr);
             }

--- a/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -12,7 +12,7 @@
 /**
  * PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshift.
  *
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0 
+ * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -45,7 +45,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff extends PHPComp
     {
         if ($this->supportsAbove('7.0')) {
             $tokens = $phpcsFile->getTokens();
-            
+
             $nextNumber = $phpcsFile->findNext(T_LNUMBER, $stackPtr, null, false, null, true);
             if ($tokens[$nextNumber - 1]['code'] == T_MINUS) {
                 $error = 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0';

--- a/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -47,7 +47,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff 
     {
         if ($this->supportsAbove('7.0')) {
             $tokens = $phpcsFile->getTokens();
-            
+
             $defaultToken = $stackPtr;
             $defaultCount = 0;
             if (isset($tokens[$stackPtr]['scope_closer'])) {
@@ -58,7 +58,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff 
                         $defaultCount++;
                     }
                 }
-                
+
                 if ($defaultCount > 1) {
                     $phpcsFile->addError('Switch statements can not have multiple default blocks since PHP 7.0', $stackPtr);
                 }

--- a/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -51,7 +51,7 @@ class PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff extends PHPCompatibil
         if ($whitespace === false || $class === false) {
             return;
         }
-        
+
         if ($this->supportsAbove('7.0')) {
             return;
         } else {

--- a/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -46,15 +46,14 @@ class PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff extends PHPCompatibil
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
         $whitespace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, $stackPtr + 2);
-        $class = $phpcsFile->findNext(T_ANON_CLASS, $stackPtr + 2, $stackPtr + 3);
-        if ($whitespace == false || $class == false) {
-            return false;
+        $class      = $phpcsFile->findNext(T_ANON_CLASS, $stackPtr + 2, $stackPtr + 3);
+        if ($whitespace === false || $class === false) {
+            return;
         }
         
         if ($this->supportsAbove('7.0')) {
-            return false;
+            return;
         } else {
             $phpcsFile->addError('Anonymous classes are not supported in PHP 5.6 or earlier', $stackPtr);
         }

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -237,7 +237,6 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
         }
 
 
-
     }//end process()
 
 

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -247,7 +247,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the function
      *                                        in the token array.
-     * @param string               $function  The name of the function.
+     * @param string               $className The name of the class.
      * @param string               $pattern   The pattern used for the match.
      *
      * @return void

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -242,7 +242,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the function

--- a/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -25,7 +25,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
     {
         return array(T_STRING);
     }//end register()
-    
+
     /**
      * Processes this test, when one of its tokens is encountered.
      *
@@ -51,7 +51,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
             // Not a call to a PHP function.
             return;
         }
-        
+
         if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['type'] == 'T_OPEN_PARENTHESIS') {
             $closeParenthesis = $tokens[$stackPtr + 1]['parenthesis_closer'];
             if ($tokens[$closeParenthesis + 1]['type'] == 'T_OPEN_SQUARE_BRACKET') {

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -146,11 +146,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
     /**
      * Generates the error or wanrning for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
-     * @param string               $pattern   The pattern used for the match.
+     * @param PHP_CodeSniffer_File $phpcsFile         The file being scanned.
+     * @param int                  $stackPtr          The position of the function
+     *                                                in the token array.
+     * @param string               $function          The name of the function.
+     * @param int                  $parameterLocation The parameter position within the function call.
      *
      * @return void
      */

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -144,7 +144,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile         The file being scanned.
      * @param int                  $stackPtr          The position of the function

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -23,7 +23,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
      * @var bool
      */
     protected $patternMatch = false;
-    
+
     /**
      * A list of new functions, not present in older versions.
      *
@@ -66,7 +66,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
 
 
     /**
-     * 
+     *
      * @var array
      */
     private $newFunctionParametersNames;
@@ -82,16 +82,16 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         // Everyone has had a chance to figure out what forbidden functions
         // they want to check for, so now we can cache out the list.
         $this->newFunctionParametersNames = array_keys($this->newFunctionParameters);
-    
+
         if ($this->patternMatch === true) {
             foreach ($this->newFunctionParametersNames as $i => $name) {
                 $this->newFunctionParametersNames[$i] = '/'.$name.'/i';
             }
         }
-    
+
         return array(T_STRING);
     }//end register()
-    
+
     /**
      * Processes this test, when one of its tokens is encountered.
      *
@@ -123,7 +123,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         if (in_array($function, $this->newFunctionParametersNames) === false) {
             return;
         }
-        
+
         if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['type'] == 'T_OPEN_PARENTHESIS') {
             $closeParenthesis = $tokens[$stackPtr + 1]['parenthesis_closer'];
 
@@ -138,7 +138,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
                 }
                 $cnt++;
             }
-            
+
         }
     }//end process()
 
@@ -167,7 +167,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
                 }
             }
         }
-        
+
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' does not have a parameter ' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . ' ' . $error;
 

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -23,7 +23,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      * @var bool
      */
     protected $patternMatch = false;
-    
+
     /**
      * A list of new functions, not present in older versions.
      *
@@ -1180,7 +1180,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      * @var array
      */
     private $forbiddenFunctionNames;
-    
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -1192,17 +1192,17 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
         // Everyone has had a chance to figure out what forbidden functions
         // they want to check for, so now we can cache out the list.
         $this->forbiddenFunctionNames = array_keys($this->forbiddenFunctions);
-    
+
         if ($this->patternMatch === true) {
             foreach ($this->forbiddenFunctionNames as $i => $name) {
                 $this->forbiddenFunctionNames[$i] = '/'.$name.'/i';
             }
         }
-    
+
         return array(T_STRING);
-    
+
     }//end register()
-    
+
     /**
      * Processes this test, when one of its tokens is encountered.
      *

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1176,8 +1176,8 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
 
     /**
-     * 
-     * @var unknown
+     *
+     * @var array
      */
     private $forbiddenFunctionNames;
     
@@ -1236,7 +1236,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
             $count   = 0;
             $pattern = preg_replace(
                     $this->forbiddenFunctionNames,
-                    $this->forbiddenFunctionsNames,
+                    $this->forbiddenFunctionNames,
                     $function,
                     1,
                     $count

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1260,7 +1260,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the function

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -160,7 +160,7 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
      * @param int                  $stackPtr    The position of the function

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -162,11 +162,11 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
     /**
      * Generates the error or wanrning for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
-     * @param string               $pattern   The pattern used for the match.
+     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                  $stackPtr    The position of the function
+     *                                          in the token array.
+     * @param string               $keywordName The name of the keyword.
+     * @param string               $pattern     The pattern used for the match.
      *
      * @return void
      */

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -96,10 +96,11 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
     /**
      * Generates the error or warning for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
+     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                  $stackPtr    The position of the function
+     *                                          in the token array.
+     * @param string               $keywordName The name of the keyword.
+     * @param string               $pattern     The pattern used for the match.
      *
      * @return void
      */

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -83,7 +83,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the function

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -82,7 +82,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the function

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -71,14 +71,9 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        // Get function name.
-        $methodName = $phpcsFile->getDeclarationName($stackPtr);
-        
         // Get all parameters from method signature.
-        $paramNames = array();
-        foreach ($phpcsFile->getMethodParameters($stackPtr) as $param) {
+        $paramNames = $phpcsFile->getMethodParameters($stackPtr);
+        foreach ($paramNames as $param) {
             if (in_array($param['type_hint'], array_keys($this->newTypes))) {
                 $this->addError($phpcsFile, $stackPtr, $param['type_hint']);
             }

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -3,7 +3,7 @@
  * PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff
  *
  * Discourages use of superglobals as parameters for functions.
- * 
+ *
  * PHP version 5.4
  *
  * @category   PHP
@@ -39,7 +39,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff implements PH
 
     /**
      * Processes the test.
-     * 
+     *
      * @param PHP_CodeSniffer_file $phpcsFile The file being scanned.
      * @param int                  $stackPtr  The position of the current token
      *
@@ -65,7 +65,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff implements PH
                     $phpcsFile->addError("Parameter shadowing super global ($variable) causes fatal error since PHP 5.4", $i);
                 }
             }
-            
+
         }
     }
 }

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -148,7 +148,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
 
 
     /**
-     * Generates the error or wanrning for this sniff.
+     * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile         The file being scanned.
      * @param int                  $stackPtr          The position of the function

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -23,7 +23,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
      * @var bool
      */
     protected $patternMatch = false;
-    
+
     /**
      * A list of Removed function parameters, not present in older versions.
      *
@@ -51,7 +51,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
 
 
     /**
-     * 
+     *
      * @var array
      */
     private $removedFunctionParametersNames;
@@ -67,16 +67,16 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
         // Everyone has had a chance to figure out what forbidden functions
         // they want to check for, so now we can cache out the list.
         $this->removedFunctionParametersNames = array_keys($this->removedFunctionParameters);
-    
+
         if ($this->patternMatch === true) {
             foreach ($this->removedFunctionParametersNames as $i => $name) {
                 $this->removedFunctionParametersNames[$i] = '/'.$name.'/i';
             }
         }
-    
+
         return array(T_STRING);
     }//end register()
-    
+
     /**
      * Processes this test, when one of its tokens is encountered.
      *
@@ -108,7 +108,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
         if (in_array($function, $this->removedFunctionParametersNames) === false) {
             return;
         }
-        
+
         if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['type'] == 'T_OPEN_PARENTHESIS') {
             $closeParenthesis = $tokens[$stackPtr + 1]['parenthesis_closer'];
             $openParenthesis = $tokens[$closeParenthesis]['parenthesis_opener'];
@@ -132,17 +132,17 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
                 ) {
                     continue;
                 }
-                
+
                 if ($tokens[$nextComma]['type'] == 'T_CLOSE_PARENTHESIS' && $nextComma != $closeParenthesis) {
                     continue;
                 }
-                
+
                 if (isset($this->removedFunctionParameters[$function][$cnt])) {
                     $this->addError($phpcsFile, $nextComma, $function, $cnt);
                 }
                 $cnt++;
             }
-            
+
         }
     }//end process()
 
@@ -171,7 +171,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
                 }
             }
         }
-        
+
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' does not have a parameter ' . $this->removedFunctionParameters[$function][$parameterLocation]['name'] . ' ' . $error;
 

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -150,11 +150,11 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
     /**
      * Generates the error or wanrning for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
-     * @param string               $pattern   The pattern used for the match.
+     * @param PHP_CodeSniffer_File $phpcsFile         The file being scanned.
+     * @param int                  $stackPtr          The position of the function
+     *                                                in the token array.
+     * @param string               $function          The name of the function.
+     * @param int                  $parameterLocation The parameter position within the function call.
      *
      * @return void
      */

--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -57,7 +57,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        
+
         foreach ($this->removedGlobalVariables as $variable => $versionList) {
             if (strtolower($tokens[$stackPtr]['content']) == '$' . strtolower($variable)) {
                 $error = '';

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -8,7 +8,7 @@
 /**
  * BaseSniffTest
  *
- * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and 
+ * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings
  *
  * @uses PHPUnit_Framework_TestCase
@@ -78,7 +78,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
 
         return $phpcsFile;
     }
-    
+
     /**
      * Assert a PHPCS error on a particular line number
      *
@@ -156,7 +156,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
 
         if ($lineNumber == 0) {
             $allMessages = $errors + $warnings;
-            // TODO: Update the fail message to give the tester some 
+            // TODO: Update the fail message to give the tester some
             // indication of what the errors or warnings were
             return $this->assertEmpty($allMessages, 'Failed asserting no violations in file');
         }
@@ -186,7 +186,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
 
     /**
      * Show violations in file by line number
-     * 
+     *
      * This is useful for debugging sniffs on a file
      *
      * @param PHP_CodeSniffer_File $file Codesniffer file object

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -60,7 +60,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
      *
      * @param string $filename Filename to sniff
      * @param string $targetPhpVersion Value of 'testVersion' to set on PHPCS object
-     * @return PHP_CodeSniffer_File File object
+     * @return PHP_CodeSniffer_File File object|false
      */
     public function sniffFile($filename, $targetPhpVersion = null)
     {


### PR DESCRIPTION
On a whim, I've run the codebase through Scrutinizer (without any specific config) and this threw up some interesting findings.

This PR handles most of these (for the sniff files).

Typical issues found & handled in this PR:
* Returning `false` from the `process()` method. This is wrong. If the process method returns something it will be interpreted as an integer stack position to continue checking from, so returning false could lead to race conditions.
* Variables which are set and subsequently never used.
* Strict(er) checking of variables before/when using them
* Function calls within loops
* Minor documentation inconsistencies
* A particular typo

Also:
* Removed trailing spaces

One thing Scrutinizer threw up which is *not* (yet) handled is the following from the `BaseSniffTest.php` file:
```php
    /**
     * Tear down after each test
     *
     * @return void
     */
    public function tearDown()
    {
        // Reset any settingsStandard (targetPhpVersion)
        self::$phpcs->cli->settingsStandard = array();
    }
```

The `PHP_CodeSniffer_CLI` class does not have a `settingsStandard` property, so this code is effectively useless. All the same, I imagine something like this *does* need to be done, so someone more familiar with the original intend of this code might want to have a look at what this should be replaced with.