### PR TITLE
Lots of additional ini directives & ability to indicate renamed directives

### DIFF
--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -187,21 +187,26 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
 
         foreach ($this->deprecatedIniDirectives[$filteredToken] as $version => $forbidden)
         {
-            if ($this->supportsAbove($version)) {
-                if ($forbidden === true) {
-                    $isError = ($function != 'ini_get') ?: false;
-                    $error .= " forbidden";
-                } else {
-                    $isError = false;
-                    $error .= " deprecated";
-                }
-                $error .= " from PHP " . $version . " and";
-            }
+			if ($version !== 'alternative') {
+	            if ($this->supportsAbove($version)) {
+	                if ($forbidden === true) {
+	                    $isError = ($function != 'ini_get') ?: false;
+	                    $error .= " forbidden";
+	                } else {
+	                    $isError = false;
+	                    $error .= " deprecated";
+	                }
+	                $error .= " from PHP " . $version . " and";
+	            }
+			}
         }
 
         if (strlen($error) > 0) {
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             $error = substr($error, 0, strlen($error) - 4) . ".";
+            if (isset($this->deprecatedIniDirectives[$filteredToken]['alternative'])) {
+				$error .= 'Use ' . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . ' instead.';
+			}
 
             if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -28,7 +28,74 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
      * @var array(string)
      */
     protected $deprecatedIniDirectives = array(
-        'define_syslog_variables' => array(
+        'fbsql.batchSize' => array(
+            '5.0' => false,
+            '5.1' => true,
+            'alternative' => 'fbsql.batchsize',
+        ),
+
+        'ifx.allow_persistent' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.blobinfile' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.byteasvarchar' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.charasvarchar' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.default_host' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.default_password' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.default_user' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.max_links' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.max_persistent' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.nullformat' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+        'ifx.textasvarchar' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.1' => true
+        ),
+
+        'zend.ze1_compatibility_mode' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+
+		'define_syslog_variables' => array(
             '5.3' => false,
             '5.4' => true
         ),
@@ -99,6 +166,14 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         'safe_mode_protected_env_vars' => array(
             '5.3' => false,
             '5.4' => true
+        ),
+        'detect_unicode' => array(
+            '5.4' => true,
+            'alternative' => 'zend.detect_unicode',
+        ),
+        'mbstring.script_encoding' => array(
+            '5.4' => true,
+            'alternative' => 'zend.script_encoding',
         ),
         'always_populate_raw_post_data' => array(
             '5.6' => false

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -23,70 +23,50 @@
 class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompatibility_Sniff
 {
     /**
-     * A list of deprecated INI directives
+     * A list of deprecated INI directives.
+     *
+     * version => false means the directive was deprecated in that version.
+     * version => true means it was removed in that version.
      *
      * @var array(string)
      */
     protected $deprecatedIniDirectives = array(
         'fbsql.batchSize' => array(
-            '5.0' => false,
             '5.1' => true,
             'alternative' => 'fbsql.batchsize',
         ),
 
         'ifx.allow_persistent' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.blobinfile' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.byteasvarchar' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.charasvarchar' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.default_host' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.default_password' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.default_user' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.max_links' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.max_persistent' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.nullformat' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
         'ifx.textasvarchar' => array(
-            '5.1'   => false,
-            '5.2'   => false,
             '5.2.1' => true
         ),
 
@@ -95,15 +75,19 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             '5.3' => true,
         ),
 
-		'define_syslog_variables' => array(
+        'allow_call_time_pass_reference' => array(
             '5.3' => false,
             '5.4' => true
         ),
-        'register_globals' => array(
+        'define_syslog_variables' => array(
             '5.3' => false,
             '5.4' => true
         ),
-        'register_long_arrays' => array(
+        'detect_unicode' => array(
+            '5.4'         => true,
+            'alternative' => 'zend.detect_unicode',
+        ),
+        'highlight.bg' => array(
             '5.3' => false,
             '5.4' => true
         ),
@@ -119,11 +103,39 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             '5.3' => false,
             '5.4' => true
         ),
-        'allow_call_time_pass_reference' => array(
+        'mbstring.script_encoding' => array(
+            '5.4'         => true,
+            'alternative' => 'zend.script_encoding',
+        ),
+        'register_globals' => array(
             '5.3' => false,
             '5.4' => true
         ),
-        'highlight.bg' => array(
+        'register_long_arrays' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode_allowed_env_vars' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode_exec_dir' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode_gid' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode_include_dir' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+        'safe_mode_protected_env_vars' => array(
             '5.3' => false,
             '5.4' => true
         ),
@@ -140,43 +152,12 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             '5.4' => true
         ),
         'zend.ze1_compatibility_mode' => array(
-            '5.3' => false,
             '5.4' => true
         ),
-        'safe_mode' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'safe_mode_gid' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'safe_mode_include_dir' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'safe_mode_exec_dir' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'safe_mode_allowed_env_vars' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'safe_mode_protected_env_vars' => array(
-            '5.3' => false,
-            '5.4' => true
-        ),
-        'detect_unicode' => array(
-            '5.4' => true,
-            'alternative' => 'zend.detect_unicode',
-        ),
-        'mbstring.script_encoding' => array(
-            '5.4' => true,
-            'alternative' => 'zend.script_encoding',
-        ),
+
         'always_populate_raw_post_data' => array(
-            '5.6' => false
+            '5.6' => false,
+            '7.0' => true
         ),
         'iconv.input_encoding' => array(
             '5.6' => false
@@ -196,10 +177,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         'mbstring.internal_encoding' => array(
             '5.6' => false
         ),
-        'always_populate_raw_post_data' => array(
-            '5.6' => false,
-            '7.0' => true
-        ),
+
         'asp_tags' => array(
             '7.0' => true
         ),
@@ -262,26 +240,26 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
 
         foreach ($this->deprecatedIniDirectives[$filteredToken] as $version => $forbidden)
         {
-			if ($version !== 'alternative') {
-	            if ($this->supportsAbove($version)) {
-	                if ($forbidden === true) {
-	                    $isError = ($function != 'ini_get') ?: false;
-	                    $error .= " forbidden";
-	                } else {
-	                    $isError = false;
-	                    $error .= " deprecated";
-	                }
-	                $error .= " from PHP " . $version . " and";
-	            }
-			}
+            if ($version !== 'alternative') {
+                if ($this->supportsAbove($version)) {
+                    if ($forbidden === true) {
+                        $isError = ($function != 'ini_get') ?: false;
+                        $error .= " forbidden";
+                    } else {
+                        $isError = false;
+                        $error .= " deprecated";
+                    }
+                    $error .= " from PHP " . $version . " and";
+                }
+            }
         }
 
         if (strlen($error) > 0) {
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             $error = substr($error, 0, strlen($error) - 4) . ".";
             if (isset($this->deprecatedIniDirectives[$filteredToken]['alternative'])) {
-				$error .= 'Use ' . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . ' instead.';
-			}
+                $error .= 'Use ' . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . ' instead.';
+            }
 
             if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -71,7 +71,6 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         ),
 
         'zend.ze1_compatibility_mode' => array(
-            '5.2' => false,
             '5.3' => true,
         ),
 
@@ -149,9 +148,6 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         ),
         'y2k_compliance' => array(
             '5.3' => false,
-            '5.4' => true
-        ),
-        'zend.ze1_compatibility_mode' => array(
             '5.4' => true
         ),
 
@@ -258,7 +254,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             $error = substr($error, 0, strlen($error) - 4) . ".";
             if (isset($this->deprecatedIniDirectives[$filteredToken]['alternative'])) {
-                $error .= ". Use '" . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . "' instead.";
+                $error .= " Use '" . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . "' instead.";
             }
 
             if ($isError === true) {

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -179,7 +179,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
 
         $iniToken      = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
         $filteredToken = trim($tokens[$iniToken]['content'], '\'"');
-        if (in_array($filteredToken, array_keys($this->deprecatedIniDirectives)) === false) {
+        if (isset($this->deprecatedIniDirectives[$filteredToken]) === false) {
             return;
         }
 

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -176,14 +176,16 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         if ($function != 'ini_get' && $function != 'ini_set') {
             return;
         }
-        $iniToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
-        if (in_array(str_replace("'", "", $tokens[$iniToken]['content']), array_keys($this->deprecatedIniDirectives)) === false) {
+
+        $iniToken      = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
+        $filteredToken = trim($tokens[$iniToken]['content'], '\'"');
+        if (in_array($filteredToken, array_keys($this->deprecatedIniDirectives)) === false) {
             return;
         }
 
         $error = '';
 
-        foreach ($this->deprecatedIniDirectives[str_replace("'", "", $tokens[$iniToken]['content'])] as $version => $forbidden)
+        foreach ($this->deprecatedIniDirectives[$filteredToken] as $version => $forbidden)
         {
             if ($this->supportsAbove($version)) {
                 if ($forbidden === true) {
@@ -198,7 +200,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         }
 
         if (strlen($error) > 0) {
-            $error = "INI directive " . $tokens[$iniToken]['content'] . " is" . $error;
+            $error = "INI directive '" . $filteredToken . "' is" . $error;
             $error = substr($error, 0, strlen($error) - 4) . ".";
 
             if ($isError === true) {

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -258,7 +258,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             $error = substr($error, 0, strlen($error) - 4) . ".";
             if (isset($this->deprecatedIniDirectives[$filteredToken]['alternative'])) {
-                $error .= 'Use ' . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . ' instead.';
+                $error .= ". Use '" . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . "' instead.";
             }
 
             if ($isError === true) {

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -527,7 +527,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         if (strlen($error) > 0) {
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             if (isset($this->newIniDirectives[$filteredToken]['alternative'])) {
-                $error .= 'This directive was previously called ' . $this->newIniDirectives[$filteredToken]['alternative'] . '.';
+                $error .= ". This directive was previously called '" . $this->newIniDirectives[$filteredToken]['alternative'] . "'.";
             }
 
             $phpcsFile->addWarning($error, $stackPtr);

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -194,11 +194,11 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         ),
         'filter.default' => array(
             '5.1' => false,
-            '5.2' => true
+            '5.2' => true,
         ),
         'filter.default_flags' => array(
             '5.1' => false,
-            '5.2' => true
+            '5.2' => true,
         ),
         'pcre.backtrack_limit' => array(
             '5.1' => false,
@@ -245,11 +245,11 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.2' => false,
             '5.3' => true,
         ),
-        'intl.error_level' => array(
+        'intl.default_locale' => array(
             '5.2' => false,
             '5.3' => true,
         ),
-        'intl.use_exceptions' => array(
+        'intl.error_level' => array(
             '5.2' => false,
             '5.3' => true,
         ),

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -28,7 +28,173 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
      * @var array(string)
      */
     protected $newIniDirectives = array(
+        'auto_globals_jit' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'com.code_page' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'date.default_latitude' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'date.default_longitude' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'date.sunrise_zenith' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'date.sunset_zenith' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'ibase.default_charset' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'ibase.default_db' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mail.force_extra_parameters' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mime_magic.debug' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.max_links' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.default_port' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.default_socket' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.default_host' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.default_user' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'mysqli.default_pw' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'report_zend_debug' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'session.hash_bits_per_character' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'session.hash_function' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'soap.wsdl_cache_dir' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'soap.wsdl_cache_enabled' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'soap.wsdl_cache_ttl' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'sqlite.assoc_case' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'tidy.clean_output' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'tidy.default_config' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+        'zend.ze1_compatibility_mode' => array(
+            '4.4' => false,
+            '5.0' => true,
+        ),
+
+        'date.timezone' => array(
+            '5.0' => false,
+            '5.1' => true,
+        ),
+        'detect_unicode' => array(
+            '5.0' => false,
+            '5.1' => true,
+        ),
+        'fbsql.batchsize' => array(
+            '5.0'         => false,
+            '5.1'         => true,
+            'alternative' => 'fbsql.batchSize',
+        ),
+        'realpath_cache_size' => array(
+            '5.0' => false,
+            '5.1' => true,
+        ),
+        'realpath_cache_ttl' => array(
+            '5.0' => false,
+            '5.1' => true,
+        ),
+
+        'mbstring.strict_detection' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.2' => true,
+        ),
+        'mssql.charset' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.2' => true,
+        ),
+        'gd.jpeg_ignore_warning' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.3' => true,
+        ),
+        'fbsql.show_timestamp_decimals' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.5' => true,
+        ),
+        'soap.wsdl_cache' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.5' => true,
+        ),
+        'soap.wsdl_cache_limit' => array(
+            '5.0'   => false,
+            '5.1'   => false,
+            '5.1.5' => true,
+        ),
+
         'allow_url_include' => array(
+            '5.1' => false,
+            '5.2' => true
+        ),
+        'filter.default' => array(
+            '5.1' => false,
+            '5.2' => true
+        ),
+        'filter.default_flags' => array(
             '5.1' => false,
             '5.2' => true
         ),
@@ -44,10 +210,25 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.1' => false,
             '5.2' => true
         ),
-        'max_input_nesting_level' => array(
+        'cgi.check_shebang_line' => array(
             '5.1' => false,
             '5.2' => false,
-            '5.2.2' => true
+            '5.2.1' => true
+        ),
+		'max_input_nesting_level' => array(
+            '5.1' => false,
+            '5.2' => false,
+            '5.2.3' => true
+        ),
+        'mysqli.allow_local_infile' => array(
+            '5.1'   => false,
+            '5.2'   => false,
+            '5.2.4' => true,
+        ),
+        'max_file_uploads' => array(
+            '5.1'    => false,
+            '5.2'    => false,
+            '5.2.12' => true,
         ),
 
         'user_ini.filename' => array(
@@ -70,6 +251,78 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.2' => false,
             '5.3' => true,
         ),
+        'cgi.discard_path' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'intl.error_level' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'intl.use_exceptions' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mail.add_x_header' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mail.log' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqli.allow_persistent' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqli.max_persistent' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqli.cache_size' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqlnd.collect_memory_statistics' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqlnd.collect_statistics' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqlnd.debug' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'mysqlnd.net_read_buffer_size' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'odbc.default_cursortype' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'zend.enable_gc' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+
+        'curl.cainfo' => array(
+            '5.2' => false,
+            '5.3' => false,
+            '5.3.7' => true,
+        ),
+        'max_input_vars' => array(
+            '5.2'   => false,
+            '5.3'   => false,
+            '5.3.9' => true,
+        ),
+        'sqlite3.extension_dir' => array(
+            '5.2'    => false,
+            '5.3'    => false,
+            '5.3.11' => true,
+        ),
 
         'cli.pager' => array(
             '5.3' => false,
@@ -80,10 +333,6 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.4' => true,
         ),
         'cli_server.color' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'max_input_vars' => array(
             '5.3' => false,
             '5.4' => true,
         ),
@@ -119,11 +368,40 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.3' => false,
             '5.4' => true,
         ),
+        'session.upload_progress.prefix' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
         'enable_post_data_reading' => array(
             '5.3' => false,
             '5.4' => true,
         ),
         'windows_show_crt_warning' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'zend.detect_unicode' => array(
+            '5.3'         => false,
+            '5.4'         => true,
+            'alternative' => 'detect_unicode',
+        ),
+        'mysqlnd.log_mask' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'mysqlnd.mempool_default_size' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'mysqlnd.net_cmd_buffer_size' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'mysqlnd.net_read_timeout' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'phar.cache_list' => array(
             '5.3' => false,
             '5.4' => true,
         ),
@@ -136,7 +414,46 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.4' => false,
             '5.5' => true,
         ),
+        'mysqlnd.trace_alloc' => array(
+            '5.4' => false,
+            '5.5' => true,
+        ),
+        'sys_temp_dir' => array(
+            '5.4' => false,
+            '5.5' => true,
+        ),
+        'xsl.security_prefs' => array(
+            '5.4' => false,
+            '5.5' => true,
+        ),
 
+        'session.use_strict_mode' => array(
+            '5.4'   => false,
+            '5.5'   => false,
+            '5.5.2' => true,
+        ),
+
+        'mysqli.rollback_on_cached_plink' => array(
+            '5.5' => false,
+            '5.6' => true,
+        ),
+
+        'assert.exception' => array(
+            '5.6' => false,
+            '7.0' => true,
+        ),
+        'pcre.jit' => array(
+            '5.6' => false,
+            '7.0' => true,
+        ),
+        'session.lazy_write' => array(
+            '5.6' => false,
+            '7.0' => true,
+        ),
+        'zend.assertions' => array(
+            '5.6' => false,
+            '7.0' => true,
+        ),
     );
 
     /**

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -180,9 +180,9 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         if ($function != 'ini_get' && $function != 'ini_set') {
             return;
         }
-        $iniToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
 
-        $filteredToken = str_replace(array('"', "'"), array("", ""), $tokens[$iniToken]['content']);
+        $iniToken      = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
+        $filteredToken = trim($tokens[$iniToken]['content'], '\'"');
         if (in_array($filteredToken, array_keys($this->newIniDirectives)) === false) {
             return;
         }

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -183,7 +183,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
 
         $iniToken      = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stackPtr, null);
         $filteredToken = trim($tokens[$iniToken]['content'], '\'"');
-        if (in_array($filteredToken, array_keys($this->newIniDirectives)) === false) {
+        if (isset($this->newIniDirectives[$filteredToken]) === false) {
             return;
         }
 

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -165,11 +165,13 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.1'   => false,
             '5.1.2' => true,
         ),
+
         'gd.jpeg_ignore_warning' => array(
             '5.0'   => false,
             '5.1'   => false,
             '5.1.3' => true,
         ),
+
         'fbsql.show_timestamp_decimals' => array(
             '5.0'   => false,
             '5.1'   => false,
@@ -210,48 +212,36 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.1' => false,
             '5.2' => true
         ),
+
         'cgi.check_shebang_line' => array(
             '5.1' => false,
             '5.2' => false,
             '5.2.1' => true
         ),
-		'max_input_nesting_level' => array(
+
+        'max_input_nesting_level' => array(
             '5.1' => false,
             '5.2' => false,
             '5.2.3' => true
         ),
+
         'mysqli.allow_local_infile' => array(
             '5.1'   => false,
             '5.2'   => false,
             '5.2.4' => true,
         ),
+
         'max_file_uploads' => array(
             '5.1'    => false,
             '5.2'    => false,
             '5.2.12' => true,
         ),
 
-        'user_ini.filename' => array(
-            '5.2' => false,
-            '5.3' => true,
-        ),
-        'user_ini.cache_ttl' => array(
+        'cgi.discard_path' => array(
             '5.2' => false,
             '5.3' => true,
         ),
         'exit_on_timeout' => array(
-            '5.2' => false,
-            '5.3' => true,
-        ),
-        'mbstring.http_output_conv_mimetype' => array(
-            '5.2' => false,
-            '5.3' => true,
-        ),
-        'request_order' => array(
-            '5.2' => false,
-            '5.3' => true,
-        ),
-        'cgi.discard_path' => array(
             '5.2' => false,
             '5.3' => true,
         ),
@@ -271,15 +261,19 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.2' => false,
             '5.3' => true,
         ),
+        'mbstring.http_output_conv_mimetype' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
         'mysqli.allow_persistent' => array(
             '5.2' => false,
             '5.3' => true,
         ),
-        'mysqli.max_persistent' => array(
+        'mysqli.cache_size' => array(
             '5.2' => false,
             '5.3' => true,
         ),
-        'mysqli.cache_size' => array(
+        'mysqli.max_persistent' => array(
             '5.2' => false,
             '5.3' => true,
         ),
@@ -303,6 +297,18 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.2' => false,
             '5.3' => true,
         ),
+        'request_order' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'user_ini.cache_ttl' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
+        'user_ini.filename' => array(
+            '5.2' => false,
+            '5.3' => true,
+        ),
         'zend.enable_gc' => array(
             '5.2' => false,
             '5.3' => true,
@@ -313,11 +319,13 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.3' => false,
             '5.3.7' => true,
         ),
+
         'max_input_vars' => array(
             '5.2'   => false,
             '5.3'   => false,
             '5.3.9' => true,
         ),
+
         'sqlite3.extension_dir' => array(
             '5.2'    => false,
             '5.3'    => false,
@@ -336,15 +344,23 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.3' => false,
             '5.4' => true,
         ),
-        'zend.multibyte' => array(
+        'enable_post_data_reading' => array(
             '5.3' => false,
             '5.4' => true,
         ),
-        'zend.script_encoding' => array(
+        'mysqlnd.mempool_default_size' => array(
             '5.3' => false,
             '5.4' => true,
         ),
-        'zend.signal_check' => array(
+        'mysqlnd.net_cmd_buffer_size' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'mysqlnd.net_read_timeout' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'phar.cache_list' => array(
             '5.3' => false,
             '5.4' => true,
         ),
@@ -372,10 +388,6 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.3' => false,
             '5.4' => true,
         ),
-        'enable_post_data_reading' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
         'windows_show_crt_warning' => array(
             '5.3' => false,
             '5.4' => true,
@@ -385,23 +397,19 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.4'         => true,
             'alternative' => 'detect_unicode',
         ),
+        'zend.multibyte' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'zend.script_encoding' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
+        'zend.signal_check' => array(
+            '5.3' => false,
+            '5.4' => true,
+        ),
         'mysqlnd.log_mask' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.mempool_default_size' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.net_cmd_buffer_size' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'mysqlnd.net_read_timeout' => array(
-            '5.3' => false,
-            '5.4' => true,
-        ),
-        'phar.cache_list' => array(
             '5.3' => false,
             '5.4' => true,
         ),
@@ -507,20 +515,20 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         $error = '';
 
         foreach ($this->newIniDirectives[$filteredToken] as $version => $present) {
-			if ($version !== 'alternative') {
-	            if ($this->supportsBelow($version)) {
-	                if ($present === true) {
-	                    $error .= " not available before version " . $version;
-	                }
-	            }
-			}
+            if ($version !== 'alternative') {
+                if ($this->supportsBelow($version)) {
+                    if ($present === true) {
+                        $error .= " not available before version " . $version;
+                    }
+                }
+            }
         }
 
         if (strlen($error) > 0) {
             $error = "INI directive '" . $filteredToken . "' is" . $error;
             if (isset($this->newIniDirectives[$filteredToken]['alternative'])) {
-				$error .= 'This directive was previously called ' . $this->newIniDirectives[$filteredToken]['alternative'] . '.';
-			}
+                $error .= 'This directive was previously called ' . $this->newIniDirectives[$filteredToken]['alternative'] . '.';
+            }
 
             $phpcsFile->addWarning($error, $stackPtr);
         }

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -190,15 +190,20 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         $error = '';
 
         foreach ($this->newIniDirectives[$filteredToken] as $version => $present) {
-            if ($this->supportsBelow($version)) {
-                if ($present === true) {
-                    $error .= " not available before version " . $version;
-                }
-            }
+			if ($version !== 'alternative') {
+	            if ($this->supportsBelow($version)) {
+	                if ($present === true) {
+	                    $error .= " not available before version " . $version;
+	                }
+	            }
+			}
         }
 
         if (strlen($error) > 0) {
             $error = "INI directive '" . $filteredToken . "' is" . $error;
+            if (isset($this->newIniDirectives[$filteredToken]['alternative'])) {
+				$error .= 'This directive was previously called ' . $this->newIniDirectives[$filteredToken]['alternative'] . '.';
+			}
 
             $phpcsFile->addWarning($error, $stackPtr);
         }

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -25,7 +25,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 3, "INI directive 'define_syslog_variables' is deprecated from PHP 5.3");
         $this->assertWarning($file, 4, "INI directive 'define_syslog_variables' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 3, "INI directive 'define_syslog_variables' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 4, "INI directive 'define_syslog_variables' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -41,7 +41,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 6, "INI directive 'register_globals' is deprecated from PHP 5.3");
         $this->assertWarning($file, 7, "INI directive 'register_globals' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 6, "INI directive 'register_globals' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 7, "INI directive 'register_globals' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -57,7 +57,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 9, "INI directive 'register_long_arrays' is deprecated from PHP 5.3");
         $this->assertWarning($file, 10, "INI directive 'register_long_arrays' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 9, "INI directive 'register_long_arrays' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 10, "INI directive 'register_long_arrays' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -73,7 +73,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 12, "INI directive 'magic_quotes_gpc' is deprecated from PHP 5.3");
         $this->assertWarning($file, 13, "INI directive 'magic_quotes_gpc' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 12, "INI directive 'magic_quotes_gpc' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 13, "INI directive 'magic_quotes_gpc' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -89,7 +89,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 15, "INI directive 'magic_quotes_runtime' is deprecated from PHP 5.3");
         $this->assertWarning($file, 16, "INI directive 'magic_quotes_runtime' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 15, "INI directive 'magic_quotes_runtime' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 16, "INI directive 'magic_quotes_runtime' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -105,7 +105,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 18, "INI directive 'magic_quotes_sybase' is deprecated from PHP 5.3");
         $this->assertWarning($file, 19, "INI directive 'magic_quotes_sybase' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 18, "INI directive 'magic_quotes_sybase' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 19, "INI directive 'magic_quotes_sybase' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -121,7 +121,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 21, "INI directive 'allow_call_time_pass_reference' is deprecated from PHP 5.3");
         $this->assertWarning($file, 22, "INI directive 'allow_call_time_pass_reference' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 21, "INI directive 'allow_call_time_pass_reference' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 22, "INI directive 'allow_call_time_pass_reference' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -137,7 +137,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 24, "INI directive 'highlight.bg' is deprecated from PHP 5.3");
         $this->assertWarning($file, 25, "INI directive 'highlight.bg' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 24, "INI directive 'highlight.bg' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 25, "INI directive 'highlight.bg' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -153,7 +153,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 27, "INI directive 'session.bug_compat_42' is deprecated from PHP 5.3");
         $this->assertWarning($file, 28, "INI directive 'session.bug_compat_42' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 27, "INI directive 'session.bug_compat_42' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 28, "INI directive 'session.bug_compat_42' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -169,7 +169,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 30, "INI directive 'session.bug_compat_warn' is deprecated from PHP 5.3");
         $this->assertWarning($file, 31, "INI directive 'session.bug_compat_warn' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 30, "INI directive 'session.bug_compat_warn' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 31, "INI directive 'session.bug_compat_warn' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -185,7 +185,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 33, "INI directive 'y2k_compliance' is deprecated from PHP 5.3");
         $this->assertWarning($file, 34, "INI directive 'y2k_compliance' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 33, "INI directive 'y2k_compliance' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 34, "INI directive 'y2k_compliance' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -213,7 +213,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 39, "INI directive 'safe_mode' is deprecated from PHP 5.3");
         $this->assertWarning($file, 40, "INI directive 'safe_mode' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 39, "INI directive 'safe_mode' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 40, "INI directive 'safe_mode' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -229,7 +229,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 42, "INI directive 'safe_mode_gid' is deprecated from PHP 5.3");
         $this->assertWarning($file, 43, "INI directive 'safe_mode_gid' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 42, "INI directive 'safe_mode_gid' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 43, "INI directive 'safe_mode_gid' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -245,7 +245,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 45, "INI directive 'safe_mode_include_dir' is deprecated from PHP 5.3");
         $this->assertWarning($file, 46, "INI directive 'safe_mode_include_dir' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 45, "INI directive 'safe_mode_include_dir' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 46, "INI directive 'safe_mode_include_dir' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -261,7 +261,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 48, "INI directive 'safe_mode_exec_dir' is deprecated from PHP 5.3");
         $this->assertWarning($file, 49, "INI directive 'safe_mode_exec_dir' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 48, "INI directive 'safe_mode_exec_dir' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 49, "INI directive 'safe_mode_exec_dir' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -277,7 +277,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 51, "INI directive 'safe_mode_allowed_env_vars' is deprecated from PHP 5.3");
         $this->assertWarning($file, 52, "INI directive 'safe_mode_allowed_env_vars' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 51, "INI directive 'safe_mode_allowed_env_vars' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 52, "INI directive 'safe_mode_allowed_env_vars' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -293,7 +293,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
         $this->assertWarning($file, 54, "INI directive 'safe_mode_protected_env_vars' is deprecated from PHP 5.3");
         $this->assertWarning($file, 55, "INI directive 'safe_mode_protected_env_vars' is deprecated from PHP 5.3");
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
         $this->assertError($file, 54, "INI directive 'safe_mode_protected_env_vars' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
         $this->assertWarning($file, 55, "INI directive 'safe_mode_protected_env_vars' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
@@ -321,7 +321,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 62);
         $this->assertNoViolation($file, 63);
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 62, "INI directive 'iconv.input_encoding' is deprecated from PHP 5.6");
         $this->assertWarning($file, 63, "INI directive 'iconv.input_encoding' is deprecated from PHP 5.6");
@@ -337,12 +337,12 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 65);
         $this->assertNoViolation($file, 66);
-        
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 65, "INI directive 'iconv.output_encoding' is deprecated from PHP 5.6");
         $this->assertWarning($file, 66, "INI directive 'iconv.output_encoding' is deprecated from PHP 5.6");
     }
-    
+
     /**
      * Test iconv.internal_encoding setting
      *
@@ -353,13 +353,13 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 68);
         $this->assertNoViolation($file, 69);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 68, "INI directive 'iconv.internal_encoding' is deprecated from PHP 5.6");
         $this->assertWarning($file, 69, "INI directive 'iconv.internal_encoding' is deprecated from PHP 5.6");
     }
-    
-    
+
+
     /**
      * Test mbstring.http_input setting
      *
@@ -370,12 +370,12 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 71);
         $this->assertNoViolation($file, 72);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 71, "INI directive 'mbstring.http_input' is deprecated from PHP 5.6");
         $this->assertWarning($file, 72, "INI directive 'mbstring.http_input' is deprecated from PHP 5.6");
     }
-    
+
     /**
      * Test mbstring.http_output setting
      *
@@ -386,12 +386,12 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 74);
         $this->assertNoViolation($file, 75);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 74, "INI directive 'mbstring.http_output' is deprecated from PHP 5.6");
         $this->assertWarning($file, 75, "INI directive 'mbstring.http_output' is deprecated from PHP 5.6");
     }
-    
+
     /**
      * Test mbstring.internal_encoding setting
      *
@@ -402,12 +402,12 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.5');
         $this->assertNoViolation($file, 77);
         $this->assertNoViolation($file, 78);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 77, "INI directive 'mbstring.internal_encoding' is deprecated from PHP 5.6");
         $this->assertWarning($file, 78, "INI directive 'mbstring.internal_encoding' is deprecated from PHP 5.6");
     }
-    
+
     /**
      * Test always_populate_raw_post_data setting
      *
@@ -422,7 +422,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertWarning($file, 80, "INI directive 'always_populate_raw_post_data' is deprecated from PHP 5.6");
         $this->assertWarning($file, 81, "INI directive 'always_populate_raw_post_data' is deprecated from PHP 5.6");
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '7.0');
         $this->assertError($file, 80, "INI directive 'always_populate_raw_post_data' is deprecated from PHP 5.6 and forbidden from PHP 7.0");
         $this->assertWarning($file, 81, "INI directive 'always_populate_raw_post_data' is deprecated from PHP 5.6 and forbidden from PHP 7.0");
@@ -438,12 +438,12 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertNoViolation($file, 83);
         $this->assertNoViolation($file, 84);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '7.0');
         $this->assertError($file, 83, "INI directive 'asp_tags' is forbidden from PHP 7.0");
         $this->assertWarning($file, 84, "INI directive 'asp_tags' is forbidden from PHP 7.0");
     }
-    
+
     /**
      * Test xsl.security_prefs  setting
      *
@@ -454,13 +454,13 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.6');
         $this->assertNoViolation($file, 86);
         $this->assertNoViolation($file, 87);
-    
+
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '7.0');
         $this->assertError($file, 86, "INI directive 'xsl.security_prefs' is forbidden from PHP 7.0");
         $this->assertWarning($file, 87, "INI directive 'xsl.security_prefs' is forbidden from PHP 7.0");
     }
-    
-    
+
+
     public function testSettingTestVersion()
     {
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
@@ -480,20 +480,20 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
-		}
+        }
 
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $deprecatedIn);
         $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}. Use '{$alternative}' instead.");
         $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}. Use '{$alternative}' instead.");
     }
-    
+
     public function dataDeprecatedWithAlternative() {
-		return array(
-		    array('fbsql.batchSize', '5.1', 'fbsql.batchsize', array(89, 90), '5.0'),
-		    array('detect_unicode', '5.4', 'zend.detect_unicode', array(125, 126), '5.3'),
-		    array('mbstring.script_encoding', '5.4', 'zend.script_encoding', array(128, 129), '5.3'),
-		);
-	}
+        return array(
+            array('fbsql.batchSize', '5.1', 'fbsql.batchsize', array(89, 90), '5.0'),
+            array('detect_unicode', '5.4', 'zend.detect_unicode', array(125, 126), '5.3'),
+            array('mbstring.script_encoding', '5.4', 'zend.script_encoding', array(128, 129), '5.3'),
+        );
+    }
 
     /**
      * testDeprecatedDirectives
@@ -507,20 +507,20 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
-		}
+        }
 
-		if (isset($errorVersion)){
+        if (isset($errorVersion)){
             $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $errorVersion);
-		}
-		else {
+        }
+        else {
             $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $deprecatedIn);
-		}
+        }
         $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}.");
         $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}.");
     }
 
     public function dataDeprecatedDirectives() {
-		return array(
+        return array(
             array('ifx.allow_persistent', '5.2.1', array(92, 93), '5.1', '5.3'),
             array('ifx.blobinfile', '5.2.1', array(95, 96), '5.1', '5.3'),
             array('ifx.byteasvarchar', '5.2.1', array(98, 99), '5.1', '5.3'),
@@ -532,7 +532,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('ifx.max_persistent', '5.2.1', array(116, 117), '5.1', '5.3'),
             array('ifx.nullformat', '5.2.1', array(119, 120), '5.1', '5.3'),
             array('ifx.textasvarchar', '5.2.1', array(122, 123), '5.1', '5.3'),
-		);
-	}
+        );
+    }
 
 }

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -199,12 +199,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     public function testZendZe1CompatibilityMode()
     {
         $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.3');
-        $this->assertWarning($file, 36, "INI directive 'zend.ze1_compatibility_mode' is deprecated from PHP 5.3");
-        $this->assertWarning($file, 37, "INI directive 'zend.ze1_compatibility_mode' is deprecated from PHP 5.3");
-        
-        $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', '5.4');
-        $this->assertError($file, 36, "INI directive 'zend.ze1_compatibility_mode' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
-        $this->assertWarning($file, 37, "INI directive 'zend.ze1_compatibility_mode' is deprecated from PHP 5.3 and forbidden from PHP 5.4");
+        $this->assertError($file, 36, "INI directive 'zend.ze1_compatibility_mode' is forbidden from PHP 5.3");
+        $this->assertWarning($file, 37, "INI directive 'zend.ze1_compatibility_mode' is forbidden from PHP 5.3");
     }
 
     /**
@@ -471,4 +467,72 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
         $this->assertWarning($file, 54, "INI directive 'safe_mode_protected_env_vars' is deprecated from PHP 5.3");
     }
+
+    /**
+     * testDeprecatedWithAlternative
+     *
+     * @dataProvider dataDeprecatedWithAlternative
+     *
+     * @return void
+     */
+    public function testDeprecatedWithAlternative($iniName, $deprecatedIn, $alternative, $lines, $okVersion)
+    {
+        $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $okVersion);
+        foreach($lines as $line) {
+            $this->assertNoViolation($file, $line);
+		}
+
+        $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $deprecatedIn);
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}. Use '{$alternative}' instead.");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}. Use '{$alternative}' instead.");
+    }
+    
+    public function dataDeprecatedWithAlternative() {
+		return array(
+		    array('fbsql.batchSize', '5.1', 'fbsql.batchsize', array(89, 90), '5.0'),
+		    array('detect_unicode', '5.4', 'zend.detect_unicode', array(125, 126), '5.3'),
+		    array('mbstring.script_encoding', '5.4', 'zend.script_encoding', array(128, 129), '5.3'),
+		);
+	}
+
+    /**
+     * testDeprecatedDirectives
+     *
+     * @dataProvider dataDeprecatedDirectives
+     *
+     * @return void
+     */
+    public function testDeprecatedDirectives($iniName, $deprecatedIn, $lines, $okVersion, $errorVersion = null)
+    {
+        $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $okVersion);
+        foreach($lines as $line) {
+            $this->assertNoViolation($file, $line);
+		}
+
+		if (isset($errorVersion)){
+            $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $errorVersion);
+		}
+		else {
+            $file = $this->sniffFile('sniff-examples/deprecated_ini_directives.php', $deprecatedIn);
+		}
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}.");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$deprecatedIn}.");
+    }
+
+    public function dataDeprecatedDirectives() {
+		return array(
+            array('ifx.allow_persistent', '5.2.1', array(92, 93), '5.1', '5.3'),
+            array('ifx.blobinfile', '5.2.1', array(95, 96), '5.1', '5.3'),
+            array('ifx.byteasvarchar', '5.2.1', array(98, 99), '5.1', '5.3'),
+            array('ifx.charasvarchar', '5.2.1', array(101, 102), '5.1', '5.3'),
+            array('ifx.default_host', '5.2.1', array(104, 105), '5.1', '5.3'),
+            array('ifx.default_password', '5.2.1', array(107, 108), '5.1', '5.3'),
+            array('ifx.default_user', '5.2.1', array(110, 111), '5.1', '5.3'),
+            array('ifx.max_links', '5.2.1', array(113, 114), '5.1', '5.3'),
+            array('ifx.max_persistent', '5.2.1', array(116, 117), '5.1', '5.3'),
+            array('ifx.nullformat', '5.2.1', array(119, 120), '5.1', '5.3'),
+            array('ifx.textasvarchar', '5.2.1', array(122, 123), '5.1', '5.3'),
+		);
+	}
+
 }

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -93,13 +93,13 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', '5.1');
 
