### PR TITLE
Add new sniff to check for NewExecutionDirectives.

### DIFF
--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * A list of new execution directives
+     *
+     * The array lists : version number with false (not present) or true (present).
+     * If the execution order is conditional, add the condition as a string to the version nr.
+     * If's sufficient to list the first version where the execution directive appears.
+     *
+     * @var array(string => array(string => int|string|null))
+     */
+    protected $newDirectives = array (
+                                'ticks' => array(
+                                    '3.1' => false,
+                                    '4.0' => true,
+                                    'valid_value_callback' => 'isNumeric',
+                                ),
+                                'encoding' => array(
+                                    '5.2' => false,
+                                    '5.3' => '--enable-zend-multibyte', // Directive ignored unless.
+                                    '5.4' => true,
+                                    'valid_value_callback' => 'validEncoding',
+                                ),
+                                'strict_types' => array(
+                                    '5.6' => false,
+                                    '7.0' => true,
+                                    'valid_values' => array(1),
+                                ),
+                               );
+
+
+    /**
+     * Tokens to ignore when trying to find the value for the directive.
+     *
+     * @var array
+     */
+    protected $ignoreTokens = array();
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $this->ignoreTokens          = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->ignoreTokens[T_EQUAL] = T_EQUAL;
+
+        return array(T_DECLARE);
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === true) {
+	        $openParenthesis  = $tokens[$stackPtr]['parenthesis_opener'];
+	        $closeParenthesis = $tokens[$stackPtr]['parenthesis_closer'];
+        }
+        else {
+	        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '>=')) {
+				return;
+			}
+
+			// Deal with PHPCS 1.x which does not set the parenthesis properly for declare statements.
+			$openParenthesis = $phpcsFile->findNext(T_OPEN_PARENTHESIS, ($stackPtr + 1), null, false, null, true);
+			if ($openParenthesis === false || isset($tokens[$openParenthesis]['parenthesis_closer']) === false) {
+				return;
+			}
+			$closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
+		}
+
+        $directivePtr = $phpcsFile->findNext(T_STRING, ($openParenthesis + 1), $closeParenthesis, false);
+        if ($directivePtr === false) {
+            return;
+        }
+
+        $directiveContent = $tokens[$directivePtr]['content'];
+
+        if (isset($this->newDirectives[$directiveContent]) === false) {
+            $error = 'Declare can only be used with the directives %s. Found: %s';
+            $data  = array(
+                implode(', ', array_keys($this->newDirectives)),
+                $directiveContent,
+            );
+            $phpcsFile->addError($error, $stackPtr, 'InvalidDirectiveFound', $data);
+        }
+        else {
+            // Check for valid directive for version.
+            $this->maybeAddError($phpcsFile, $stackPtr, $directiveContent);
+
+            // Check for valid directive value.
+            $valuePtr = $phpcsFile->findNext($this->ignoreTokens, $directivePtr + 1, $closeParenthesis, true);
+            if ($valuePtr === false) {
+                return;
+            }
+
+            $this->addErrorOnInvalidValue($phpcsFile, $valuePtr, $directiveContent);
+        }
+
+    }//end process()
+
+
+    /**
+     * Generates a error or warning for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the declare statement
+     *                                        in the token array.
+     * @param string               $directive The directive.
+     *
+     * @return void
+     */
+    protected function maybeAddError($phpcsFile, $stackPtr, $directive)
+    {
+        $isError            = false;
+        $notInVersion       = '';
+        $conditionalVersion = '';
+        foreach ($this->newDirectives[$directive] as $version => $present) {
+            if (strpos($version, 'valid_') === false && $this->supportsBelow($version)) {
+                if ($present === false) {
+                    $isError      = true;
+                    $notInVersion = $version;
+                }
+                else if (is_string($present)) {
+                    // We cannot test for compilation option (ok, except by scraping the output of phpinfo...).
+                    $conditionalVersion = $version;
+                }
+            }
+        }
+        if ($notInVersion !== '' || $conditionalVersion !== '') {
+            if ($isError === true && $notInVersion !== '') {
+                $error     = 'Directive %s is not present in PHP version %s or earlier';
+                $errorCode = $directive . 'Found';
+                $data      = array(
+                    $directive,
+                    $notInVersion,
+                );
+
+                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+            }
+            else if($conditionalVersion !== '') {
+                $error     = 'Directive %s is present in PHP version %s but will be disregarded unless PHP is compiled with %s';
+                $errorCode = $directive . 'Found';
+                $data      = array(
+                    $directive,
+                    $conditionalVersion,
+                    $this->newDirectives[$directive][$conditionalVersion],
+                );
+
+                $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
+            }
+        }
+
+    }//end maybeAddError()
+
+
+    /**
+     * Generates a error or warning for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the execution directive value
+     *                                        in the token array.
+     * @param string               $directive The directive.
+     *
+     * @return void
+     */
+    protected function addErrorOnInvalidValue($phpcsFile, $stackPtr, $directive)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $value = $tokens[$stackPtr]['content'];
+        if ($tokens[$stackPtr]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+            $value = trim($value, '\'"');
+        }
+
+        $isError = false;
+        if (isset($this->newDirectives[$directive]['valid_values'])) {
+            if (in_array($value, $this->newDirectives[$directive]['valid_values']) === false) {
+                $isError = true;
+            }
+        }
+        else if (isset($this->newDirectives[$directive]['valid_value_callback'])) {
+            $valid = call_user_func(array($this, $this->newDirectives[$directive]['valid_value_callback']), $value);
+            if ($valid === false) {
+                $isError = true;
+            }
+        }
+
+        if ($isError === true) {
+            $error = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
+            $data  = array(
+                $directive,
+                $value,
+            );
+            $phpcsFile->addError($error, $stackPtr, 'InvalidDirectiveValueFound', $data);
+        }
+    }// addErrorOnInvalidValue()
+
+
+    /**
+     * Check whether a value is numeric.
+     *
+     * Callback function to test whether the value for an execution directive is valid.
+     *
+     * @param mixed $value The value to test.
+     *
+     * @return bool
+     */
+    protected function isNumeric($value)
+    {
+        return is_numeric($value);
+    }
+
+
+    /**
+     * Check whether a value is valid encoding.
+     *
+     * Callback function to test whether the value for an execution directive is valid.
+     *
+     * @param mixed $value The value to test.
+     *
+     * @return bool
+     */
+    protected function validEncoding($value)
+    {
+        $encodings = array();
+        if (function_exists('mb_list_encodings')) {
+            $encodings = mb_list_encodings();
+        }
+
+        if (empty($encodings)) {
+            // If we can't test the encoding, let it pass through.
+            return true;
+        }
+
+        if (in_array($value, $encodings, true)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+}//end class

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * New execution directives test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New execution directives test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewExecutionDirectivesSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_execution_directives.php';
+
+    /**
+     * Sniffed file
+     *
+     * @var PHP_CodeSniffer_File
+     */
+    protected $_sniffFile;
+
+    /**
+     * setUp
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->_sniffFile = $this->sniffFile(self::TEST_FILE);
+    }
+
+    /**
+     * testNewExecutionDirective
+     *
+     * @group newExecutionDirectives
+     *
+     * @dataProvider dataNewExecutionDirective
+     *
+     * @param string $directive          Name of the execution directive.
+     * @param string $lastVersionBefore  The PHP version just *before* the directive was introduced.
+     * @param array  $lines              The line numbers in the test file where the error should occur.
+     * @param string $okVersion          A PHP version in which the directive was ok to be used.
+     * @param string $conditionalVersion Optional. A PHP version in which the directive was conditionaly available.
+     * @param string $condition          The availability condition.
+     *
+     * @return void
+     */
+    public function testNewExecutionDirective($directive, $lastVersionBefore, $lines, $okVersion, $conditionalVersion = null, $condition = null)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, "Directive {$directive} is not present in PHP version {$lastVersionBefore} or earlier");
+        }
+
+        if (isset($conditionalVersion, $condition)) {
+            $file = $this->sniffFile(self::TEST_FILE, $conditionalVersion);
+            foreach ($lines as $line) {
+                $this->assertWarning($file, $line, "Directive {$directive} is present in PHP version {$conditionalVersion} but will be disregarded unless PHP is compiled with {$condition}");
+            }
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewExecutionDirectivs()
+     *
+     * @return array
+     */
+    public function dataNewExecutionDirective()
+    {
+        return array(
+            array('ticks', '3.1', array(6, 7), '4.0'),
+            array('encoding', '5.2', array(8), '5.4', '5.3', '--enable-zend-multibyte'),
+            array('strict_types', '5.6', array(9), '7.0'),
+        );
+    }
+
+
+    /**
+     * testInvalidDirectiveValue
+     *
+     * @group newExecutionDirectives
+     *
+     * @dataProvider dataInvalidDirectiveValue
+     *
+     * @param string $directive Name of the execution directive.
+     * @param string $value     The value.
+     * @param int    $line      Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testInvalidDirectiveValue($directive, $value, $line)
+    {
+        $this->assertError($this->_sniffFile, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
+    }
+
+    /**
+     * dataInvalidDirectiveValue
+     *
+     * @see testInvalidDirectiveValue()
+     *
+     * @return array
+     */
+    public function dataInvalidDirectiveValue() {
+        return array(
+            array('ticks', 'TICK_VALUE', 16),
+            array('strict_types', 'false', 18),
+        );
+    }
+
+
+    /**
+     * testInvalidEncodingDirectiveValue
+     *
+     * @group newExecutionDirectives
+     *
+     * @requires function mb_list_encodings
+     *
+     * @dataProvider dataInvalidEncodingDirectiveValue
+     *
+     * @param string $directive Name of the execution directive.
+     * @param string $value     The value.
+     * @param int    $line      Line number where the error should occur.
+     *
+     * @return void
+     */
+    public function testInvalidEncodingDirectiveValue($directive, $value, $line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
+    }
+
+    /**
+     * dataInvalidEncodingDirectiveValue
+     *
+     * @see testInvalidEncodingDirectiveValue()
+     *
+     * @return array
+     */
+    public function dataInvalidEncodingDirectiveValue() {
+        return array(
+            array('encoding', 'invalid', 17),
+        );
+    }
+
+
+    /**
+     * testInvalidDirective
+     *
+     * @group newExecutionDirectives
+     *
+     * @return void
+     */
+    public function testInvalidDirective()
+    {
+        $this->assertError($this->_sniffFile, 22, 'Declare can only be used with the directives ticks, encoding, strict_types. Found: invalid');
+    }
+
+
+    /**
+     * testIncompleteDirective
+     *
+     * @group newExecutionDirectives
+     *
+     * @return void
+     */
+    public function testIncompleteDirective()
+    {
+        $this->assertNoViolation($this->_sniffFile, 25);
+    }
+
+}
+

