### PR TITLE
Improve `ForbiddenBreakContinueVariableArguments` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -19,6 +19,8 @@
  */
 class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/forbidden_break_continue_variable_argument.php';
+
     /**
      * Sniffed file
      *
@@ -35,72 +37,105 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
     {
         parent::setUp();
 
-        $this->_sniffFile = $this->sniffFile('sniff-examples/forbidden_break_continue_variable_argument.php');
-    }
-
-    /**
-     * Test break
-     *
-     * @return void
-     */
-    public function testBreakAndContinueAlone()
-    {
-        $this->assertNoViolation($this->_sniffFile, 6);
-        $this->assertNoViolation($this->_sniffFile, 10);
-    }
-
-    /**
-     * testBreakAndContinueWithInteger
-     *
-     * @return void
-     */
-    public function testBreakAndContinueWithInteger()
-    {
-        $this->assertNoViolation($this->_sniffFile, 18);
-        $this->assertNoViolation($this->_sniffFile, 22);
-    }
-
-    /**
-     * testBreakAndContinueWithVariable
-     *
-     * @return void
-     */
-    public function testBreakAndContinueWithVariable()
-    {
-        $this->assertError($this->_sniffFile, 32, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
-        $this->assertError($this->_sniffFile, 36, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
-
-    }
-
-    /**
-     * testBreakAndContinueWithFunction
-     *
-     * @return void
-     */
-    public function testBreakAndContinueWithFunction()
-    {
-        $this->assertError($this->_sniffFile, 45, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
-        $this->assertError($this->_sniffFile, 49, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
-
+        $this->_sniffFile = $this->sniffFile(self::TEST_FILE);
     }
 
 
     /**
-     * testBreakAndContinueWithConstant
+     * testAllowedBreakAndContinueVariableArgument
+     *
+     * In PHP 5.3, none of the statements should give an error.
+     *
+     * @group forbiddenBreakContinue
      *
      * @return void
      */
-    public function testBreakAndContinueWithConstant()
+    public function testAllowedBreakAndContinueVariableArgument()
     {
-        $this->assertNoViolation($this->_sniffFile, 58);
-        $this->assertNoViolation($this->_sniffFile, 62);
-    }
-
-    public function testSettingTestVersion()
-    {
-        $file = $this->sniffFile('sniff-examples/forbidden_break_continue_variable_argument.php', '5.3');
-
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file);
+    }
+
+
+    /**
+     * testBreakAndContinueVariableArgument
+     *
+     * @group forbiddenBreakContinue
+     *
+     * @dataProvider dataBreakAndContinueVariableArgument
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testBreakAndContinueVariableArgument($line)
+    {
+        $this->assertError($this->_sniffFile, $line, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testBreakAndContinueVariableArgument()
+     *
+     * @return array
+     */
+    public function dataBreakAndContinueVariableArgument()
+    {
+        return array(
+            array(53),
+            array(57),
+            array(62),
+            array(66),
+            array(71),
+            array(75),
+            array(80),
+            array(84),
+            array(89),
+            array(93),
+            array(98),
+            array(102),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group forbiddenBreakContinue
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $this->assertNoViolation($this->_sniffFile, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(8),
+            array(12),
+            array(17),
+            array(21),
+            array(26),
+            array(30),
+            array(35),
+            array(39),
+            array(44),
+            array(48),
+        );
     }
 }
 

--- a/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
+++ b/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
@@ -1,66 +1,106 @@
 <?php
 
-for ($i = 0; $i < 5; $i++) {
-
-    if ($i == 3) {
-        break;
-    }
-
-    if ($i < 7) {
-        continue;
-    }
-}
-
-for ($i = 0; $i < 5; $i++) {
+for ($i = 0; $i < 20; $i++) {
     for ($j = 0; $j < 5; $j++) {
 
-        if ($i == 3) {
+        // OK: Simple break/continue.
+        if ($i == 1) {
+            break;
+        }
+
+        if ($i < 20) {
+            continue;
+        }
+
+        // OK: Break/continue with integer.
+        if ($i == 2) {
             break 1;
         }
 
-        if ($i < 7) {
+        if ($i < 19) {
             continue 1;
         }
-    }
-}
 
-$num = 1;
-for ($i = 0; $i < 5; $i++) {
-    for ($j = 0; $j < 5; $j++) {
+        // OK: Break/continue with some random (namespaced) constant.
+        if ($i == 5) {
+            break E_WARNING; // Just some random constant.
+        }
 
+        if ($i < 16) {
+            continue \E_WARNING;
+        }
+
+        // OK: Break/continue with a calculation.
+        if ($i == 6) {
+            break (1 + 1);
+        }
+
+        if ($i < 15) {
+            continue (1 * 2);
+        }
+
+        // OK: Break/continue with cast and a (namespaced) constant.
+        if ($i == 9) {
+            break (int) MyNamespace\E_WARNING;
+        }
+
+        if ($i < 12) {
+            continue (int) E_WARNING;
+        }
+
+        // Bad: Break/continue with variable.
         if ($i == 3) {
-            break $num;
+            break $num; // Bad.
         }
 
-        if ($i < 7) {
-            continue $num;
+        if ($i < 18) {
+            continue $num; // Bad.
+        }
+
+        // Bad: Break/continue with function call.
+        if ($i == 4) {
+            break rand(); // Bad.
+        }
+
+        if ($i < 17) {
+            continue rand(); // Bad.
+        }
+
+        // Bad: Break/continue with a calculation using a variable.
+        if ($i == 7) {
+            break 1 + $num; // Bad.
+        }
+
+        if ($i < 14) {
+            continue 1 + $num; // Bad.
+        }
+
+        // Bad: Break/continue with a cast and a variable.
+        if ($i == 8) {
+            break (int) $i; // Bad.
+        }
+
+        if ($i < 13) {
+            continue (int) $i; // Bad.
+        }
+
+        // Bad: Break/continue with a closure.
+        if ($i == 10) {
+            break function () { return 1; }; // Bad.
+        }
+
+        if ($i < 11) {
+            continue function () { return 1; }; // Bad.
+        }
+
+        // Bad: Break/continue with a namespaced function call.
+        if ($i == 11) {
+            break MyNamespace\myFunction(); // Bad.
+        }
+
+        if ($i < 10) {
+            continue MyNamespace\myFunction(); // Bad.
         }
     }
 }
 
-for ($i = 0; $i < 5; $i++) {
-    for ($j = 0; $j < 5; $j++) {
-
-        if ($i == 3) {
-            break rand();
-        }
-
-        if ($i < 7) {
-            continue rand();
-        }
-    }
-}
-
-
-for ($i = 0; $i < 5; $i++) {
-    for ($j = 0; $j < 5; $j++) {
-
-        if ($i == 3) {
-            break E_WARNING; // just some random constant
-        }
-
-        if ($i < 7) {
-            continue E_WARNING;
-        }
-    }
-}


### PR DESCRIPTION
* Bug fix: Throw error on closures. Looks like the intend was for this to be implemented, but the reality was that it wasn't working.
* Break out of the `foreach()` as soon as we've determined there is an error, no need to go through the rest of the tokens.
* Bow out early if check is not applicable.
* Minor code simplification.
* Add a number of additional unit test cases & simplified the test case file.
* Reorganised the unit tests to data providers and moved the documentation for the various tests to the test case file.