### PR TITLE
Allow for unit tests to be run when using PEAR installed PHPCS.

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -9,13 +9,21 @@ if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     define('PHP_CODESNIFFER_IN_TESTS', true);
 }
 
-$vendorDir = __DIR__ . '/../vendor';
+// See if we are in a PEAR install or PHPCS.
+$phpcsDir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+if (file_exists($phpcsDir . 'CodeSniffer.php')) {
+    require $phpcsDir . 'CodeSniffer.php';
+}
+else {
+    // Otherwise we must be in a composer install.
+    $vendorDir = __DIR__ . '/../vendor';
 
-if (!@include($vendorDir . '/autoload.php')) {
-    die("You must set up the project dependencies, run the following commands:
-wget http://getcomposer.org/composer.phar
-php composer.phar install
-");
+    if (!@include($vendorDir . '/autoload.php')) {
+        die("You must set up the project dependencies, run the following commands:
+    wget http://getcomposer.org/composer.phar
+    php composer.phar install
+    ");
+    }
 }
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';


### PR DESCRIPTION
Some silly people (=me) still use the PHPCS PEAR install and just have a local fork of PHPCompatibility in the PHPCS PEAR `Standards` directory.

In that case, running the unit tests locally fails miserably while it doesn't *have* to fail as the path is predictable.

This PR solves that.