--- a/Tests/sniff-examples/new_execution_directives.php
+++ b/Tests/sniff-examples/new_execution_directives.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * The below directives are valid.
+ */
+declare(ticks=1);
+declare ( ticks = 1 ) {} // Test with varying spacing.
+declare(encoding='ISO-8859-1');
+declare(strict_types=1) {
+    $var = false;
+}
+
+/*
+ * The below directives have invalid values.
+ */
+declare(ticks=TICK_VALUE); // Invalid - only literals may be given as directive values.
+declare(encoding='invalid'); // Invalid - not a valid encoding.
+declare(strict_types=false); // Invalid - only 1 is a valid value.
+
+
+// Invalid directive name.
+declare(invalid=true);
+
+// Incomplete directive.
+declare(


### PR DESCRIPTION
This sniff checks for valid execution directives set with `declare()`.
Ref: http://php.net/manual/en/control-structures.declare.php

The sniff contains three distinct checks:
* Check if the execution directive used is valid. PHP currently only supports three execution directives.
* Check if the execution directive used is available in the PHP versions for which support is being checked. In the case of the `encoding` directive on PHP 5.3, support is conditional on the `--enable-zend-multibyte` compilation option. This will be indicated as such.
* Check whether the value for the directive is valid.

Includes unit tests.