### PR TITLE
Get correct function call parameter count.

### DIFF
--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -124,22 +124,21 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
             return;
         }
 
-        if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['type'] == 'T_OPEN_PARENTHESIS') {
-            $closeParenthesis = $tokens[$stackPtr + 1]['parenthesis_closer'];
-
-            $nextComma = $stackPtr + 1;
-            $cnt = 0;
-            while ($nextComma = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS), $nextComma + 1, $closeParenthesis + 1)) {
-                if ($tokens[$nextComma]['type'] == 'T_CLOSE_PARENTHESIS' && $nextComma != $closeParenthesis) {
-                    continue;
-                }
-                if (isset($this->newFunctionParameters[$function][$cnt])) {
-                    $this->addError($phpcsFile, $nextComma, $function, $cnt);
-                }
-                $cnt++;
-            }
-
+        $parameterCount = $this->getFunctionCallParameterCount($phpcsFile, $stackPtr);
+        if ($parameterCount === 0) {
+            return;
         }
+
+        // If the parameter count returned > 0, we know there will be valid open parenthesis.
+        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $parameterOffsetFound = $parameterCount - 1;
+
+        foreach($this->newFunctionParameters[$function] as $offset => $parameterDetails) {
+            if ($offset <= $parameterOffsetFound) {
+                $this->addError($phpcsFile, $openParenthesis, $function, $offset);
+            }
+        }
+
     }//end process()
 
 

