### PR TITLE
Improve removedFunctionParameters sniff.

### DIFF
--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -28,19 +28,25 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
      * @param string $removedIn     The PHP version in which the parameter was removed.
      * @param array  $lines         The line numbers in the test file which apply to this class.
      * @param string $okVersion     A PHP version in which the parameter was ok to be used.
+     * @param string $testVersion   Optional. A PHP version in which to test for the removal message.
      *
      * @return void
      */
-    public function testRemovedParameter($functionName, $parameterName, $removedIn, $lines, $okVersion)
+    public function testRemovedParameter($functionName, $parameterName, $removedIn, $lines, $okVersion, $testVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach ($lines as $line) {
             $this->assertNoViolation($file, $line);
         }
 
-        $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        if (isset($testVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $testVersion);
+        }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        }
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName} does not have a parameter {$parameterName} in PHP version {$removedIn} or later");
+            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was removed in PHP version {$removedIn}");
         }
     }
 
@@ -54,8 +60,56 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
     public function dataRemovedParameter()
     {
         return array(
-            array('mktime', 'is_dst', '7.0', array(8), '5.6'),
-            array('gmmktime', 'is_dst', '7.0', array(9), '5.6'),
+            array('ldap_first_attribute', 'ber_identifier', '5.2.4', array(11), '5.2', '5.3'),
+            array('ldap_next_attribute', 'ber_identifier', '5.2.4', array(12), '5.2', '5.3'),
+        );
+    }
+
+
+    /**
+     * testDeprecatedRemovedParameter
+     *
+     * @dataProvider dataDeprecatedRemovedParameter
+     *
+     * @param string $functionName  Function name.
+     * @param string $parameterName Parameter name.
+     * @param string $deprecatedIn  The PHP version in which the parameter was deprecated.
+     * @param string $removedIn     The PHP version in which the parameter was removed.
+     * @param array  $lines         The line numbers in the test file which apply to this class.
+     * @param string $okVersion     A PHP version in which the parameter was ok to be used.
+     *
+     * @return void
+     */
+    public function testDeprecatedRemovedParameter($functionName, $parameterName, $deprecatedIn, $removedIn, $lines, $okVersion)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was deprecated in PHP version {$deprecatedIn}");
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was deprecated in PHP version {$deprecatedIn} and removed in PHP version {$removedIn}");
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedRemovedParameter()
+     *
+     * @return array
+     */
+    public function dataDeprecatedRemovedParameter()
+    {
+        return array(
+            array('mktime', 'is_dst', '5.1', '7.0', array(8), '5.0'),
+            array('gmmktime', 'is_dst', '5.1', '7.0', array(9), '5.0'),
         );
     }
 

--- a/Tests/sniff-examples/removed_function_parameter.php
+++ b/Tests/sniff-examples/removed_function_parameter.php
@@ -7,3 +7,6 @@ gmmktime(1, 2, 3, 4, 5, 6);
 // These are not.
 mktime(1, 2, 3, 4, 5, 6, true);
 gmmktime(1, 2, 3, 4, 5, 6, true);
+
+ldap_first_attribute( $link_identifier, $result_entry_identifier, $ber_identifier );
+ldap_next_attribute( $link_identifier, $result_entry_identifier, $ber_identifier );


### PR DESCRIPTION
* Add code to handle parameters which are first deprecated and only later removed. While a parameter is deprecated, but not yet removed, the sniff will show a warning instead of an error.
* Add deprecation version for the existing parameter checks.
* Add some additional removal parameters.
* Minor rewrite of the actual error message.

Includes unit tests and adjusted documentation.

Question: the sniff name does no longer really cover what this sniff does. Should the sniff be renamed ? and if so, to what ? `DeprecatedFunctionParameters` ?