-        $this->assertWarning($file, 20, "INI directive 'max_input_nesting_level' is not available before version 5.2.2");
-        $this->assertWarning($file, 21, "INI directive 'max_input_nesting_level' is not available before version 5.2.2");
+        $this->assertWarning($file, 20, "INI directive 'max_input_nesting_level' is not available before version 5.2.3");
+        $this->assertWarning($file, 21, "INI directive 'max_input_nesting_level' is not available before version 5.2.3");
 
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', '5.2');
 
-        $this->assertWarning($file, 20, "INI directive 'max_input_nesting_level' is not available before version 5.2.2");
-        $this->assertWarning($file, 21, "INI directive 'max_input_nesting_level' is not available before version 5.2.2");
+        $this->assertWarning($file, 20, "INI directive 'max_input_nesting_level' is not available before version 5.2.3");
+        $this->assertWarning($file, 21, "INI directive 'max_input_nesting_level' is not available before version 5.2.3");
     }
 
     /**
@@ -213,10 +213,10 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
      */
     public function testMaxInputVars()
     {
-        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', '5.3');
+        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', '5.2');
 
-        $this->assertWarning($file, 47, "INI directive 'max_input_vars' is not available before version 5.4");
-        $this->assertWarning($file, 48, "INI directive 'max_input_vars' is not available before version 5.4");
+        $this->assertWarning($file, 47, "INI directive 'max_input_vars' is not available before version 5.3.9");
+        $this->assertWarning($file, 48, "INI directive 'max_input_vars' is not available before version 5.3.9");
     }
 
     /**
@@ -361,4 +361,148 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         $this->assertWarning($file, 80, "INI directive 'mysqlnd.sha256_server_public_key' is not available before version 5.5");
         $this->assertWarning($file, 81, "INI directive 'mysqlnd.sha256_server_public_key' is not available before version 5.5");
     }
+
+
+    /**
+     * testNewIniDirectives
+     *
+     * @dataProvider dataNewIniDirectives
+     *
+     * @return void
+     */
+    public function testNewIniDirectives($iniName, $fromVersion, $lines, $warningVersion, $okVersion)
+    {
+        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $warningVersion);
+        foreach($lines as $line) {
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version $fromVersion");
+		}
+
+        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $okVersion);
+        foreach( $lines as $line ) {
+            $this->assertNoViolation($file, $line);
+		}
+    }
+
+    public function dataNewIniDirectives() {
+        return array(
+            array('auto_globals_jit', '5.0', array(83, 84), '4.4', '5.1'),
+            array('com.code_page', '5.0', array(86, 87), '4.4', '5.1'),
+            array('date.default_latitude', '5.0', array(89, 90), '4.4', '5.1'),
+            array('date.default_longitude', '5.0', array(92, 93), '4.4', '5.1'),
+            array('date.sunrise_zenith', '5.0', array(95, 96), '4.4', '5.1'),
+            array('date.sunset_zenith', '5.0', array(98, 99), '4.4', '5.1'),
+            array('ibase.default_charset', '5.0', array(101, 102), '4.4', '5.1'),
+            array('ibase.default_db', '5.0', array(104, 105), '4.4', '5.1'),
+            array('mail.force_extra_parameters', '5.0', array(107, 108), '4.4', '5.1'),
+            array('mime_magic.debug', '5.0', array(110, 111), '4.4', '5.1'),
+            array('mysqli.max_links', '5.0', array(113, 114), '4.4', '5.1'),
+            array('mysqli.default_port', '5.0', array(116, 117), '4.4', '5.1'),
+            array('mysqli.default_socket', '5.0', array(119, 120), '4.4', '5.1'),
+            array('mysqli.default_host', '5.0', array(122, 123), '4.4', '5.1'),
+            array('mysqli.default_user', '5.0', array(125, 126), '4.4', '5.1'),
+            array('mysqli.default_pw', '5.0', array(128, 129), '4.4', '5.1'),
+            array('report_zend_debug', '5.0', array(131, 132), '4.4', '5.1'),
+            array('session.hash_bits_per_character', '5.0', array(134, 135), '4.4', '5.1'),
+            array('session.hash_function', '5.0', array(137, 138), '4.4', '5.1'),
+            array('soap.wsdl_cache_dir', '5.0', array(140, 141), '4.4', '5.1'),
+            array('soap.wsdl_cache_enabled', '5.0', array(143, 144), '4.4', '5.1'),
+            array('soap.wsdl_cache_ttl', '5.0', array(146, 147), '4.4', '5.1'),
+            array('sqlite.assoc_case', '5.0', array(149, 150), '4.4', '5.1'),
+            array('tidy.clean_output', '5.0', array(152, 153), '4.4', '5.1'),
+            array('tidy.default_config', '5.0', array(155, 156), '4.4', '5.1'),
+            array('zend.ze1_compatibility_mode', '5.0', array(158, 159), '4.4', '5.1'),
+
+            array('date.timezone', '5.1', array(161, 162), '5.0', '5.2'),
+            array('detect_unicode', '5.1', array(164, 165), '5.0', '5.2'),
+            array('realpath_cache_size', '5.1', array(170, 171), '5.0', '5.2'),
+            array('realpath_cache_ttl', '5.1', array(173, 174), '5.0', '5.2'),
+            
+            array('mbstring.strict_detection', '5.1.2', array(176, 177), '5.1', '5.2'),
+            array('mssql.charset', '5.1.2', array(179, 180), '5.1', '5.2'),
+            
+            array('gd.jpeg_ignore_warning', '5.1.3', array(182, 183), '5.1', '5.2'),
+            
+            array('fbsql.show_timestamp_decimals', '5.1.5', array(185, 186), '5.1', '5.2'),
+            array('soap.wsdl_cache', '5.1.5', array(188, 189), '5.1', '5.2'),
+            array('soap.wsdl_cache_limit', '5.1.5', array(191, 192), '5.1', '5.2'),
+            
+            array('filter.default', '5.2', array(194, 195), '5.1', '5.3'),
+            array('filter.default_flags', '5.2', array(197, 198), '5.1', '5.3'),
+            
+            array('cgi.check_shebang_line', '5.2.1', array(200, 201), '5.2', '5.3'),
+
+            array('mysqli.allow_local_infile', '5.2.4', array(203, 204), '5.2', '5.3'),
+
+            array('max_file_uploads', '5.2.12', array(206, 207), '5.2', '5.3'),
+            
+            array('cgi.discard_path', '5.3', array(209, 210), '5.2', '5.4'),
+            array('intl.default_locale', '5.3', array(212, 213), '5.2', '5.4'),
+            array('intl.error_level', '5.3', array(215, 216), '5.2', '5.4'),
+            array('mail.add_x_header', '5.3', array(218, 219), '5.2', '5.4'),
+            array('mail.log', '5.3', array(221, 222), '5.2', '5.4'),
+            array('mysqli.allow_persistent', '5.3', array(224, 225), '5.2', '5.4'),
+            array('mysqli.max_persistent', '5.3', array(227, 228), '5.2', '5.4'),
+            array('mysqli.cache_size', '5.3', array(230, 231), '5.2', '5.4'),
+            array('mysqlnd.collect_memory_statistics', '5.3', array(233, 234), '5.2', '5.4'),
+            array('mysqlnd.collect_statistics', '5.3', array(236, 237), '5.2', '5.4'),
+            array('mysqlnd.debug', '5.3', array(239, 240), '5.2', '5.4'),
+            array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2', '5.4'),
+            array('odbc.default_cursortype', '5.3', array(245, 246), '5.2', '5.4'),
+            array('zend.enable_gc', '5.3', array(248, 249), '5.2', '5.4'),
+            
+            array('curl.cainfo', '5.3.7', array(251, 252), '5.3', '5.4'),
+
+            array('sqlite3.extension_dir', '5.3.11', array(254, 255), '5.3', '5.4'),
+
+            array('session.upload_progress.prefix', '5.4', array(257, 258), '5.3', '5.5'),
+            array('mysqlnd.log_mask', '5.4', array(263, 264), '5.3', '5.5'),
+            array('mysqlnd.mempool_default_size', '5.4', array(266, 267), '5.3', '5.5'),
+            array('mysqlnd.net_cmd_buffer_size', '5.4', array(269, 270), '5.3', '5.5'),
+            array('mysqlnd.net_read_timeout', '5.4', array(272, 273), '5.3', '5.5'),
+            array('phar.cache_list', '5.4', array(275, 276), '5.3', '5.5'),
+
+            array('mysqlnd.trace_alloc', '5.5', array(278, 279), '5.4', '5.6'),
+            array('sys_temp_dir', '5.5', array(281, 282), '5.4', '5.6'),
+            array('xsl.security_prefs', '5.5', array(284, 285), '5.4', '5.6'),
+            
+            array('session.use_strict_mode', '5.5.2', array(287, 288), '5.5', '5.6'),
+
+            array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5', '7.0'),
+
+            array('assert.exception', '7.0', array(293, 294), '5.6', '7.1'),
+            array('pcre.jit', '7.0', array(296, 297), '5.6', '7.1'),
+            array('session.lazy_write', '7.0', array(299, 300), '5.6', '7.1'),
+            array('zend.assertions', '7.0', array(302, 303), '5.6', '7.1'),
+
+        );
+	}
+
+
+    /**
+     * testNewIniDirectivesWithAlternative
+     *
+     * @dataProvider dataNewIniDirectivesWithAlternative
+     *
+     * @return void
+     */
+    public function testNewIniDirectivesWithAlternative($iniName, $fromVersion, $alternative, $lines, $warningVersion, $okVersion)
+    {
+        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $warningVersion);
+        foreach($lines as $line) {
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version $fromVersion");
+		}
+
+        $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $okVersion);
+        foreach($lines as $line) {
+            $this->assertNoViolation($file, $line);
+		}
+    }
+
+    public function dataNewIniDirectivesWithAlternative() {
+        return array(
+            array('fbsql.batchsize', '5.1', 'fbsql.batchSize', array(167, 168), '5.0', '5.2'),
+            array('zend.detect_unicode', '5.4', 'detect_unicode', array(260, 261), '5.3', '5.5'),
+        );
+	}
+
 }

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -375,12 +375,12 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $warningVersion);
         foreach($lines as $line) {
             $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version $fromVersion");
-		}
+        }
 
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $okVersion);
         foreach( $lines as $line ) {
             $this->assertNoViolation($file, $line);
-		}
+        }
     }
 
     public function dataNewIniDirectives() {
@@ -416,25 +416,25 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('detect_unicode', '5.1', array(164, 165), '5.0', '5.2'),
             array('realpath_cache_size', '5.1', array(170, 171), '5.0', '5.2'),
             array('realpath_cache_ttl', '5.1', array(173, 174), '5.0', '5.2'),
-            
+
             array('mbstring.strict_detection', '5.1.2', array(176, 177), '5.1', '5.2'),
             array('mssql.charset', '5.1.2', array(179, 180), '5.1', '5.2'),
-            
+
             array('gd.jpeg_ignore_warning', '5.1.3', array(182, 183), '5.1', '5.2'),
-            
+
             array('fbsql.show_timestamp_decimals', '5.1.5', array(185, 186), '5.1', '5.2'),
             array('soap.wsdl_cache', '5.1.5', array(188, 189), '5.1', '5.2'),
             array('soap.wsdl_cache_limit', '5.1.5', array(191, 192), '5.1', '5.2'),
-            
+
             array('filter.default', '5.2', array(194, 195), '5.1', '5.3'),
             array('filter.default_flags', '5.2', array(197, 198), '5.1', '5.3'),
-            
+
             array('cgi.check_shebang_line', '5.2.1', array(200, 201), '5.2', '5.3'),
 
             array('mysqli.allow_local_infile', '5.2.4', array(203, 204), '5.2', '5.3'),
 
             array('max_file_uploads', '5.2.12', array(206, 207), '5.2', '5.3'),
-            
+
             array('cgi.discard_path', '5.3', array(209, 210), '5.2', '5.4'),
             array('intl.default_locale', '5.3', array(212, 213), '5.2', '5.4'),
             array('intl.error_level', '5.3', array(215, 216), '5.2', '5.4'),
@@ -449,7 +449,7 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2', '5.4'),
             array('odbc.default_cursortype', '5.3', array(245, 246), '5.2', '5.4'),
             array('zend.enable_gc', '5.3', array(248, 249), '5.2', '5.4'),
-            
+
             array('curl.cainfo', '5.3.7', array(251, 252), '5.3', '5.4'),
 
             array('sqlite3.extension_dir', '5.3.11', array(254, 255), '5.3', '5.4'),
@@ -464,7 +464,7 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('mysqlnd.trace_alloc', '5.5', array(278, 279), '5.4', '5.6'),
             array('sys_temp_dir', '5.5', array(281, 282), '5.4', '5.6'),
             array('xsl.security_prefs', '5.5', array(284, 285), '5.4', '5.6'),
-            
+
             array('session.use_strict_mode', '5.5.2', array(287, 288), '5.5', '5.6'),
 
             array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5', '7.0'),
@@ -475,7 +475,7 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('zend.assertions', '7.0', array(302, 303), '5.6', '7.1'),
 
         );
