### PR TITLE
Add minimal scrutinizer config.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,12 @@
+filter:
+    excluded_paths:
+        - 'Tests/sniff-examples/*'
+
+tools:
+    php_sim: true
+    php_pdepend: true
+    php_analyzer: true
+    sensiolabs_security_checker: true
+
+checks:
+    php: true


### PR DESCRIPTION
This config will make Scrutinizer ignore the example test files.