### PR TITLE
Add *a lot* more new function parameters to the `NewFunctionParameter` sniff

### DIFF
--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -34,11 +34,673 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
      * @var array
      */
     protected $newFunctionParameters = array(
+                                        'array_filter' => array(
+                                            2 => array(
+                                                'name' => 'flag',
+                                                '5.5' => false,
+                                                '5.6' => true
+                                            ),
+                                        ),
+                                        'array_slice' => array(
+                                            1 => array(
+                                                'name' => 'preserve_keys',
+                                                '5.0.1' => false,
+                                                '5.0.2' => true
+                                            ),
+                                        ),
+                                        'array_unique' => array(
+                                            1 => array(
+                                                'name' => 'sort_flags',
+                                                '5.2.8' => false,
+                                                '5.2.9' => true
+                                            ),
+                                        ),
+                                        'assert' => array(
+                                            1 => array(
+                                                'name' => 'description',
+                                                '5.4.7' => false,
+                                                '5.4.8' => true
+                                            ),
+                                        ),
+                                        'base64_decode' => array(
+                                            1 => array(
+                                                'name' => 'strict',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'class_implements' => array(
+                                            1 => array(
+                                                'name' => 'autoload',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'class_parents' => array(
+                                            1 => array(
+                                                'name' => 'autoload',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'clearstatcache' => array(
+                                            0 => array(
+                                                'name' => 'clear_realpath_cache',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                            1 => array(
+                                                'name' => 'filename',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'copy' => array(
+                                            2 => array(
+                                                'name' => 'context',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'curl_multi_info_read' => array(
+                                            1 => array(
+                                                'name' => 'msgs_in_queue',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'debug_backtrace' => array(
+                                            0 => array(
+                                                'name' => 'options',
+                                                '5.2.4' => false,
+                                                '5.2.5' => true
+                                            ),
+                                            1 => array(
+                                                'name' => 'limit',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'debug_print_backtrace' => array(
+                                            0 => array(
+                                                'name' => 'options',
+                                                '5.3.5' => false,
+                                                '5.3.6' => true
+                                            ),
+                                            1 => array(
+                                                'name' => 'limit',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
                                         'dirname' => array(
                                             1 => array(
-                                                'name' => 'depth',
+                                                'name' => 'levels',
                                                 '5.6' => false,
                                                 '7.0' => true
+                                            ),
+                                        ),
+                                        'dns_get_record' => array(
+                                            4 => array(
+                                                'name' => 'raw',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'fgetcsv' => array(
+                                            4 => array(
+                                                'name' => 'escape',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'fputcsv' => array(
+                                            4 => array(
+                                                'name' => 'escape_char',
+                                                '5.5.3' => false,
+                                                '5.5.4' => true
+                                            ),
+                                        ),
+                                        'file_get_contents' => array(
+                                            3 => array(
+                                                'name' => 'offset',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                            4 => array(
+                                                'name' => 'maxlen',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'filter_input_array' => array(
+                                            2 => array(
+                                                'name' => 'add_empty',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'filter_var_array' => array(
+                                            2 => array(
+                                                'name' => 'add_empty',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'gettimeofday' => array(
+                                            0 => array(
+                                                'name' => 'return_float',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'get_html_translation_table' => array(
+                                            2 => array(
+                                                'name' => 'encoding',
+                                                '5.3.3' => false,
+                                                '5.3.4' => true
+                                            ),
+                                        ),
+                                        'get_loaded_extensions' => array(
+                                            0 => array(
+                                                'name' => 'zend_extensions',
+                                                '5.2.3' => false,
+                                                '5.2.4' => true
+                                            ),
+                                        ),
+                                        'gzcompress' => array(
+                                            2 => array(
+                                                'name' => 'encoding',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'gzdeflate' => array(
+                                            2 => array(
+                                                'name' => 'encoding',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'htmlentities' => array(
+                                            3 => array(
+                                                'name' => 'double_encode',
+                                                '5.2.2' => false,
+                                                '5.2.3' => true
+                                            ),
+                                        ),
+                                        'htmlspecialchars' => array(
+                                            3 => array(
+                                                'name' => 'double_encode',
+                                                '5.2.2' => false,
+                                                '5.2.3' => true
+                                            ),
+                                        ),
+                                        'http_build_query' => array(
+                                            2 => array(
+                                                'name' => 'arg_separator',
+                                                '5.1.1' => false,
+                                                '5.1.2' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'enc_type',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'idn_to_ascii' => array(
+                                            2 => array(
+                                                'name' => 'variant',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'idna_info',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'idn_to_utf8' => array(
+                                            2 => array(
+                                                'name' => 'variant',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'idna_info',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'imagecolorset' => array(
+                                            5 => array(
+                                                'name' => 'alpha',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'imagepng' => array(
+                                            2 => array(
+                                                'name' => 'quality',
+                                                '5.1.1' => false,
+                                                '5.1.2' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'filters',
+                                                '5.1.2' => false,
+                                                '5.1.3' => true
+                                            ),
+                                        ),
+                                        'imagerotate' => array(
+                                            3 => array(
+                                                'name' => 'ignore_transparent',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'imap_open' => array(
+                                            4 => array(
+                                                'name' => 'n_retries',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                            5 => array(
+                                                'name' => 'params',
+                                                '5.3.1' => false,
+                                                '5.3.2' => true
+                                            ),
+                                        ),
+                                        'imap_reopen' => array(
+                                            3 => array(
+                                                'name' => 'n_retries',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'ini_get_all' => array(
+                                            1 => array(
+                                                'name' => 'details',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'is_a' => array(
+                                            2 => array(
+                                                'name' => 'allow_string',
+                                                '5.3.8' => false,
+                                                '5.3.9' => true
+                                            ),
+                                        ),
+                                        'is_subclass_of' => array(
+                                            2 => array(
+                                                'name' => 'allow_string',
+                                                '5.3.8' => false,
+                                                '5.3.9' => true
+                                            ),
+                                        ),
+                                        'iterator_to_array' => array(
+                                            1 => array(
+                                                'name' => 'use_keys',
+                                                '5.2' => false,
+                                                '5.2.1' => true
+                                            ),
+                                        ),
+                                        'json_decode' => array(
+                                            2 => array(
+                                                'name' => 'depth',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'options',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'json_encode' => array(
+                                            1 => array(
+                                                'name' => 'options',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                            2 => array(
+                                                'name' => 'depth',
+                                                '5.4' => false,
+                                                '5.5' => true
+                                            ),
+                                        ),
+                                        'memory_get_peak_usage' => array(
+                                            0 => array(
+                                                'name' => 'real_usage',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'memory_get_usage' => array(
+                                            0 => array(
+                                                'name' => 'real_usage',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'mb_encode_numericentity' => array(
+                                            3 => array(
+                                                'name' => 'is_hex',
+                                                '5.3' => false,
+                                                '5.4' => true
+                                            ),
+                                        ),
+                                        'mb_strrpos' => array(
+                                            /*
+                                             * Note: the actual position is 2, but the original 3rd
+                                             * parameter 'encoding' was moved to the 4th position.
+                                             * So the only way to detect if offset is used is when
+                                             * both offset and encoding are set.
+                                             */
+                                            3 => array(
+                                                'name' => 'offset',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'mssql_connect' => array(
+                                            3 => array(
+                                                'name' => 'new_link',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'mysqli_commit' => array(
+                                            1 => array(
+                                                'name' => 'flags',
+                                                '5.4' => false,
+                                                '5.5' => true
+                                            ),
+                                            2 => array(
+                                                'name' => 'name',
+                                                '5.4' => false,
+                                                '5.5' => true
+                                            ),
+                                        ),
+                                        'mysqli_rollback' => array(
+                                            1 => array(
+                                                'name' => 'flags',
+                                                '5.4' => false,
+                                                '5.5' => true
+                                            ),
+                                            2 => array(
+                                                'name' => 'name',
+                                                '5.4' => false,
+                                                '5.5' => true
+                                            ),
+                                        ),
+                                        'nl2br' => array(
+                                            1 => array(
+                                                'name' => 'is_xhtml',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'openssl_decrypt' => array(
+                                            4 => array(
+                                                'name' => 'iv',
+                                                '5.3.2' => false,
+                                                '5.3.3' => true
+                                            ),
+                                        ),
+                                        'openssl_encrypt' => array(
+                                            4 => array(
+                                                'name' => 'iv',
+                                                '5.3.2' => false,
+                                                '5.3.3' => true
+                                            ),
+                                        ),
+                                        'openssl_pkcs7_verify' => array(
+                                            5 => array(
+                                                'name' => 'content',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'openssl_seal' => array(
+                                            4 => array(
+                                                'name' => 'method',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'openssl_verify' => array(
+                                            3 => array(
+                                                'name' => 'signature_alg',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'parse_ini_file' => array(
+                                            2 => array(
+                                                'name' => 'scanner_mode',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'parse_url' => array(
+                                            1 => array(
+                                                'name' => 'component',
+                                                '5.1.1' => false,
+                                                '5.1.2' => true
+                                            ),
+                                        ),
+                                        'pg_lo_create' => array(
+                                            1 => array(
+                                                'name' => 'object_id',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'pg_lo_import' => array(
+                                            2 => array(
+                                                'name' => 'object_id',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'preg_replace' => array(
+                                            4 => array(
+                                                'name' => 'count',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'preg_replace_callback' => array(
+                                            4 => array(
+                                                'name' => 'count',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'round' => array(
+                                            2 => array(
+                                                'name' => 'mode',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'sem_acquire' => array(
+                                            1 => array(
+                                                'name' => 'nowait',
+                                                '5.6' => false,
+                                                '5.6.1' => true
+                                            ),
+                                        ),
+                                        'session_regenerate_id' => array(
+                                            0 => array(
+                                                'name' => 'delete_old_session',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'session_set_cookie_params' => array(
+                                            4 => array(
+                                                'name' => 'httponly',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'session_set_save_handler' => array(
+                                            6 => array(
+                                                'name' => 'create_sid',
+                                                '5.5' => false,
+                                                '5.5.1' => true
+                                            ),
+                                        ),
+                                        'session_start' => array(
+                                            0 => array(
+                                                'name' => 'options',
+                                                '5.6' => false,
+                                                '7.0' => true
+                                            ),
+                                        ),
+                                        'setcookie' => array(
+                                            6 => array(
+                                                'name' => 'httponly',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'setrawcookie' => array(
+                                            6 => array(
+                                                'name' => 'httponly',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'simplexml_load_file' => array(
+                                            4 => array(
+                                                'name' => 'is_prefix',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'simplexml_load_string' => array(
+                                            4 => array(
+                                                'name' => 'is_prefix',
+                                                '5.1' => false,
+                                                '5.2' => true
+                                            ),
+                                        ),
+                                        'spl_autoload_register' => array(
+                                            2 => array(
+                                                'name' => 'prepend',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'stream_context_create' => array(
+                                            1 => array(
+                                                'name' => 'params',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'stream_copy_to_stream' => array(
+                                            3 => array(
+                                                'name' => 'offset',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'stream_get_contents' => array(
+                                            2 => array(
+                                                'name' => 'offset',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'stream_wrapper_register' => array(
+                                            2 => array(
+                                                'name' => 'flags',
+                                                '5.2.3' => false,
+                                                '5.2.4' => true
+                                            ),
+                                        ),
+                                        'stristr' => array(
+                                            2 => array(
+                                                'name' => 'before_needle',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'strstr' => array(
+                                            2 => array(
+                                                'name' => 'before_needle',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'str_word_count' => array(
+                                            2 => array(
+                                                'name' => 'charlist',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'substr_count' => array(
+                                            2 => array(
+                                                'name' => 'offset',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                            3 => array(
+                                                'name' => 'length',
+                                                '5.0' => false,
+                                                '5.1' => true
+                                            ),
+                                        ),
+                                        'sybase_connect' => array(
+                                            5 => array(
+                                                'name' => 'new',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'timezone_transitions_get' => array(
+                                            1 => array(
+                                                'name' => 'timestamp_begin',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                            2 => array(
+                                                'name' => 'timestamp_end',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'timezone_identifiers_list' => array(
+                                            0 => array(
+                                                'name' => 'what',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                            1 => array(
+                                                'name' => 'country',
+                                                '5.2' => false,
+                                                '5.3' => true
+                                            ),
+                                        ),
+                                        'token_get_all' => array(
+                                            1 => array(
+                                                'name' => 'flags',
+                                                '5.6' => false,
+                                                '7.0' => true
+                                            ),
+                                        ),
+                                        'ucwords' => array(
+                                            1 => array(
+                                                'name' => 'delimiters',
+                                                '5.4.31' => false,
+                                                '5.5.15' => false,
+                                                '5.4.32' => true,
+                                                '5.5.16' => true
                                             ),
                                         ),
                                         'unserialize' => array(
@@ -48,20 +710,6 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
                                                 '7.0' => true
                                             ),
                                         ),
-                                        'session_start' => array(
-                                            0 => array(
-                                                'name' => 'options',
-                                                '5.6' => false,
-                                                '7.0' => true
-                                            )
-                                        ),
-                                        'strstr' => array(
-                                            2 => array(
-                                                'name' => 'before_needle',
-                                                '5.2' => false,
-                                                '5.3' => true
-                                            )
-                                        )
                                     );
 
 
@@ -159,16 +807,15 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
 
         $isError = false;
         foreach ($this->newFunctionParameters[$function][$parameterLocation] as $version => $present) {
-            if ($version != 'name' && $this->supportsBelow($version)) {
-                if ($present === false) {
-                    $isError = true;
-                    $error .= 'in PHP version ' . $version . ' or earlier';
-                }
+            if ($version != 'name' && $present === false && $this->supportsBelow($version)) {
+                $isError = true;
+                $error .= 'in PHP version ' . $version . ' or earlier';
+                break;
             }
         }
 
         if (strlen($error) > 0) {
-            $error = 'The function ' . $function . ' does not have a parameter ' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . ' ' . $error;
+            $error = 'The function ' . $function . ' does not have a parameter "' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . '" ' . $error;
 
             if ($isError === true) {
                 $phpcsFile->addError($error, $stackPtr);

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -28,14 +28,20 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
      * @param string $lastVersionBefore The PHP version just *before* the parameter was introduced.
      * @param array  $lines             The line numbers in the test file which apply to this class.
      * @param string $okVersion         A PHP version in which the parameter was ok to be used.
+     * @param string $testVersion       Optional PHP version to use for testing the flagged case.
      *
      * @return void
      */
-    public function testInvalidParameter($functionName, $parameterName, $lastVersionBefore, $lines, $okVersion)
+    public function testInvalidParameter($functionName, $parameterName, $lastVersionBefore, $lines, $okVersion, $testVersion = null)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        if (isset($testVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $testVersion);
+        }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        }
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName} does not have a parameter {$parameterName} in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, "The function {$functionName} does not have a parameter \"{$parameterName}\" in PHP version {$lastVersionBefore} or earlier");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
@@ -54,10 +60,106 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
     public function dataInvalidParameter()
     {
         return array(
-            array('dirname', 'depth', '5.6', array(7), '7.0'),
-            array('unserialize', 'options', '5.6', array(8), '7.0'),
-            array('session_start', 'options', '5.6', array(9), '7.0'),
-            array('strstr', 'before_needle', '5.2', array(10), '5.3'),
+            array('array_filter', 'flag', '5.5', array(11), '5.6'),
+            array('array_slice', 'preserve_keys', '5.0.1', array(12), '5.1', '5.0'),
+            array('array_unique', 'sort_flags', '5.2.8', array(13), '5.3', '5.2'),
+            array('assert', 'description', '5.4.7', array(14), '5.5', '5.4'),
+            array('base64_decode', 'strict', '5.1', array(15), '5.2'),
+            array('class_implements', 'autoload', '5.0', array(16), '5.1'),
+            array('class_parents', 'autoload', '5.0', array(17), '5.1'),
+            array('clearstatcache', 'clear_realpath_cache', '5.2', array(18), '5.3'),
+            array('clearstatcache', 'filename', '5.2', array(18), '5.3'),
+            array('copy', 'context', '5.2', array(19), '5.3'),
+            array('curl_multi_info_read', 'msgs_in_queue', '5.1', array(20), '5.2'),
+            array('debug_backtrace', 'options', '5.2.4', array(21), '5.4', '5.2'),
+            array('debug_backtrace', 'limit', '5.3', array(21), '5.4'),
+            array('debug_print_backtrace', 'options', '5.3.5', array(22), '5.4', '5.3'),
+            array('debug_print_backtrace', 'limit', '5.3', array(22), '5.4'),
+            array('dirname', 'levels', '5.6', array(23), '7.0'),
+            array('dns_get_record', 'raw', '5.3', array(24), '5.4'),
+            array('fgetcsv', 'escape', '5.2', array(25), '5.3'),
+            array('fputcsv', 'escape_char', '5.5.3', array(26), '5.6', '5.5'),
+            array('file_get_contents', 'offset', '5.0', array(27), '5.1'),
+            array('file_get_contents', 'maxlen', '5.0', array(27), '5.1'),
+            array('filter_input_array', 'add_empty', '5.3', array(28), '5.4'),
+            array('filter_var_array', 'add_empty', '5.3', array(29), '5.4'),
+            array('gettimeofday', 'return_float', '5.0', array(30), '5.1'),
+            array('get_html_translation_table', 'encoding', '5.3.3', array(31), '5.4', '5.3'),
+            array('get_loaded_extensions', 'zend_extensions', '5.2.3', array(32), '5.3', '5.2'),
+            array('gzcompress', 'encoding', '5.3', array(33), '5.4'),
+            array('gzdeflate', 'encoding', '5.3', array(34), '5.4'),
+            array('htmlentities', 'double_encode', '5.2.2', array(35), '5.3', '5.2'),
+            array('htmlspecialchars', 'double_encode', '5.2.2', array(36), '5.3', '5.2'),
+            array('http_build_query', 'arg_separator', '5.1.1', array(37), '5.4', '5.1'),
+            array('http_build_query', 'enc_type', '5.3', array(37), '5.4'),
+            array('idn_to_ascii', 'variant', '5.3', array(38), '5.4'),
+            array('idn_to_ascii', 'idna_info', '5.3', array(38), '5.4'),
+            array('idn_to_utf8', 'variant', '5.3', array(39), '5.4'),
+            array('idn_to_utf8', 'idna_info', '5.3', array(39), '5.4'),
+            array('imagecolorset', 'alpha', '5.3', array(40), '5.4'),
+            array('imagepng', 'quality', '5.1.1', array(41), '5.2', '5.1'),
+            array('imagepng', 'filters', '5.1.2', array(41), '5.2', '5.1'),
+            array('imagerotate', 'ignore_transparent', '5.0', array(42), '5.1'),
+            array('imap_open', 'n_retries', '5.1', array(43), '5.4'),
+            array('imap_open', 'params', '5.3.1', array(43), '5.4', '5.3'),
+            array('imap_reopen', 'n_retries', '5.1', array(44), '5.2'),
+            array('ini_get_all', 'details', '5.2', array(45), '5.3'),
+            array('is_a', 'allow_string', '5.3.8', array(46), '5.4', '5.3'),
+            array('is_subclass_of', 'allow_string', '5.3.8', array(47), '5.4', '5.3'),
+            array('iterator_to_array', 'use_keys', '5.2', array(48), '5.3', '5.2'),
+            array('json_decode', 'depth', '5.2', array(49), '5.4'),
+            array('json_decode', 'options', '5.3', array(49), '5.4'),
+            array('json_encode', 'options', '5.2', array(50), '5.5'),
+            array('json_encode', 'depth', '5.4', array(50), '5.5'),
+            array('memory_get_peak_usage', 'real_usage', '5.1', array(51), '5.2'),
+            array('memory_get_usage', 'real_usage', '5.1', array(52), '5.2'),
+            array('mb_encode_numericentity', 'is_hex', '5.3', array(53), '5.4'),
+            array('mb_strrpos', 'offset', '5.1', array(54), '5.2'),
+            array('mssql_connect', 'new_link', '5.0', array(55), '5.1'),
+            array('mysqli_commit', 'flags', '5.4', array(56), '5.5'),
+            array('mysqli_commit', 'name', '5.4', array(56), '5.5'),
+            array('mysqli_rollback', 'flags', '5.4', array(57), '5.5'),
+            array('mysqli_rollback', 'name', '5.4', array(57), '5.5'),
+            array('nl2br', 'is_xhtml', '5.2', array(58), '5.3'),
+            array('openssl_decrypt', 'iv', '5.3.2', array(59), '5.4', '5.3'),
+            array('openssl_encrypt', 'iv', '5.3.2', array(60), '5.4', '5.3'),
+            array('openssl_pkcs7_verify', 'content', '5.0', array(61), '5.1'),
+            array('openssl_seal', 'method', '5.2', array(62), '5.3'),
+            array('openssl_verify', 'signature_alg', '5.1', array(63), '5.2'),
+            array('parse_ini_file', 'scanner_mode', '5.2', array(64), '5.3'),
+            array('parse_url', 'component', '5.1.1', array(65), '5.2', '5.1'),
+            array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
+            array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
+            array('preg_replace', 'count', '5.0', array(68), '5.1'),
+            array('preg_replace_callback', 'count', '5.0', array(69), '5.1'),
+            array('round', 'mode', '5.2', array(70), '5.3'),
+            array('sem_acquire', 'nowait', '5.6', array(71), '7.0'),
+            array('session_regenerate_id', 'delete_old_session', '5.0', array(72), '5.1'),
+            array('session_set_cookie_params', 'httponly', '5.1', array(73), '5.2'),
+            array('session_set_save_handler', 'create_sid', '5.5', array(74), '5.6'),
+            array('session_start', 'options', '5.6', array(75), '7.0'),
+            array('setcookie', 'httponly', '5.1', array(76), '5.2'),
+            array('setrawcookie', 'httponly', '5.1', array(77), '5.2'),
+            array('simplexml_load_file', 'is_prefix', '5.1', array(78), '5.2'),
+            array('simplexml_load_string', 'is_prefix', '5.1', array(79), '5.2'),
+            array('spl_autoload_register', 'prepend', '5.2', array(80), '5.3'),
+            array('stream_context_create', 'params', '5.2', array(81), '5.3'),
+            array('stream_copy_to_stream', 'offset', '5.0', array(82), '5.1'),
+            array('stream_get_contents', 'offset', '5.0', array(83), '5.1'),
+            array('stream_wrapper_register', 'flags', '5.2.3', array(84), '5.3', '5.2'),
+            array('stristr', 'before_needle', '5.2', array(85), '5.3'),
+            array('strstr', 'before_needle', '5.2', array(86), '5.3'),
+            array('str_word_count', 'charlist', '5.0', array(87), '5.1'),
+            array('substr_count', 'offset', '5.0', array(88), '5.1'),
+            array('substr_count', 'length', '5.0', array(88), '5.1'),
+            array('sybase_connect', 'new', '5.2', array(89), '5.2.17'),
+            array('timezone_transitions_get', 'timestamp_begin', '5.2', array(90), '5.3'),
+            array('timezone_transitions_get', 'timestamp_end', '5.2', array(90), '5.3'),
+            array('timezone_identifiers_list', 'what', '5.2', array(91), '5.3'),
+            array('timezone_identifiers_list', 'country', '5.2', array(91), '5.3'),
+            array('token_get_all', 'flags', '5.6', array(92), '7.0'),
+            array('ucwords', 'delimiters', '5.4.31', array(93), '5.6', '5.4'),
+            array('unserialize', 'options', '5.6', array(94), '7.0'),
         );
     }
 
@@ -90,4 +192,5 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
             array(4),
         );
     }
+
 }

--- a/Tests/sniff-examples/new_function_parameter.php
+++ b/Tests/sniff-examples/new_function_parameter.php
@@ -3,8 +3,92 @@
 // This is ok.
 dirname( dirname( __FILE__ ) );
 
-// These should all be flagged.
+/*
+ * These should all be flagged.
+ * The examples use varying spacing to verify that the sniff
+ * works with different spacing choices.
+ */
+array_filter( $array, $callback, ARRAY_FILTER_USE_BOTH );
+array_slice($array, 0, 10, true );
+array_unique( $array, SORT_NUMERIC );
+assert( $assertion, $description );
+base64_decode($str, true);
+class_implements('not_loaded', true);
+class_parents('not_loaded', true);
+clearstatcache(true, 'somefile.txt'); // NB: 2 new params
+copy($file, $newfile, $context);
+curl_multi_info_read( $mh, $msgs_in_queue );
+debug_backtrace( DEBUG_BACKTRACE_PROVIDE_OBJECT, 3 ); // NB: 2 new params
+debug_print_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 3 ); // NB: 2 new params
 dirname('somewhere', 5);
-$data = unserialize($foo, ["allowed_classes" => false]);
+dns_get_record("php.net", DNS_ANY, $authns, $addtl, true);
+fgetcsv($handle, 1000, ',', '"', '`');
+fputcsv( $handle, $fields, "," , '"', "`" );
+file_get_contents('./people.txt', NULL, NULL, 20, 14); // NB: 2 new params
+filter_input_array(INPUT_POST, $args, false);
+filter_var_array($data, $args, false);
+gettimeofday ( true );
+get_html_translation_table(HTML_ENTITIES, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+get_loaded_extensions(true);
+gzcompress('Compress me', 9, ZLIB_ENCODING_GZIP);
+gzdeflate($compressed, 9, ZLIB_ENCODING_GZIP);
+htmlentities($str, ENT_QUOTES, 'UTF-8', false);
+htmlspecialchars('<a href="test">Test</a>', ENT_QUOTES, 'UTF-8', false);
+http_build_query($data, '', '&amp;', PHP_QUERY_RFC1738); // NB: 2 new params
+idn_to_ascii('t‰st.de', IDNA_CHECK_BIDI,  INTL_IDNA_VARIANT_UTS46, $result); // NB: 2 new params
+idn_to_utf8($domain, IDNA_CHECK_BIDI,  INTL_IDNA_VARIANT_UTS46, $result); // NB: 2 new params
+imagecolorset($im, $bg, 0, 0, 255, 0);
+imagepng ( $image, $to, 7, PNG_ALL_FILTERS ); // NB: 2 new params
+imagerotate($source, $degrees, 0, true);
+imap_open("{localhost:143}INBOX", "user_id", "password", OP_READONLY, 3, array('DISABLE_AUTHENTICATOR'=>true)); // NB: 2 new params
+imap_reopen($mbox, "{imap.example.org:143}INBOX.Sent", OP_READONLY, 3);
+ini_get_all('pcre', false);
+is_a($WF, 'WidgetFactory', true);
+is_subclass_of($WFC, 'WidgetFactory', true);
+iterator_to_array($iterator, true);
+json_decode($json, false, 512, JSON_BIGINT_AS_STRING); // NB: 2 new params
+json_encode($mixed, JSON_FORCE_OBJECT, 100); // NB: 2 new params
+memory_get_peak_usage(true);
+memory_get_usage(true);
+mb_encode_numericentity($str, $convmap, "ISO-8859-1", true);
+mb_strrpos( $haystack, $needle, 2, 'UTF-8' );
+mssql_connect($server, 'sa', 'phpfi', true);
+mysqli_commit( $link, $flags, $name ); // NB: 2 new params
+mysqli_rollback( $link, $flags, $name ); // NB: 2 new params
+nl2br("Welcome\r\nThis is my HTML document", false);
+openssl_decrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv);
+openssl_encrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv);
+openssl_pkcs7_verify ( $filename , $flags , $outfilename , $cainfo , $extracerts , $content );
+openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2), 'RC4');
+openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA1);
+parse_ini_file('sample.ini', true, INI_SCANNER_RAW);
+parse_url($url, PHP_URL_PATH);
+pg_lo_create($database, $id);
+pg_lo_import($database, '/tmp/lob.dat', $id);
+preg_replace( '`[A-Z]([a-z]+)`', '$1', $subject , -1 , $count );
+preg_replace_callback( '`[A-Z]([a-z]+)`' , $callback , $subject , -1 , $count );
+round(1.55, 1, PHP_ROUND_HALF_EVEN);
+sem_acquire( $sem_identifier, true );
+session_regenerate_id (true);
+session_set_cookie_params($lifetime, $path, $domain, false, true );
+session_set_save_handler( array($handler, 'open'), array($handler, 'close'), array($handler, 'read'), array($handler, 'write'), array($handler, 'destroy'), array($handler, 'gc'), array($handler, 'create_sid') );
 session_start(array('bla'));
+setcookie('TestCookie', '', time() - 3600, '/~rasmus/', 'example.com', 1, true);
+setrawcookie('TestCookie', '', time() - 3600, '/~rasmus/', 'example.com', 1, true);
+simplexml_load_file( $filename, 'SimpleXMLElement', 0, '', true );
+simplexml_load_string( $xmlString, 'SimpleXMLElement', 0, '', true );
+spl_autoload_register($autoload_function,true,true);
+stream_context_create($opts, $params);
+stream_copy_to_stream($src, $dest1, 1024, 1024);
+stream_get_contents( $handle, 1024, 1024 );
+stream_wrapper_register("var", "VariableStream", STREAM_IS_URL);
+stristr('a', 'bla', true);
 strstr('a', 'bla', true);
+str_word_count($str, 1, '‡·„Á3');
+substr_count($text, 'is', 2, 3); // NB: 2 new params
+sybase_connect('SYBASE', '', '', 'utf-8', '', true);
+timezone_transitions_get( $dtzObject, $timestamp_begin, $timestamp_end ); // NB: 2 new params
+timezone_identifiers_list( $what, $country); // NB: 2 new params
+token_get_all('<?php echo; ?>',TOKEN_PARSE);
+ucwords($foo, '|');
+$data = unserialize($foo, ["allowed_classes" => false]);


### PR DESCRIPTION
Based on the information found in:
http://php.net/manual/en/doc.changelog.php
http://php.net/manual/en/migration52.parameters.php
http://php.net/manual/en/migration53.parameters.php

By no means claiming completeness, but it's big step in the right direction.

Functions are ordered alphabetically. As some functions have several parameters added in different PHP  versions, this made the most sense.

Includes unit tests.

Also:
* Correct parameter name for the `dirname()` function.
* Add quotes around the parameter name in the error notice.