### PR TITLE
Feature completeness `NewScalarTypeDeclarations` sniff (code review).

### DIFF
--- a/Tests/InClassScopeTest.php
+++ b/Tests/InClassScopeTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * In class scope test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * In class scope function tests
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class InClassScopeTest extends BaseAbstractClassMethodTest
+{
+
+    public $filename = 'sniff-examples/utility-functions/in_class_scope.php';
+
+    /**
+     * testInClassScope
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataInClassScope
+     *
+     * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
+     * @param string $expected The expected boolean return value.
+     */
+    public function testInClassScope($stackPtr, $expected)
+    {
+        $result = $this->helperClass->inClassScope($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataInClassScope
+     *
+     * @see testInClassScope()
+     *
+     * @return array
+     */
+    public function dataInClassScope()
+    {
+        return array(
+            array(2, false), // $var
+            array(9, false), // function
+            array(28, true), // $property
+            array(32, true), // function
+            array(49, false), // function
+            array(67, true), // function
+        );
+    }
+
+}

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -18,39 +18,167 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/new_scalar_type_declarations.php';
 
     /**
-     * testScalarTypeDeclaration
+     * testNewTypeDeclaration
      *
-     * @dataProvider dataScalarTypeDeclaration
+     * @group TypeDeclarations
+     *
+     * @dataProvider dataNewTypeDeclaration
      *
      * @param string $type The scalar type.
-     * @param int    $line The line number.
+     * @param int    $line Line number on which to expect an error.
      *
      * @return void
      */
-    public function testScalarTypeDeclaration($type, $line)
+    public function testNewTypeDeclaration($type, $lastVersionBefore, $line, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertError($file, $line, $type . ' type is not present in PHP version 5.6 or earlier');
+        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $this->assertError($file, $line, "'{$type}' type declaration is not present in PHP version {$lastVersionBefore} or earlier");
 
-        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         $this->assertNoViolation($file, $line);
-
     }
 
     /**
      * Data provider.
      *
-     * @see testScalarTypeDeclaration()
+     * @see testNewTypeDeclaration()
      *
      * @return array
      */
-    public function dataScalarTypeDeclaration()
+    public function dataNewTypeDeclaration()
     {
         return array(
-            array('bool', 3),
-            array('int', 5),
-            array('float', 7),
-            array('string', 9),
+            array('array', '5.0', 4, '5.1'),
+            array('array', '5.0', 5, '5.1'),
+            array('callable', '5.3', 9, '5.4'),
+            array('bool', '5.6', 13, '7.0'),
+            array('int', '5.6', 14, '7.0'),
+            array('float', '5.6', 15, '7.0'),
+            array('string', '5.6', 16, '7.0'),
+        );
+    }
+
+
+    /**
+     * testInvalidTypeDeclaration
+     *
+     * @group TypeDeclarations
+     *
+     * @dataProvider dataInvalidTypeDeclaration
+     *
+     * @param string $type The scalar type.
+     * @param int    $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testInvalidTypeDeclaration($type, $alternative, $line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertError($file, $line, "'{$type}' is not a valid type declaration. Did you mean {$alternative} ?");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidTypeDeclaration()
+     *
+     * @return array
+     */
+    public function dataInvalidTypeDeclaration()
+    {
+        return array(
+            array('boolean', 'bool', 20),
+            array('integer', 'int', 21),
+            array('parent', 'self', 24),
+            array('static', 'self', 25),
+        );
+    }
+
+
+    /**
+     * testInvalidSelfTypeDeclaration
+     *
+     * @group TypeDeclarations
+     *
+     * @dataProvider dataInvalidSelfTypeDeclaration
+     *
+     * @param int $line Line number on which to expect an error.
+     *
+     * @return void
+     */
+    public function testInvalidSelfTypeDeclaration($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertError($file, $line, "'self' type cannot be used outside of class scope");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testInvalidSelfTypeDeclaration()
+     *
+     * @return array
+     */
+    public function dataInvalidSelfTypeDeclaration()
+    {
+        return array(
+            array(37),
+            array(44),
+        );
+    }
+
+
+    /**
+     * testTypeDeclaration
+     *
+     * @group TypeDeclarations
+     *
+     * @dataProvider dataTypeDeclaration
+     *
+     * @param int  $line            Line number on which to expect an error.
+     * @param bool $testNoViolation Whether or not to test noViolation for PHP 5.0.
+     *                              This covers the remaining few cases not covered
+     *                              by the above tests.
+     *
+     * @return void
+     */
+    public function testTypeDeclaration($line, $testNoViolation = false)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '4.4');
+        $this->assertError($file, $line, 'Type hints were not present in PHP 4.4 or earlier');
+
+        if ($testNoViolation === true) {
+            $file = $this->sniffFile(self::TEST_FILE, '5.0');
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testTypeDeclaration()
+     *
+     * @return array
+     */
+    public function dataTypeDeclaration()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(9),
+            array(13),
+            array(14),
+            array(15),
+            array(16),
+            array(20),
+            array(21),
+            array(24),
+            array(25),
+            array(29, true),
+            array(34, true),
+            array(37),
+            array(41, true),
+            array(44),
         );
     }
 }

