### PR TITLE
Improve the `NewClassesSniff`.

### DIFF
--- a/Tests/GetFQClassNameFromDoubleColonToken.php
+++ b/Tests/GetFQClassNameFromDoubleColonToken.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Classname determination test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Classname determination from double colon token function tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class GetFQClassNameFromDoubleColonTokenTest extends BaseAbstractClassMethodTest
+{
+
+    public $filename = 'sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php';
+
+    /**
+     * testGetFQClassNameFromDoubleColonToken
+     *
+     * @group utilityFunctions
+     *
+     * @requires PHP 5.3
+     *
+     * @dataProvider dataGetFQClassNameFromDoubleColonToken
+     *
+     * @param int    $stackPtr Stack pointer for a T_DOUBLE_COLON token in the test file.
+     * @param string $expected The expected fully qualified class name.
+     */
+    public function testGetFQClassNameFromDoubleColonToken($stackPtr, $expected) {
+        $result = $this->helperClass->getFQClassNameFromDoubleColonToken($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataGetFQClassNameFromDoubleColonToken
+     *
+     * @see testGetFQClassNameFromDoubleColonToken()
+     *
+     * @return array
+     */
+    public function dataGetFQClassNameFromDoubleColonToken()
+    {
+        return array(
+            array(3, '\DateTime'),
+            array(8, '\DateTime'),
+            array(13, '\DateTime'),
+            array(21, '\DateTime'),
+            array(30, '\DateTime'),
+            array(39, '\AnotherNS\DateTime'),
+            array(49, '\FQNS\DateTime'),
+            array(61, '\DateTime'),
+            array(76, '\AnotherNS\DateTime'),
+            array(90, '\Testing\DateTime'),
+            array(96, '\Testing\DateTime'),
+            array(102, '\Testing\DateTime'),
+            array(127, '\Testing\MyClass'),
+            array(135, ''),
+            array(141, ''),
+            array(173, '\MyClass'),
+            array(181, ''),
+            array(187, ''),
+        );
+    }
+
+}

--- a/Tests/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/GetFQClassNameFromNewTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Classname determination test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Classname determination function tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class GetFQClassNameFromNewTokenTest extends BaseAbstractClassMethodTest
+{
+
+    public $filename = 'sniff-examples/utility-functions/get_fqclassname_from_new_token.php';
+
+    /**
+     * testGetFQClassNameFromNewToken
+     *
+     * @group utilityFunctions
+     *
+     * @requires PHP 5.3
+     *
+     * @dataProvider dataGetFQClassNameFromNewToken
+     *
+     * @param int    $stackPtr Stack pointer for a T_NEW token in the test file.
+     * @param string $expected The expected fully qualified class name.
+     */
+    public function testGetFQClassNameFromNewToken($stackPtr, $expected) {
+        $result = $this->helperClass->getFQClassNameFromNewToken($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataGetFQClassNameFromNewToken
+     *
+     * @see testGetFQClassNameFromNewToken()
+     *
+     * @return array
+     */
+    public function dataGetFQClassNameFromNewToken()
+    {
+        return array(
+            array(7, '\MyTesting\DateTime'),
+            array(16, '\MyTesting\DateTime'),
+            array(21, '\DateTime'),
+            array(29, '\MyTesting\anotherNS\DateTime'),
+            array(38, '\FQNS\DateTime'),
+            array(56, '\AnotherTesting\DateTime'),
+            array(66, '\AnotherTesting\DateTime'),
+            array(72, '\DateTime'),
+            array(81, '\AnotherTesting\anotherNS\DateTime'),
+            array(91, '\FQNS\DateTime'),
+            array(104, '\DateTime'),
+            array(109, '\DateTime'),
+            array(115, '\AnotherTesting\DateTime'),
+        );
+    }
+
+}

--- a/Tests/GetFQExtendedClassNameTest.php
+++ b/Tests/GetFQExtendedClassNameTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Extended class name determination test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Extended class name determination function tests
+ *
+ * @uses BaseSniffTest
+ * @package PHPCompatibility
+ */
+class GetFQExtendedClassNameTest extends BaseAbstractClassMethodTest
+{
+
+    public $filename = 'sniff-examples/utility-functions/get_fqextended_classname.php';
+
+    /**
+     * testGetFQExtendedClassName
+     *
+     * @requires PHP 5.3
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataGetFQExtendedClassName
+     *
+     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
+     * @param string $expected The expected fully qualified class name.
+     */
+    public function testGetFQExtendedClassName($stackPtr, $expected) {
+        $result = $this->helperClass->getFQExtendedClassName($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataGetFQExtendedClassName
+     *
+     * @see testGetFQExtendedClassName()
+     *
+     * @return array
+     */
+    public function dataGetFQExtendedClassName()
+    {
+        return array(
+            array(7, '\MyTesting\DateTime'),
+            array(18, '\DateTime'),
+            array(30, '\MyTesting\anotherNS\DateTime'),
+            array(43, '\FQNS\DateTime'),
+            array(65, '\AnotherTesting\DateTime'),
+            array(77, '\DateTime'),
+            array(90, '\AnotherTesting\anotherNS\DateTime'),
+            array(104, '\FQNS\DateTime'),
+            array(121, '\DateTime'),
+            array(132, '\DateTime'),
+            array(155, '\Yet\More\Testing\DateTime'),
+            array(166, '\Yet\More\Testing\anotherNS\DateTime'),
+            array(179, '\FQNS\DateTime'),
+        );
+    }
+
+}

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -53,44 +53,74 @@ class NewClassesSniffTest extends BaseSniffTest
     public function dataNewClass()
     {
         return array(
-            array('DateTime', '5.1', array(3, 43, 45), '5.2'),
-            array('DateTimeZone', '5.1', array(4, 46), '5.2'),
-            array('RegexIterator', '5.1', array(5, 47), '5.2'),
-            array('RecursiveRegexIterator', '5.1', array(6, 48), '5.2'),
-            array('DateInterval', '5.2', array(7, 49), '5.3'),
-            array('DatePeriod', '5.2', array(8, 50), '5.3'),
-            array('Phar', '5.2', array(9, 51), '5.3'),
-            array('PharData', '5.2', array(10, 52), '5.3'),
-            array('PharException', '5.2', array(11, 53), '5.3'),
-            array('PharFileInfo', '5.2', array(12, 54), '5.3'),
-            array('FilesystemIterator', '5.2', array(13, 55), '5.3'),
-            array('GlobIterator', '5.2', array(14, 56), '5.3'),
-            array('MultipleIterator', '5.2', array(15, 57), '5.3'),
-            array('RecursiveTreeIterator', '5.2', array(16, 58), '5.3'),
-            array('SplDoublyLinkedList', '5.2', array(17, 59), '5.3'),
-            array('SplFixedArray', '5.2', array(18, 60), '5.3'),
-            array('SplHeap', '5.2', array(19, 61), '5.3'),
-            array('SplMaxHeap', '5.2', array(20, 62), '5.3'),
-            array('SplMinHeap', '5.2', array(21, 63), '5.3'),
-            array('SplPriorityQueue', '5.2', array(22, 64), '5.3'),
-            array('SplQueue', '5.2', array(23, 65), '5.3'),
-            array('SplStack', '5.2', array(24, 66), '5.3'),
-            array('CallbackFilterIterator', '5.3', array(25, 67), '5.4'),
-            array('RecursiveCallbackFilterIterator', '5.3', array(26, 68), '5.4'),
-            array('ReflectionZendExtension', '5.3', array(27, 69), '5.4'),
-            array('JsonSerializable', '5.3', array(28), '5.4'),
-            array('SessionHandler', '5.3', array(29, 71), '5.4'),
-            array('SNMP', '5.3', array(30, 72), '5.4'),
-            array('Transliterator', '5.3', array(31, 73), '5.4'),
-            array('CURLFile', '5.4', array(32, 74), '5.5'),
-            array('DateTimeImmutable', '5.4', array(33, 75), '5.5'),
-            array('IntlCalendar', '5.4', array(34, 76), '5.5'),
-            array('IntlGregorianCalendar', '5.4', array(35, 77), '5.5'),
-            array('IntlTimeZone', '5.4', array(36, 78), '5.5'),
-            array('IntlBreakIterator', '5.4', array(37, 79), '5.5'),
-            array('IntlRuleBasedBreakIterator', '5.4', array(38, 80), '5.5'),
-            array('IntlCodePointBreakIterator', '5.4', array(39, 81), '5.5'),
+            array('DateTime', '5.1', array(25, 65, 105), '5.2'),
+            array('DateTimeZone', '5.1', array(26, 66, 106), '5.2'),
+            array('RegexIterator', '5.1', array(27, 67, 107), '5.2'),
+            array('RecursiveRegexIterator', '5.1', array(28, 68, 108), '5.2'),
+            array('DateInterval', '5.2', array(17, 18, 19, 20, 29, 69, 109), '5.3'),
+            array('DatePeriod', '5.2', array(30, 70, 110), '5.3'),
+            array('Phar', '5.2', array(31, 71, 111), '5.3'),
+            array('PharData', '5.2', array(32, 72, 112), '5.3'),
+            array('PharException', '5.2', array(33, 73, 113), '5.3'),
+            array('PharFileInfo', '5.2', array(34, 74, 114), '5.3'),
+            array('FilesystemIterator', '5.2', array(35, 75, 115), '5.3'),
+            array('GlobIterator', '5.2', array(36, 76, 116), '5.3'),
+            array('MultipleIterator', '5.2', array(37, 77, 117), '5.3'),
+            array('RecursiveTreeIterator', '5.2', array(38, 78, 118), '5.3'),
+            array('SplDoublyLinkedList', '5.2', array(39, 79, 119), '5.3'),
+            array('SplFixedArray', '5.2', array(40, 80, 120), '5.3'),
+            array('SplHeap', '5.2', array(41, 81, 121), '5.3'),
+            array('SplMaxHeap', '5.2', array(42, 82, 122), '5.3'),
+            array('SplMinHeap', '5.2', array(43, 83, 123), '5.3'),
+            array('SplPriorityQueue', '5.2', array(44, 84, 124), '5.3'),
+            array('SplQueue', '5.2', array(45, 85, 125), '5.3'),
+            array('SplStack', '5.2', array(46, 86, 126), '5.3'),
+            array('CallbackFilterIterator', '5.3', array(47, 87, 127), '5.4'),
+            array('RecursiveCallbackFilterIterator', '5.3', array(48, 88, 128), '5.4'),
+            array('ReflectionZendExtension', '5.3', array(49, 89, 129), '5.4'),
+            array('SessionHandler', '5.3', array(50, 90, 130), '5.4'),
+            array('SNMP', '5.3', array(51, 91, 131), '5.4'),
+            array('Transliterator', '5.3', array(52, 92, 132), '5.4'),
+            array('CURLFile', '5.4', array(53, 93, 133), '5.5'),
+            array('DateTimeImmutable', '5.4', array(54, 94, 134), '5.5'),
+            array('IntlCalendar', '5.4', array(55, 95, 135), '5.5'),
+            array('IntlGregorianCalendar', '5.4', array(56, 96, 136), '5.5'),
+            array('IntlTimeZone', '5.4', array(57, 97, 137), '5.5'),
+            array('IntlBreakIterator', '5.4', array(58, 98, 138), '5.5'),
+            array('IntlRuleBasedBreakIterator', '5.4', array(59, 99, 139), '5.5'),
+            array('IntlCodePointBreakIterator', '5.4', array(60, 100, 140), '5.5'),
         );
     }
 
+
+    /**
+     * testNoViolation
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+        );
+    }
 }

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -1,5 +1,27 @@
 <?php
 
+/*
+ * These should not be flagged.
+ */
+$okay = new StdClass();
+$okay = new \myNamespace\DateTime();
+$okay = \myNamespace\DateTime::static_method();
+$okay = namespace\DateTime::static_method();
+// Left empty for additional test cases to be added.
+
+/*
+ * 1. Verify instantiation without parameters is being flagged.
+ * 2. + 3. Verify that instation with spacing/comments between elements is being flagged.
+ * 4. Verify that instation with global namespace indicator is being flagged.
+ */
+$test = new DateInterval;
+$test = new DateInterval ();
+$test = new /*comment*/ DateInterval();
+$test = new \DateInterval();
+
+/*
+ * These should all be flagged.
+ */
 $test = new DateTime ();
 $test = new DateTimeZone();
 $test = new RegexIterator();
@@ -25,7 +47,6 @@ $test = new SplStack();
 $test = new CallbackFilterIterator();
 $test = new RecursiveCallbackFilterIterator();
 $test = new ReflectionZendExtension();
-$test = new JsonSerializable();
 $test = new SessionHandler();
 $test = new SNMP();
 $test = new Transliterator();
@@ -38,9 +59,8 @@ $test = new IntlBreakIterator();
 $test = new IntlRuleBasedBreakIterator();
 $test = new IntlCodePointBreakIterator();
 
-$okay = new StdClass();
 
-$test = new DateTime;
+
 
 class MyDateTime extends DateTime {}
 class MyDateTimeZone extends DateTimeZone {}
@@ -67,7 +87,6 @@ class MySplStack extends SplStack {}
 class MyCallbackFilterIterator extends CallbackFilterIterator {}
 class MyRecursiveCallbackFilterIterator extends RecursiveCallbackFilterIterator {}
 class MyReflectionZendExtension extends ReflectionZendExtension {}
-
 class MySessionHandler extends SessionHandler {}
 class MySNMP extends SNMP {}
 class MyTransliterator extends Transliterator {}
@@ -79,3 +98,43 @@ class MyIntlTimeZone extends IntlTimeZone {}
 class MyIntlBreakIterator extends IntlBreakIterator {}
 class MyIntlRuleBasedBreakIterator extends IntlRuleBasedBreakIterator {}
 class MyIntlCodePointBreakIterator extends IntlCodePointBreakIterator {}
+
+
+
+
+DateTime::static_method();
+DateTimeZone::static_method();
+RegexIterator::static_method();
+RecursiveRegexIterator::static_method();
+DateInterval::static_method();
+DatePeriod::static_method();
+Phar::static_method();
+PharData::static_method();
+PharException::static_method();
+PharFileInfo::static_method();
+FilesystemIterator::static_method();
+GlobIterator::static_method();
+MultipleIterator::static_method();
+RecursiveTreeIterator::static_method();
+SplDoublyLinkedList::static_method();
+SplFixedArray::CLASS_CONSTANT;
+SplHeap::CLASS_CONSTANT;
+SplMaxHeap::CLASS_CONSTANT;
+SplMinHeap::CLASS_CONSTANT;
+SplPriorityQueue::CLASS_CONSTANT;
+SplQueue::CLASS_CONSTANT;
+SplStack::CLASS_CONSTANT;
+CallbackFilterIterator::CLASS_CONSTANT;
+RecursiveCallbackFilterIterator::CLASS_CONSTANT;
+ReflectionZendExtension::CLASS_CONSTANT;
+SessionHandler::$static_property;
+SNMP::$static_property;
+Transliterator::$static_property;
+CURLFile::$static_property;
+DateTimeImmutable::$static_property;
+IntlCalendar::$static_property;
+IntlGregorianCalendar::$static_property;
+IntlTimeZone::$static_property;
+IntlBreakIterator::$static_property;
+IntlRuleBasedBreakIterator::$static_property;
+IntlCodePointBreakIterator::$static_property;

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
@@ -1,0 +1,33 @@
+<?php
+
+DateTime::CONSTANT;
+DateTime::$static_property;
+DateTime::static_function();
+\DateTime::static_function();
+namespace\DateTime::static_function();
+AnotherNS\DateTime::static_function();
+\FQNS\DateTime::static_function();
+$var = (DateTime::$static_property);
+$var = (5+AnotherNS\DateTime::$static_property);
+
+namespace Testing {
+	DateTime::CONSTANT;
+	DateTime::$static_property;
+	DateTime::static_function();
+	
+	class MyClass {
+		function test {
+			echo self::CONSTANT;
+			echo parent::$static_property;
+			static::test_function();
+		}
+	}
+}
+
+class MyClass {
+	function test {
+		echo self::CONSTANT;
+		echo parent::$static_property;
+		static::test_function();
+	}
+}

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
@@ -1,0 +1,20 @@
+<?php
+namespace MyTesting;
+
+new namespace\DateTime();
+new DateTime;
+new \DateTime();
+new anotherNS\DateTime();
+new \FQNS\DateTime();
+
+namespace AnotherTesting {
+	new namespace\DateTime();
+	new DateTime;
+	new \DateTime();
+	new anotherNS\DateTime();
+	new \FQNS\DateTime();
+}
+
+new DateTime;
+new \DateTime;
+new \AnotherTesting\DateTime();

--- a/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
+++ b/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
@@ -1,0 +1,23 @@
+<?php
+namespace MyTesting;
+
+class MyTestA extends DateTime {}
+class MyTestB extends \DateTime {}
+class MyTestD extends anotherNS\DateTime {}
+class MyTestE extends \FQNS\DateTime {}
+
+namespace AnotherTesting {
+	class MyTestF extends DateTime {}
+	class MyTestG extends \DateTime {}
+	class MyTestI extends anotherNS\DateTime {}
+	class MyTestJ extends \FQNS\DateTime {}
+}
+
+class MyTestK extends DateTime {}
+class MyTestL extends \DateTime {}
+
+namespace Yet\More\Testing;
+
+class MyTestN extends DateTime {}
+class MyTestO extends anotherNS\DateTime {}
+class MyTestP extends \FQNS\DateTime {}


### PR DESCRIPTION
* Remove the `JsonSerializable` item from the `NewClassesSniff` as it's an interface and now covered by the `NewInterfacesSniff`.
* Add recognition for static use of a class - includes unit tests.
* Add recognition of namespaced classes - as class names always resolve to the current namespace, we should check for the namespace and only flag non-namespaced classes.
Ref: http://php.net/manual/en/language.namespaces.fallback.php
* Abstract out and add a number of utility methods which can be reused in the `RemovedClassesSniff` #154, and for the namespace related methods, reused for functions and more.
* Add some `NoViolation` cases to the unit tests.
* Add unit tests for the new utility methods.