### PR TITLE
Improve `ForbiddenEmptyListAssignment` sniff (code review).

### DIFF
--- a/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -24,12 +24,30 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPC
 {
 
     /**
+     * List of tokens to disregard when determining whether the list() is empty.
+     *
+     * @var array
+     */
+    protected $ignoreTokens = array();
+
+    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register()
     {
+        // Set up a list of tokens to disregard when determining whether the list() is empty.
+        // Only needs to be set up once.
+        $this->ignoreTokens = PHP_CodeSniffer_Tokens::$emptyTokens;
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<')) {
+            $this->ignoreTokens = array_combine($this->ignoreTokens, $this->ignoreTokens);
+        }
+        $this->ignoreTokens[T_COMMA]             = T_COMMA;
+        $this->ignoreTokens[T_OPEN_PARENTHESIS]  = T_OPEN_PARENTHESIS;
+        $this->ignoreTokens[T_CLOSE_PARENTHESIS] = T_CLOSE_PARENTHESIS;
+
+
         return array(T_LIST);
     }
 
@@ -47,31 +65,24 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPC
         if ($this->supportsAbove('7.0')) {
             $tokens = $phpcsFile->getTokens();
 
-            $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false);
-            $close = $phpcsFile->findNext(T_CLOSE_PARENTHESIS, $stackPtr, null, false);
+            $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
+            if ($open === false || isset($tokens[$open]['parenthesis_closer']) === false) {
+                return;
+            }
 
+            $close = $tokens[$open]['parenthesis_closer'];
             $error = true;
-            for ($cnt = $open + 1; $cnt < $close; $cnt++) {
-                if ($tokens[$cnt]['type'] != 'T_WHITESPACE' && $tokens[$cnt]['type'] != 'T_COMMA') {
-                    $error = false;
+            if(($close - $open) > 1) {
+                for ($cnt = $open + 1; $cnt < $close; $cnt++) {
+                    if (isset($this->ignoreTokens[$tokens[$cnt]['code']]) === false) {
+                        $error = false;
+                    }
                 }
             }
 
-            if ($open !== false && $close !== false) {
-                if (
-                    $close - $open == 1
-                    ||
-                    (
-                        $close - $open > 2
-                        &&
-                        $error === true
-                    )
-                ) {
-                    $error = sprintf(
-                        "Empty list() assignments are not allowed since PHP 7.0"
-                    );
-                    $phpcsFile->addError($error, $stackPtr);
-                }
+            if ($error === true) {
+                $error = 'Empty list() assignments are not allowed since PHP 7.0';
+                $phpcsFile->addError($error, $stackPtr);
             }
         }
     }

--- a/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
@@ -16,18 +16,76 @@
 class ForbiddenEmptyListAssignmentSniffTest extends BaseSniffTest
 {
     /**
-     * Verify that checking for a specific version works
+     * testEmptyListAssignment
+     *
+     * @group forbiddenEmptyListAssignment
+     *
+     * @dataProvider dataEmptyListAssignment
+     *
+     * @param int $line Line number where the error should occur.
      *
      * @return void
      */
-    public function testEmptyListAssignment()
+    public function testEmptyListAssignment($line)
     {
         $file = $this->sniffFile('sniff-examples/forbidden_empty_list_assignment.php', '5.6');
-        $this->assertNoViolation($file, 3);
-        $this->assertNoViolation($file, 5);
-        
+        $this->assertNoViolation($file, $line);
+
         $file = $this->sniffFile('sniff-examples/forbidden_empty_list_assignment.php', '7.0');
-        $this->assertError($file, 3, "Empty list() assignments are not allowed since PHP 7.0");
-        $this->assertError($file, 5, "Empty list() assignments are not allowed since PHP 7.0");
+        $this->assertError($file, $line, "Empty list() assignments are not allowed since PHP 7.0");
     }
+
+    /**
+     * dataEmptyListAssignment
+     *
+     * @see testEmptyListAssignment()
+     *
+     * @return array
+     */
+    public function dataEmptyListAssignment() {
+        return array(
+            array(3),
+            array(4),
+            array(5),
+            array(6),
+            array(7),
+        );
+    }
+
+
+    /**
+     * testValidListAssignment
+     *
+     * @group forbiddenEmptyListAssignment
+     *
+     * @dataProvider dataValidListAssignment
+     *
+     * @param int $line Line number with a valid list assignment.
+     *
+     * @return void
+     */
+    public function testValidListAssignment($line)
+    {
+        $file = $this->sniffFile('sniff-examples/forbidden_empty_list_assignment.php');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataValidListAssignment
+     *
+     * @see testValidListAssignment()
+     *
+     * @return array
+     */
+    public function dataValidListAssignment() {
+        return array(
+            array(13),
+            array(14),
+            array(15),
+            array(16),
+            array(17),
+            array(20),
+        );
+    }
+
 }

--- a/Tests/sniff-examples/forbidden_empty_list_assignment.php
+++ b/Tests/sniff-examples/forbidden_empty_list_assignment.php
@@ -1,5 +1,20 @@
 <?php
 
 list() = 5;
-
 list(, ,) = 5;
+list(/*comment*/) = 5;
+list( /*comment*/ /*another comment*/ ) = 5;
+list(,(),) = 5;
+
+
+/*
+ * The below list assignments are all valid.
+ */
+list( $item, $anotherItem ) = $infoArray;
+list($drink, , $power) = $infoArray;
+list(, , $power) = $infoArray;
+list($a[0], $a[1], $a[2]) = $infoArray;
+list( ${$drink} ) = $infoArray;
+
+// Don't trigger on unfinished code during live code review.
+list(


### PR DESCRIPTION
* Trigger error when there are only comments between the parenthesis.
* Trigger error when there are empty parenthesis between the list parenthesis.
* Don't trigger error for unfinished code when review is used during live coding (in an editor).
* Slightly simplify the code.
* Remove unnecessary `sprintf()`.

Includes unit tests demonstrating the issue with the comments and the parenthesis.
Includes some extra unit tests for valid list assignments.

As there are now more test cases, refactored the unit tests to use data providers as well.