### PR TITLE
Allow for classes which *extend* potentially newly introduced classes.

### DIFF
--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -32,10 +32,12 @@ class NewClassesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.1');
         $this->assertError($file, 3, "The built-in class DateTime is not present in PHP version 5.1 or earlier");
         $this->assertError($file, 43, "The built-in class DateTime is not present in PHP version 5.1 or earlier");
+        $this->assertError($file, 45, "The built-in class DateTime is not present in PHP version 5.1 or earlier");
 
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertNoViolation($file, 3);
         $this->assertNoViolation($file, 43);
+        $this->assertNoViolation($file, 45);
     }
 
     /**
@@ -47,6 +49,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.1');
         $this->assertError($file, 4, "The built-in class DateTimeZone is not present in PHP version 5.1 or earlier");
+        $this->assertError($file, 46, "The built-in class DateTimeZone is not present in PHP version 5.1 or earlier");
     }
 
     /**
@@ -58,6 +61,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.1');
         $this->assertError($file, 5, "The built-in class RegexIterator is not present in PHP version 5.1 or earlier");
+        $this->assertError($file, 47, "The built-in class RegexIterator is not present in PHP version 5.1 or earlier");
     }
 
     /**
@@ -69,6 +73,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.1');
         $this->assertError($file, 6, "The built-in class RecursiveRegexIterator is not present in PHP version 5.1 or earlier");
+        $this->assertError($file, 48, "The built-in class RecursiveRegexIterator is not present in PHP version 5.1 or earlier");
     }
 
     /**
@@ -80,6 +85,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 7, "The built-in class DateInterval is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 49, "The built-in class DateInterval is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -91,6 +97,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 8, "The built-in class DatePeriod is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 50, "The built-in class DatePeriod is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -102,6 +109,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 9, "The built-in class Phar is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 51, "The built-in class Phar is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -113,6 +121,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 10, "The built-in class PharData is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 52, "The built-in class PharData is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -124,6 +133,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 11, "The built-in class PharException is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 53, "The built-in class PharException is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -135,6 +145,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 12, "The built-in class PharFileInfo is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 54, "The built-in class PharFileInfo is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -146,6 +157,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 13, "The built-in class FilesystemIterator is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 55, "The built-in class FilesystemIterator is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -157,6 +169,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 14, "The built-in class GlobIterator is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 56, "The built-in class GlobIterator is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -168,6 +181,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 15, "The built-in class MultipleIterator is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 57, "The built-in class MultipleIterator is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -179,6 +193,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 16, "The built-in class RecursiveTreeIterator is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 58, "The built-in class RecursiveTreeIterator is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -190,6 +205,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 17, "The built-in class SplDoublyLinkedList is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 59, "The built-in class SplDoublyLinkedList is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -201,6 +217,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 18, "The built-in class SplFixedArray is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 60, "The built-in class SplFixedArray is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -212,6 +229,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 19, "The built-in class SplHeap is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 61, "The built-in class SplHeap is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -223,6 +241,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 20, "The built-in class SplMaxHeap is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 62, "The built-in class SplMaxHeap is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -234,6 +253,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 21, "The built-in class SplMinHeap is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 63, "The built-in class SplMinHeap is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -245,6 +265,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 22, "The built-in class SplPriorityQueue is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 64, "The built-in class SplPriorityQueue is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -256,6 +277,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 23, "The built-in class SplQueue is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 65, "The built-in class SplQueue is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -267,6 +289,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.2');
         $this->assertError($file, 24, "The built-in class SplStack is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 66, "The built-in class SplStack is not present in PHP version 5.2 or earlier");
     }
 
     /**
@@ -278,6 +301,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 25, "The built-in class CallbackFilterIterator is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 67, "The built-in class CallbackFilterIterator is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -289,6 +313,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 26, "The built-in class RecursiveCallbackFilterIterator is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 68, "The built-in class RecursiveCallbackFilterIterator is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -300,6 +325,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 27, "The built-in class ReflectionZendExtension is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 69, "The built-in class ReflectionZendExtension is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -322,6 +348,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 29, "The built-in class SessionHandler is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 71, "The built-in class SessionHandler is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -333,6 +360,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 30, "The built-in class SNMP is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 72, "The built-in class SNMP is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -344,6 +372,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.3');
         $this->assertError($file, 31, "The built-in class Transliterator is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 73, "The built-in class Transliterator is not present in PHP version 5.3 or earlier");
     }
 
     /**
@@ -355,6 +384,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 32, "The built-in class CURLFile is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 74, "The built-in class CURLFile is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -366,6 +396,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 33, "The built-in class DateTimeImmutable is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 75, "The built-in class DateTimeImmutable is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -377,6 +408,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 34, "The built-in class IntlCalendar is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 76, "The built-in class IntlCalendar is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -388,6 +420,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 35, "The built-in class IntlGregorianCalendar is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 77, "The built-in class IntlGregorianCalendar is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -399,6 +432,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 36, "The built-in class IntlTimeZone is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 78, "The built-in class IntlTimeZone is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -410,6 +444,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 37, "The built-in class IntlBreakIterator is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 79, "The built-in class IntlBreakIterator is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -421,6 +456,7 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 38, "The built-in class IntlRuleBasedBreakIterator is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 80, "The built-in class IntlRuleBasedBreakIterator is not present in PHP version 5.4 or earlier");
     }
 
     /**
@@ -432,5 +468,6 @@ class NewClassesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_classes.php', '5.4');
         $this->assertError($file, 39, "The built-in class IntlCodePointBreakIterator is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 81, "The built-in class IntlCodePointBreakIterator is not present in PHP version 5.4 or earlier");
     }
 }

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -41,3 +41,41 @@ $test = new IntlCodePointBreakIterator();
 $okay = new StdClass();
 
 $test = new DateTime;
+
+class MyDateTime extends DateTime {}
+class MyDateTimeZone extends DateTimeZone {}
+class MyRegexIterator extends RegexIterator {}
+class MyRecursiveRegexIterator extends RecursiveRegexIterator {}
+class MyDateInterval extends DateInterval {}
+class MyDatePeriod extends DatePeriod {}
+class MyPhar extends Phar {}
+class MyPharData extends PharData {}
+class MyPharException extends PharException {}
+class MyPharFileInfo extends PharFileInfo {}
+class MyFilesystemIterator extends FilesystemIterator {}
+class MyGlobIterator extends GlobIterator {}
+class MyMultipleIterator extends MultipleIterator {}
+class MyRecursiveTreeIterator extends RecursiveTreeIterator {}
+class MySplDoublyLinkedList extends SplDoublyLinkedList {}
+class MySplFixedArray extends SplFixedArray {}
+abstract class MySplHeap extends SplHeap {}
+class MySplMaxHeap extends SplMaxHeap {}
+class MySplMinHeap extends SplMinHeap {}
+class MySplPriorityQueue extends SplPriorityQueue {}
+class MySplQueue extends SplQueue {}
+class MySplStack extends SplStack {}
+class MyCallbackFilterIterator extends CallbackFilterIterator {}
+class MyRecursiveCallbackFilterIterator extends RecursiveCallbackFilterIterator {}
+class MyReflectionZendExtension extends ReflectionZendExtension {}
+
+class MySessionHandler extends SessionHandler {}
+class MySNMP extends SNMP {}
+class MyTransliterator extends Transliterator {}
+class MyCURLFile extends CURLFile {}
+class MyDateTimeImmutable extends DateTimeImmutable {}
+class MyIntlCalendar extends IntlCalendar {}
+class MyIntlGregorianCalendar extends IntlGregorianCalendar {}
+class MyIntlTimeZone extends IntlTimeZone {}
+class MyIntlBreakIterator extends IntlBreakIterator {}
+class MyIntlRuleBasedBreakIterator extends IntlRuleBasedBreakIterator {}
+class MyIntlCodePointBreakIterator extends IntlCodePointBreakIterator {}


### PR DESCRIPTION
The `NewClasses` sniff checks for instantiation of classes `new DateTime;`, but did not check for classes extending other classes, i.e. `class MyOwnDateTime extends DateTime {}`.

This PR fixes that. Includes unit tests.

As `JsonSerializable` is an interface and not a class, this is not tested with the `extends` syntax. In reality, `JsonSerializable` should probably be moved to a `NewInterfaces` sniff.