-	}
+    }
 
 
     /**
@@ -490,12 +490,12 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $warningVersion);
         foreach($lines as $line) {
             $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version $fromVersion");
-		}
+        }
 
         $file = $this->sniffFile('sniff-examples/new_ini_directives.php', $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
-		}
+        }
     }
 
     public function dataNewIniDirectivesWithAlternative() {
@@ -503,6 +503,6 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('fbsql.batchsize', '5.1', 'fbsql.batchSize', array(167, 168), '5.0', '5.2'),
             array('zend.detect_unicode', '5.4', 'detect_unicode', array(260, 261), '5.3', '5.5'),
         );
-	}
+    }
 
 }

--- a/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/Tests/sniff-examples/deprecated_ini_directives.php
@@ -85,3 +85,45 @@ $a = ini_get('asp_tags');
 
 ini_set('xsl.security_prefs', 1);
 $a = ini_get('xsl.security_prefs');
+
+ini_set('fbsql.batchSize', 1);
+$a = ini_get('fbsql.batchSize');
+
+ini_set('ifx.allow_persistent', 1);
+$a = ini_get('ifx.allow_persistent');
+
+ini_set('ifx.blobinfile', 1);
+$a = ini_get('ifx.blobinfile');
+
+ini_set('ifx.byteasvarchar', 1);
+$a = ini_get('ifx.byteasvarchar');
+
+ini_set('ifx.charasvarchar', 1);
+$a = ini_get('ifx.charasvarchar');
+
+ini_set('ifx.default_host', 1);
+$a = ini_get('ifx.default_host');
+
+ini_set('ifx.default_password', 'abc');
+$a = ini_get('ifx.default_password');
+
+ini_set('ifx.default_user', 'abc');
+$a = ini_get('ifx.default_user');
+
+ini_set('ifx.max_links', 1);
+$a = ini_get('ifx.max_links');
+
+ini_set('ifx.max_persistent', 1);
+$a = ini_get('ifx.max_persistent');
+
+ini_set('ifx.nullformat', 1);
+$a = ini_get('ifx.nullformat');
+
+ini_set('ifx.textasvarchar', 1);
+$a = ini_get('ifx.textasvarchar');
+
+ini_set('detect_unicode', 1);
+$a = ini_get('detect_unicode');
+
+ini_set('mbstring.script_encoding', 1);
+$a = ini_get('mbstring.script_encoding');

--- a/Tests/sniff-examples/new_ini_directives.php
+++ b/Tests/sniff-examples/new_ini_directives.php
@@ -79,3 +79,225 @@ $test = ini_get('intl.use_exceptions');
 
 ini_set('mysqlnd.sha256_server_public_key', 1);
 $test = ini_get('mysqlnd.sha256_server_public_key');
+
+ini_set('auto_globals_jit', 1);
+$test = ini_get('auto_globals_jit');
+
+ini_set('com.code_page', 1);
+$test = ini_get('com.code_page');
+
+ini_set('date.default_latitude', 1);
+$test = ini_get('date.default_latitude');
+
+ini_set('date.default_longitude', 1);
+$test = ini_get('date.default_longitude');
+
+ini_set('date.sunrise_zenith', 1);
+$test = ini_get('date.sunrise_zenith');
+
+ini_set('date.sunset_zenith', 1);
+$test = ini_get('date.sunset_zenith');
+
+ini_set('ibase.default_charset', 1);
+$test = ini_get('ibase.default_charset');
+
+ini_set('ibase.default_db', 1);
+$test = ini_get('ibase.default_db');
+
+ini_set('mail.force_extra_parameters', 1);
+$test = ini_get('mail.force_extra_parameters');
+
+ini_set('mime_magic.debug', 1);
+$test = ini_get('mime_magic.debug');
+
+ini_set('mysqli.max_links', 1);
+$test = ini_get('mysqli.max_links');
+
+ini_set('mysqli.default_port', 1);
+$test = ini_get('mysqli.default_port');
+
+ini_set('mysqli.default_socket', 1);
+$test = ini_get('mysqli.default_socket');
+
+ini_set('mysqli.default_host', 1);
+$test = ini_get('mysqli.default_host');
+
+ini_set('mysqli.default_user', 1);
+$test = ini_get('mysqli.default_user');
+
+ini_set('mysqli.default_pw', 1);
+$test = ini_get('mysqli.default_pw');
+
+ini_set('report_zend_debug', 1);
+$test = ini_get('report_zend_debug');
+
+ini_set('session.hash_bits_per_character', 1);
+$test = ini_get('session.hash_bits_per_character');
+
+ini_set('session.hash_function', 1);
+$test = ini_get('session.hash_function');
+
+ini_set('soap.wsdl_cache_dir', 1);
+$test = ini_get('soap.wsdl_cache_dir');
+
+ini_set('soap.wsdl_cache_enabled', 1);
+$test = ini_get('soap.wsdl_cache_enabled');
+
+ini_set('soap.wsdl_cache_ttl', 1);
+$test = ini_get('soap.wsdl_cache_ttl');
+
+ini_set('sqlite.assoc_case', 1);
+$test = ini_get('sqlite.assoc_case');
+
+ini_set('tidy.clean_output', 1);
+$test = ini_get('tidy.clean_output');
+
+ini_set('tidy.default_config', 1);
+$test = ini_get('tidy.default_config');
+
+ini_set('zend.ze1_compatibility_mode', 1);
+$test = ini_get('zend.ze1_compatibility_mode');
+
+ini_set('date.timezone', 1);
+$test = ini_get('date.timezone');
+
+ini_set('detect_unicode', 1);
+$test = ini_get('detect_unicode');
+
+ini_set('fbsql.batchsize', 1);
+$test = ini_get('fbsql.batchsize');
+
+ini_set('realpath_cache_size', 1);
+$test = ini_get('realpath_cache_size');
+
+ini_set('realpath_cache_ttl', 1);
+$test = ini_get('realpath_cache_ttl');
+
+ini_set('mbstring.strict_detection', 1);
+$test = ini_get('mbstring.strict_detection');
+
+ini_set('mssql.charset', 1);
+$test = ini_get('mssql.charset');
+
+ini_set('gd.jpeg_ignore_warning', 1);
+$test = ini_get('gd.jpeg_ignore_warning');
+
+ini_set('fbsql.show_timestamp_decimals', 1);
+$test = ini_get('fbsql.show_timestamp_decimals');
+
+ini_set('soap.wsdl_cache', 1);
+$test = ini_get('soap.wsdl_cache');
+
+ini_set('soap.wsdl_cache_limit', 1);
+$test = ini_get('soap.wsdl_cache_limit');
+
+ini_set('filter.default', 1);
+$test = ini_get('filter.default');
+
+ini_set('filter.default_flags', 1);
+$test = ini_get('filter.default_flags');
+
+ini_set('cgi.check_shebang_line', 1);
+$test = ini_get('cgi.check_shebang_line');
+
+ini_set('mysqli.allow_local_infile', 1);
+$test = ini_get('mysqli.allow_local_infile');
+
+ini_set('max_file_uploads', 1);
+$test = ini_get('max_file_uploads');
+
+ini_set('cgi.discard_path', 1);
+$test = ini_get('cgi.discard_path');
+
+ini_set('intl.default_locale', 1);
+$test = ini_get('intl.default_locale');
+
+ini_set('intl.error_level', 1);
+$test = ini_get('intl.error_level');
+
+ini_set('mail.add_x_header', 1);
+$test = ini_get('mail.add_x_header');
+
+ini_set('mail.log', 1);
+$test = ini_get('mail.log');
+
+ini_set('mysqli.allow_persistent', 1);
+$test = ini_get('mysqli.allow_persistent');
+
+ini_set('mysqli.max_persistent', 1);
+$test = ini_get('mysqli.max_persistent');
+
+ini_set('mysqli.cache_size', 1);
+$test = ini_get('mysqli.cache_size');
+
+ini_set('mysqlnd.collect_memory_statistics', 1);
+$test = ini_get('mysqlnd.collect_memory_statistics');
+
+ini_set('mysqlnd.collect_statistics', 1);
+$test = ini_get('mysqlnd.collect_statistics');
+
+ini_set('mysqlnd.debug', 1);
+$test = ini_get('mysqlnd.debug');
+
+ini_set('mysqlnd.net_read_buffer_size', 1);
+$test = ini_get('mysqlnd.net_read_buffer_size');
+
+ini_set('odbc.default_cursortype', 1);
+$test = ini_get('odbc.default_cursortype');
+
+ini_set('zend.enable_gc', 1);
+$test = ini_get('zend.enable_gc');
+
+ini_set('curl.cainfo', 1);
+$test = ini_get('curl.cainfo');
+
+ini_set('sqlite3.extension_dir', 1);
+$test = ini_get('sqlite3.extension_dir');
+
+ini_set('session.upload_progress.prefix', 1);
+$test = ini_get('session.upload_progress.prefix');
+
+ini_set('zend.detect_unicode', 1);
+$test = ini_get('zend.detect_unicode');
+
+ini_set('mysqlnd.log_mask', 1);
+$test = ini_get('mysqlnd.log_mask');
+
+ini_set('mysqlnd.mempool_default_size', 1);
+$test = ini_get('mysqlnd.mempool_default_size');
+
+ini_set('mysqlnd.net_cmd_buffer_size', 1);
+$test = ini_get('mysqlnd.net_cmd_buffer_size');
+
+ini_set('mysqlnd.net_read_timeout', 1);
+$test = ini_get('mysqlnd.net_read_timeout');
+
+ini_set('phar.cache_list', 1);
+$test = ini_get('phar.cache_list');
+
+ini_set('mysqlnd.trace_alloc', 1);
+$test = ini_get('mysqlnd.trace_alloc');
+
+ini_set('sys_temp_dir', 1);
+$test = ini_get('sys_temp_dir');
+
+ini_set('xsl.security_prefs', 1);
+$test = ini_get('xsl.security_prefs');
+
+ini_set('session.use_strict_mode', 1);
+$test = ini_get('session.use_strict_mode');
+
+ini_set('mysqli.rollback_on_cached_plink', 1);
+$test = ini_get('mysqli.rollback_on_cached_plink');
+
+ini_set('assert.exception', 1);
+$test = ini_get('assert.exception');
+
+ini_set('pcre.jit', 1);
+$test = ini_get('pcre.jit');
+
+ini_set('session.lazy_write', 1);
+$test = ini_get('session.lazy_write');
+
+ini_set('zend.assertions', 1);
+$test = ini_get('zend.assertions');


### PR DESCRIPTION
#### Add the ability to provide an alternative for renamed ini directives.

Example: the directive `detect_unicode` was renamed in PHP 5.4 to `zend.detect_unicode`.
With the code added now, an `alternative` can be added to the ini array and will be added to the message.

#### Review of the ini directives detected
* Add a lot of additional ini directives to detect.
* Added alternative name for a number of ini directives.
* Corrected the introduction version for a few.
* Re-ordered the ini directives to be alphabetical per version list.

Ref: http://php.net/manual/en/ini.list.php

----

See the individual commits for more information. I put those in to make reviewing easier and would suggest squashing them when merging.

The list is still not complete, but a lot *more* complete than it was before. 


