### PR TITLE
Fix issue with running unit tests against current PHPCS master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,33 +8,33 @@ matrix:
     - php: 5.3
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.3
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
 
     - php: 5.4
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.4
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
 
     - php: 5.5
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.5
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
     - php: 5.5
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
     - php: 5.6
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.6
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
     - php: 5.6
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
     - php: 7.0
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 7.0
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.0"
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
     - php: 7.0
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
 before_script:
   - phpenv rehash

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -37,7 +37,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
 
         PHP_CodeSniffer::setConfigData('testVersion', null, true);
         if (method_exists('PHP_CodeSniffer_CLI', 'setCommandLineValues')) { // For PHPCS 2.x
-            self::$phpcs->cli->setCommandLineValues(array('-p', '--colors'));
+            self::$phpcs->cli->setCommandLineValues(array('-pq', '--colors'));
         }
 
         self::$phpcs->process(array(), __DIR__ . '/../');


### PR DESCRIPTION
For some reason which I haven't been able to figure out, PHPCS master still throws an error when `quiet` is not defined and running with a test suite.

This small fix, gets rid of the error and will allow the test suite to run against master again.

The only PHPCS version which *will* give an issue is 2.6.2 which is missing part of the commit for the addition of the quiet parameter in PHPCS.