### PR TITLE
Improve `DeprecatedPHP4StyleConstructors` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -15,7 +15,9 @@
 class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
 {
     /**
-     * Test PHP4 style constructors
+     * Test PHP4 style constructors.
+     *
+     * @group deprecatedPHP4Constructors
      *
      * @return void
      */
@@ -26,5 +28,19 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
 
         $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '7.0');
         $this->assertError($file, 3, 'Deprecated PHP4 style constructor are not supported since PHP7');
+    }
+
+    /**
+     * Test valid methods with the same name as the class.
+     *
+     * @group deprecatedPHP4Constructors
+     *
+     * @return void
+     */
+    public function testValidMethods()
+    {
+        $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '7.0');
+        $this->assertNoViolation($file, 9);
+        $this->assertNoViolation($file, 20);
     }
 }

--- a/Tests/sniff-examples/deprecated_php4style_constructors.php
+++ b/Tests/sniff-examples/deprecated_php4style_constructors.php
@@ -7,9 +7,18 @@ class foo {
 
 class bar {
     function bar() {
-        echo 'I am just the foo method';
+        echo 'I am just the bar method';
     }
     function __construct() {
         echo 'I am the real constructor';
+    }
+}
+
+namespace foobar {
+
+    class foobar {
+        function foobar() {
+            echo 'I am just the bar method';
+        }
     }
 }


### PR DESCRIPTION
* Bow out early when PHP7 does not have to be supported.
* Defer to PHPCS native methods for determining the class and function names.
* Don't trigger error for namespaced classes with a method with the same name as the class.

> As of PHP 5.3.3, methods with the same name as the last element of a namespaced class name will no longer be treated as constructor. This change doesn't affect non-namespaced classes.

Ref: http://php.net/manual/en/language.oop5.decon.php

Includes unit test for namespaced class with same name method.
Includes additional unit tests verifying the `noViolation` cases.