### PR TITLE
Two new sniffs for Interfaces

### DIFF
--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * A list of PHP internal interfaces, not intended to be implemented by userland classes.
+     *
+     * The array lists : the error message to use.
+     *
+     * @var array(string => string)
+     */
+    protected $internalInterfaces = array(
+        'Traversable'       => 'shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
+        'DateTimeInterface' => 'is intended for type hints only and is not implementable.',
+        'Throwable'         => 'cannot be implemented directly, extend the Exception class instead.',
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Handle case-insensitivity of class names.
+        $keys = array_keys( $this->internalInterfaces );
+        $keys = array_map( 'strtolower', $keys );
+        $this->internalInterfaces = array_combine( $keys, $this->internalInterfaces );
+
+        return array(T_CLASS);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $interfaces = $this->findImplementedInterfaceNames($phpcsFile, $stackPtr);
+
+        if (is_array($interfaces) === false || $interfaces === array()) {
+            return;
+        }
+
+        foreach ($interfaces as $interface) {
+            $lcInterface = strtolower($interface);
+            if (isset($this->internalInterfaces[$lcInterface]) === true) {
+                $error = 'The interface %s %s';
+                $data  = array(
+                    $interface,
+                    $this->internalInterfaces[$lcInterface],
+                );
+                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            }
+        }
+
+    }//end process()
+
+}//end class

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewInterfacesSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewInterfacesSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * A list of new interfaces, not present in older versions.
+     *
+     * The array lists : version number with false (not present) or true (present).
+     * If's sufficient to list the first version where the interface appears.
+     *
+     * @var array(string => array(string => int|string|null))
+     */
+    protected $newInterfaces = array(
+                                'Countable' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+                                'OuterIterator' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+                                'RecursiveIterator' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+                                'SeekableIterator' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+                                'Serializable' => array(
+                                    '5.0' => false,
+                                    '5.1' => true,
+                                ),
+                                'SplObserver' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+                                'SplSubject' => array(
+                                    '5.0' => false,
+                                    '5.1' => true
+                                ),
+
+                                'JsonSerializable' => array(
+                                    '5.3' => false,
+                                    '5.4' => true
+                                ),
+                                'SessionHandlerInterface' => array(
+                                    '5.3' => false,
+                                    '5.4' => true
+                                ),
+
+                               );
+
+    /**
+     * A list of methods which cannot be used in combination with particular interfaces.
+     *
+     * @var array(string => array(string => string))
+     */
+    protected $unsupportedMethods = array(
+                                     'Serializable' => array(
+                                         '__sleep'  => 'http://php.net/serializable',
+                                         '__wakeup' => 'http://php.net/serializable',
+                                     ),
+                                    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Handle case-insensitivity of class names.
+        $keys = array_keys( $this->newInterfaces );
+        $keys = array_map( 'strtolower', $keys );
+        $this->newInterfaces = array_combine( $keys, $this->newInterfaces );
+
+        $keys = array_keys( $this->unsupportedMethods );
+        $keys = array_map( 'strtolower', $keys );
+        $this->unsupportedMethods = array_combine( $keys, $this->unsupportedMethods );
+
+        return array(T_CLASS);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $interfaces = $this->findImplementedInterfaceNames($phpcsFile, $stackPtr);
+
+        if (is_array($interfaces) === false || $interfaces === array()) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $checkMethods = false;
+
+        if(isset($tokens[$stackPtr]['scope_closer'])) {
+            $checkMethods = true;
+            $scopeCloser = $tokens[$stackPtr]['scope_closer'];
+        }
+
+        foreach ($interfaces as $interface) {
+            $lcInterface = strtolower($interface);
+            if (isset($this->newInterfaces[$lcInterface]) === true) {
+                $this->addError($phpcsFile, $stackPtr, $interface);
+            }
+
+            if ($checkMethods === true && isset($this->unsupportedMethods[$lcInterface]) === true) {
+                $nextFunc = $stackPtr;
+                while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
+                    $funcNamePos = $phpcsFile->findNext(T_STRING, $nextFunc);
+                    $funcName    = strtolower($tokens[$funcNamePos]['content']);
+
+                    if (isset($this->unsupportedMethods[$lcInterface][$funcName]) === true) {
+                        $error = 'Classes that implement interface %s do not support the method %s(). See %s';
+                        $data  = array(
+                            $interface,
+                            $tokens[$funcNamePos]['content'],
+                            $this->unsupportedMethods[$lcInterface][$funcName],
+                        );
+                        $phpcsFile->addError($error, $funcNamePos, 'UnsupportedMethod', $data);
+                    }
+                }
+            }
+        }
+
+    }//end process()
+
+
+    /**
+     * Generates the error or warning for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the function
+     *                                        in the token array.
+     * @param string               $interface The name of the interface.
+     * @param string               $pattern   The pattern used for the match.
+     *
+     * @return void
+     */
+    protected function addError($phpcsFile, $stackPtr, $interface, $pattern=null)
+    {
+        if ($pattern === null) {
+            $pattern = strtolower($interface);
+        }
+
+        $error = '';
+
+        $isError = false;
+        foreach ($this->newInterfaces[$pattern] as $version => $present) {
+            if ($this->supportsBelow($version)) {
+                if ($present === false) {
+                    $isError = true;
+                    $error .= 'not present in PHP version ' . $version . ' or earlier';
+                }
+            }
+        }
+
+        if (strlen($error) > 0) {
+            $error = 'The built-in interface ' . $interface . ' is ' . $error;
+
+            if ($isError === true) {
+                $phpcsFile->addError($error, $stackPtr);
+            } else {
+                $phpcsFile->addWarning($error, $stackPtr);
+            }
+        }
+
+    }//end addError()
+
+}//end class

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Internal Interfaces Sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Internal Interfaces Sniff tests
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class InternalInterfacesSniffTest extends BaseSniffTest
+{
+    /**
+     * Sniffed file
+     *
+     * @var PHP_CodeSniffer_File
+     */
+    protected $_sniffFile;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_sniffFile = $this->sniffFile('sniff-examples/internal_interfaces.php');
+    }
+
+    /**
+     * Test Traversable interface
+     *
+     * @return void
+     */
+    public function testTraversable()
+    {
+        $this->assertError($this->_sniffFile, 3, 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.');
+    }
+
+    /**
+     * Test DateTimeInterface interface
+     *
+     * @return void
+     */
+    public function testDateTimeInterface()
+    {
+        $this->assertError($this->_sniffFile, 4, 'The interface DateTimeInterface is intended for type hints only and is not implementable.');
+    }
+
+    /**
+     * Test Throwable interface
+     *
+     * @return void
+     */
+    public function testThrowable()
+    {
+        $this->assertError($this->_sniffFile, 5, 'The interface Throwable cannot be implemented directly, extend the Exception class instead.');
+    }
+
+    /**
+     * Test multiple interfaces
+     *
+     * @return void
+     */
+    public function testMultipleInterfaces()
+    {
+        $this->assertError($this->_sniffFile, 7, 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.');
+        $this->assertError($this->_sniffFile, 7, 'The interface Throwable cannot be implemented directly, extend the Exception class instead.');
+    }
+
+    /**
+     * Test interfaces in different cases.
+     *
+     * @return void
+     */
+    public function testCaseInsensitive()
+    {
+        $this->assertError($this->_sniffFile, 9, 'The interface DATETIMEINTERFACE is intended for type hints only and is not implementable.');
+        $this->assertError($this->_sniffFile, 10, 'The interface datetimeinterface is intended for type hints only and is not implementable.');
+    }
+}

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * New Interfaces Sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New Interfaces Sniff tests
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewInterfacesSniffTest extends BaseSniffTest
+{
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+    }
+
+    /**
+     * Test Countable interface
+     *
+     * @return void
+     */
+    public function testCountable()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 3, 'The built-in interface Countable is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 3);
+    }
+
+    /**
+     * Test OuterIterator interface
+     *
+     * @return void
+     */
+    public function testOuterIterator()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 4, 'The built-in interface OuterIterator is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 4);
+    }
+
+    /**
+     * Test RecursiveIterator interface
+     *
+     * @return void
+     */
+    public function testRecursiveIterator()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 5, 'The built-in interface RecursiveIterator is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 5);
+    }
+
+    /**
+     * Test SeekableIterator interface
+     *
+     * @return void
+     */
+    public function testSeekableIterator()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 6, 'The built-in interface SeekableIterator is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 6);
+    }
+
+    /**
+     * Test Serializable interface
+     *
+     * @return void
+     */
+    public function testSerializable()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 7, 'The built-in interface Serializable is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 7);
+    }
+
+    /**
+     * Test SplObserver interface
+     *
+     * @return void
+     */
+    public function testSplObserver()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 11, 'The built-in interface SplObserver is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 11);
+    }
+
+    /**
+     * Test SplSubject interface
+     *
+     * @return void
+     */
+    public function testSplSubject()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 12, 'The built-in interface SplSubject is not present in PHP version 5.0 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 12);
+    }
+
+    /**
+     * Test JsonSerializable interface
+     *
+     * @return void
+     */
+    public function testJsonSerializable()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.3');
+        $this->assertError($file, 13, 'The built-in interface JsonSerializable is not present in PHP version 5.3 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 13);
+    }
+
+    /**
+     * Test SessionHandlerInterface interface
+     *
+     * @return void
+     */
+    public function testSessionHandlerInterface()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.3');
+        $this->assertError($file, 14, 'The built-in interface SessionHandlerInterface is not present in PHP version 5.3 or earlier');
+
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.5');
+        $this->assertNoViolation($file, 14);
+    }
+
+    /**
+     * Test unsupported methods
+     *
+     * @return void
+     */
+    public function testUnsupportedMethods()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php');
+        $this->assertError($file, 8, 'Classes that implement interface Serializable do not support the method __sleep(). See http://php.net/serializable');
+        $this->assertError($file, 9, 'Classes that implement interface Serializable do not support the method __wakeup(). See http://php.net/serializable');
+    }
+
+    /**
+     * Test multiple interfaces
+     *
+     * @return void
+     */
+    public function testMultipleInterfaces()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 16, 'The built-in interface SplSubject is not present in PHP version 5.0 or earlier');
+        $this->assertError($file, 16, 'The built-in interface JsonSerializable is not present in PHP version 5.3 or earlier');
+        $this->assertError($file, 16, 'The built-in interface Countable is not present in PHP version 5.0 or earlier');
+    }
+
+    /**
+     * Test interfaces in different cases.
+     *
+     * @return void
+     */
+    public function testCaseInsensitive()
+    {
+        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $this->assertError($file, 18, 'The built-in interface COUNTABLE is not present in PHP version 5.0 or earlier');
+        $this->assertError($file, 19, 'The built-in interface countable is not present in PHP version 5.0 or earlier');
+    }
+
+}

