### PR TITLE
Attempt to make the unit tests a bit faster.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: php
 
 matrix:
+  fast_finish: true
   include:
 
     - php: 5.3

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -25,6 +25,23 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     protected static $phpcs = null;
 
     /**
+     * An array of PHPCS results by filename and PHP version.
+     *
+     * @var array
+     */
+    public static $sniffFiles = array();
+
+    /**
+     * Sets up this unit test.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$sniffFiles = array();
+    }
+
+    /**
      * Sets up this unit test.
      *
      * @return void
@@ -56,6 +73,16 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tear down after each test
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        self::$sniffFiles = array();
+    }
+
+    /**
      * Sniff a file and return resulting file object
      *
      * @param string $filename Filename to sniff
@@ -64,19 +91,23 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
      */
     public function sniffFile($filename, $targetPhpVersion = null)
     {
+        if ( isset(self::$sniffFiles[$filename][$targetPhpVersion])) {
+            return self::$sniffFiles[$filename][$targetPhpVersion];
+        }
+
         if (null !== $targetPhpVersion) {
             PHP_CodeSniffer::setConfigData('testVersion', $targetPhpVersion, true);
         }
 
-        $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $filename;
+        $pathToFile = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $filename;
         try {
-            $phpcsFile = self::$phpcs->processFile($filename);
+            self::$sniffFiles[$filename][$targetPhpVersion] = self::$phpcs->processFile($pathToFile);
         } catch (Exception $e) {
             $this->fail('An unexpected exception has been caught: ' . $e->getMessage());
             return false;
         }
 
-        return $phpcsFile;
+        return self::$sniffFiles[$filename][$targetPhpVersion];
     }
 
     /**


### PR DESCRIPTION
* Share the PHPCS instance between tests in the same class & cache run results.
* Caching of the results of the PHPCS runs.

So far I'm not actually seeing much difference, so not sure if this should be merged, but might be useful conceptually for someone to build on to in the future.