--- a/Tests/BaseAbstractClassMethodTest.php
+++ b/Tests/BaseAbstractClassMethodTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Base class to use when testing methods in the Sniff.php file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Set up and Tear down methods for testing methods in the Sniff.php file.
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+abstract class BaseAbstractClassMethodTest extends BaseSniffTest
+{
+
+    public $filename;
+
+    /**
+     * The PHP_CodeSniffer_File object containing parsed contents of this file.
+     *
+     * @var PHP_CodeSniffer_File
+     */
+    protected $_phpcsFile;
+
+    /**
+     * A wrapper for the abstract PHPCompatibility sniff.
+     *
+     * @var PHPCompatibility_Sniff
+     */
+    protected $helperClass;
+
+
+    public static function setUpBeforeClass()
+    {
+        require_once dirname(__FILE__) . '/TestHelperPHPCompatibility.php';
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->helperClass = new TestHelperPHPCompatibility;
+
+        $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->filename;
+        $phpcs    = new PHP_CodeSniffer();
+
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<')) {
+            $this->_phpcsFile = new PHP_CodeSniffer_File(
+                $filename,
+                array(),
+                array(),
+                array(),
+                array(),
+                $phpcs
+            );
+        }
+        else {
+            $this->_phpcsFile = new PHP_CodeSniffer_File(
+                $filename,
+                array(),
+                array(),
+                $phpcs
+            );
+        }
+
+        $contents = file_get_contents($filename);
+        $this->_phpcsFile->start($contents);
+    }
+
+    /**
+     * Clean up after finished test.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        unset($this->_phpcsFile, $this->helperClass);
+
+    }//end tearDown()
+
+}

--- a/Tests/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/DoesFunctionCallHaveParametersTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Function parameters test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Function parameters function tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class DoesFunctionCallHaveParametersTest extends BaseAbstractClassMethodTest
+{
+
+	public $filename = 'sniff-examples/utility-functions/does_function_call_have_parameters.php';
+
+    /**
+     * testDoesFunctionCallHaveParameters
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataDoesFunctionCallHaveParameters
+     *
+     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
+     * @param string $expected The expected fully qualified class name.
+     */
+    public function testDoesFunctionCallHaveParameters($stackPtr, $expected) {
+        $result = $this->helperClass->doesFunctionCallHaveParameters($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataDoesFunctionCallHaveParameters
+     *
+     * @see testDoesFunctionCallHaveParameters()
+     *
+     * @return array
+     */
+    public function dataDoesFunctionCallHaveParameters()
+    {
+        return array(
+            array(12, false),
+            array(17, false),
+            array(23, false),
+            array(31, false),
+            array(42, true),
+            array(50, true),
+            array(60, true),
+        );
+    }
+
+}

--- a/Tests/GetFunctionParameterCountTest.php
+++ b/Tests/GetFunctionParameterCountTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Function parameter count test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Function parameters count function tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class GetFunctionParameterCountTest extends BaseAbstractClassMethodTest
+{
+	
+	public $filename = 'sniff-examples/utility-functions/count_function_parameters.php';
+	
+    /**
+     * testGetFunctionCallParameterCount
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataGetFunctionCallParameterCount
+     *
+     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
+     * @param string $expected The expected fully qualified class name.
+     */
+    public function testGetFunctionCallParameterCount($stackPtr, $expected)
+    {
+        $result = $this->helperClass->getFunctionCallParameterCount($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataGetFunctionCallParameterCount
+     *
+     * @see testGetFunctionCallParameterCount()
+     *
+     * @return array
+     */
+    public function dataGetFunctionCallParameterCount()
+    {
+        return array(
+            array(5, 1),
+            array(11, 2),
+            array(22, 3),
+            array(34, 4),
+            array(49, 5),
+            array(67, 6),
+            array(88, 7),
+            array(120, 1),
+            array(135, 1),
+            array(150, 1),
+            array(164, 2),
+            array(181, 1),
+            array(194, 1),
+            array(209, 1),
+            array(228, 2),
+            array(250, 6),
+            array(281, 6),
+            array(312, 6),
+            array(351, 6),
+            array(386, 6),
+            array(420, 6),
+            array(454, 6),
+            array(499, 3),
+            array(518, 1),
+        );
+    }
+
+}

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -54,10 +54,10 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
     public function dataInvalidParameter()
     {
         return array(
-            array('dirname', 'depth', '5.6', array(3, 9), '7.0'),
-            array('unserialize', 'options', '5.6', array(11), '7.0'),
-            array('session_start', 'options', '5.6', array(13), '7.0'),
-            array('strstr', 'before_needle', '5.2', array(15), '5.3'),
+            array('dirname', 'depth', '5.6', array(7), '7.0'),
+            array('unserialize', 'options', '5.6', array(8), '7.0'),
+            array('session_start', 'options', '5.6', array(9), '7.0'),
+            array('strstr', 'before_needle', '5.2', array(10), '5.3'),
         );
     }
 
@@ -87,8 +87,7 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
     public function dataValidParameter()
     {
         return array(
-            array(5),
-            array(7),
+            array(4),
         );
     }
 }

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -54,8 +54,8 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
     public function dataRemovedParameter()
     {
         return array(
-            array('mktime', 'is_dst', '7.0', array(3), '5.6'),
-            array('gmmktime', 'is_dst', '7.0', array(5), '5.6'),
+            array('mktime', 'is_dst', '7.0', array(8), '5.6'),
+            array('gmmktime', 'is_dst', '7.0', array(9), '5.6'),
         );
     }
 
@@ -85,15 +85,8 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
     public function dataValidParameter()
     {
         return array(
-            array(8),
-            array(9),
-            array(10),
-            array(11),
-            array(12),
-            array(13),
-            array(14),
-            array(15),
-            array(17),
+            array(4),
+            array(5),
         );
     }
 

--- a/Tests/TestHelperPHPCompatibility.php
+++ b/Tests/TestHelperPHPCompatibility.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Test Helper file.
+ *
+ * @package PHPCompatibility
+ */
+
+if (class_exists('PHPCompatibility_Sniff', true) === false) {
+    require_once dirname( dirname(__FILE__) ) . '/Sniff.php';
+}
+
+/**
+ * Helper class to facilitate testing of the methods within the abstract PHPCompatibility_Sniff class.
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class TestHelperPHPCompatibility extends PHPCompatibility_Sniff {
+	public function register() {}
+	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {}
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -19,3 +19,4 @@ php composer.phar install
 }
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseAbstractClassMethodTest.php';

--- a/Tests/sniff-examples/new_function_parameter.php
+++ b/Tests/sniff-examples/new_function_parameter.php
@@ -1,15 +1,10 @@
 <?php
 
+// This is ok.
+dirname( dirname( __FILE__ ) );
+
+// These should all be flagged.
 dirname('somewhere', 5);
-
-dirname( dirname( __FILE__ ) ); // Added after Github issue #111
-
-dirname( plugin_basename( __FILE__ ) ); // Added after Github issue #111
-
-dirname( plugin_basename( __FILE__ ), 2 ); // Added after Github issue #111
-
 $data = unserialize($foo, ["allowed_classes" => false]);
-
 session_start(array('bla'));
-
 strstr('a', 'bla', true);

--- a/Tests/sniff-examples/removed_function_parameter.php
+++ b/Tests/sniff-examples/removed_function_parameter.php
@@ -1,17 +1,9 @@
 <?php
 
+// These are ok.
+mktime(1, 2, 3, 4, 5, 6);
+gmmktime(1, 2, 3, 4, 5, 6);
+
+// These are not.
 mktime(1, 2, 3, 4, 5, 6, true);
-
 gmmktime(1, 2, 3, 4, 5, 6, true);
-
-// Added after Github issue #114
-$stHour = date('H');
-$arrStDt = array(date('m'), date('d'), date('Y'));
-echo "\n".$case_1 = mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]);
-echo "\n".$case_2 = mktime(0, 0, 0, date('m'), date('d'), date('Y'));
-echo "\n".$case_3 = mktime(0, 0, 0, date('m'), date('d') - 1, date('Y') + 1);
-echo "\n".$case_4 = mktime(0, 0, 0, date('m') + 1, date('d'), date('Y'));
-echo "\n".$case_5 = mktime(date('H'), 0, 0, date('m'), date('d'), date('Y'));
-echo "\n".$case_6 = mktime(0, 0, date('s'), date('m'), date('d'), date('Y'));
-
-mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6);

--- a/Tests/sniff-examples/utility-functions/count_function_parameters.php
+++ b/Tests/sniff-examples/utility-functions/count_function_parameters.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Count function parameters.
+ */
+myfunction(1);
+myfunction( 1, 2 );
+myfunction(1, 2, 3);
+myfunction(1, 2, 3, 4);
+myfunction(1, 2, 3, 4, 5);
+myfunction(1, 2, 3, 4, 5, 6);
+myfunction( 1, 2, 3, 4, 5, 6, true );
+
+/*
+ * Propertly deal with nested parenthesis.
+ * Also see Github issues #111 / #114 / #151.
+ */
+dirname( dirname( __FILE__ ) ); // 1
+(dirname( dirname( __FILE__ ) )); // 1
+dirname( plugin_basename( __FILE__ ) ); // 1
+dirname( plugin_basename( __FILE__ ), 2 ); // 2
+unserialize(trim($value, "'")); // 1
+dirname(str_replace("../","/", $value)); // 1
+dirname(str_replace("../", "/", trim($value))); // 1
+dirname( plugin_basename( __FILE__ ), trim( 2 ) ); // 2
+mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+mktime(0, 0, 0, date('m'), date('d'), date('Y')); // 6
+mktime(0, 0, 0, date('m'), date('d') - 1, date('Y') + 1); // 6
+mktime(0, 0, 0, date('m') + 1, date('d'), date('Y')); // 6
+mktime(date('H'), 0, 0, date('m'), date('d'), date('Y')); // 6
+mktime(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+
+/*
+ * Testing multi-line function calls.
+ */
+filter_input_array(
+    INPUT_POST,
+	$args,
+	false
+); // 3
+
+gettimeofday (
+               true
+			 ); // 1

--- a/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
+++ b/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * Tests for doesFunctionCallHaveParameters()
+ *
+ * Added after Github issue #120 / #152.
+ */
+
+/*
+ * No parameters.
+ */
+some_function();
+some_function(     );
+some_function( /*nothing here*/ );
+some_function(/*nothing here*/);
+
+/*
+ * Has parameters.
+ */
+some_function( 1 );
+some_function(1,2,3);
+some_function(true);


### PR DESCRIPTION
Abstract out two new methods: `doesFunctionCallHaveParameters()` and `getFunctionCallParameterCount()` to be used with the `NewFunctionParameters` and `RemovedFunctionParameters` parameter sniffs.

Fixes #120, #151, #152.

Builds onto the solutions for #111 and #114.

~~Additional unit tests for these changes are contained in another branch which is waiting for #149.~~ <= unit tests have been added to the branch.

----
[Edit]: This PR also makes the error notice line number slightly more informative. This was the next comma/closing brace line number - which could be on a completely different line as the parameter -, now it is the line number for the function call - which still might not be on the same line as the parameter, but will make finding the parameter easier.