--- a/Tests/sniff-examples/internal_interfaces.php
+++ b/Tests/sniff-examples/internal_interfaces.php
@@ -1,0 +1,10 @@
+<?php
+
+class MyTraversable implements Traversable {}
+class MyDateTimeInterface implements DateTimeInterface {}
+class MyThrowable implements Throwable {}
+
+class MyMultiple implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.
+
+class MyUppercase implements DATETIMEINTERFACE {} // Test case-insensitivity.
+class MyLowercase implements datetimeinterface {} // Test case-insensitivity.

--- a/Tests/sniff-examples/new_interfaces.php
+++ b/Tests/sniff-examples/new_interfaces.php
@@ -1,0 +1,19 @@
+<?php
+
+class MyCountable implements Countable {}
+class MyOuterIterator implements OuterIterator {}
+class MyRecursiveIterator implements RecursiveIterator {}
+class MySeekableIterator implements SeekableIterator {}
+class MySerializable implements Serializable {
+	public function __sleep() {}
+	public function __wakeup() {}
+}
+class MySplObserver implements SplObserver {}
+class MySplSubject implements SplSubject {}
+class MyJsonSerializable implements JsonSerializable {}
+class MySessionHandlerInterface implements SessionHandlerInterface {}
+
+class MyMultiple implements SplSubject, JsonSerializable, Countable {}
+
+class MyUppercase implements COUNTABLE {}
+class MyLowercase implements countable {}


### PR DESCRIPTION
1, Sniff to verify the use of interfaces against the PHP version in which they were introduced.
2. Sniff to verify that interfaces intended for PHP internal use are not being implemented in user land.

Sniff 1 also includes a check for unsupported methods, particularly that `__sleep()` and `__wakeup()` are not defined within a class implementing the `Serializable` interface as they would be ignored.

All checks unit tested.

I've copied over a method which was added to PHPCS for the upcoming 2.7 release. If at some point PHPCompatibility would up the minimum PHPCS version to 2.7+, this method can be removed.
This has also been documented in the method doc block.