--- a/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -1,9 +1,45 @@
 <?php
 
+// Array type declaration - PHP 5.1+
+function foo(array $a) {}
+function foo( array   $a ) {} // Test extra spacing.
+
+
+// Callable type declaration - PHP 5.4+
+function foo(callable $a) {}
+
+
+// Scalar type declarations - PHP 7.0+
 function foo(bool $a) {}
-
 function foo(int $a) {}
-
 function foo(float $a) {}
-
 function foo(string $a) {}
+
+
+// (Very likely) Invalid type declarations - will be treated as class/interface names.
+function foo(boolean $a) {}
+function foo(integer $a) {}
+
+class MyOtherClass extends MyClass {
+    function foo(parent $a) {}
+    function bar(static $a) {}
+}
+
+// Class/interface type declaration - PHP 5.0+
+function foo(stdClass $a) {}
+
+
+// Class/interface type declaration with self keyword - PHP 5.0+
+class MyClass {
+    function foo(self $a) {}
+}
+
+function foo(self $a) {} // Invalid - not within a class.
+
+namespace test {
+    class foo {
+        function foo(self $a) {}
+    }
+
+    function foo(self $a) {} // Invalid - not within a class.
+}

--- a/Tests/sniff-examples/utility-functions/in_class_scope.php
+++ b/Tests/sniff-examples/utility-functions/in_class_scope.php
@@ -1,0 +1,17 @@
+<?php
+
+$var = false;
+function something() {}
+
+class MyClass {
+    public $property;
+    function something() {}
+}
+
+namespace {
+    function something() {}
+
+    class MyClass {
+        function something() {}
+    }
+}


### PR DESCRIPTION
This adds a number of additional checks to the `NewScalarTypeDeclarations` sniff.
* Check that type hints are not being used in pre-PHP 5.0 code.
* Check for valid usage of the `array` and `callable` type  hints.
* Check for invalid type hints which are typical mistakes.
* Check that the `self` type hint is only used within the class scope.

Ref: http://php.net/functions.arguments#functions.arguments.type-declaration

Also:
* The `description` key in the `$newTypes` array did not actually add any value, so I've removed it.
* Minor tweaks to the original error message text.
  - Was along the lines of: _"int type is not present in PHP version 5.6 or earlier"_.
  - Now: _"'int' type declaration is not present in PHP version 5.6 or earlier"_.

Includes unit tests covering all changes.

This PR also adds two new utility methods to the abstract `PHPCompatibility_Sniff` class.
One is a copy of an existing method from PHPCS with some minor tweaks which have been send in as a [PR to PHPCS](https://github.com/squizlabs/PHP_CodeSniffer/pull/1117). That PR is expected to be merged for the 2.7.0 release. Unit tests for this method are available within the PHPCS test suite.
The other is a new PHPCompatibility native method `inClassScope()` and is accompanied by unit tests for the method.

Similarly to an earlier PR, the file/sniff name does now no longer cover what the sniff actually does. File and sniff renaming advised.