### PR TITLE
Minor improvements `ForbiddenSwitchWithMultipleDefaultBlocks` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
@@ -20,20 +20,44 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniffTest extends BaseSniffTest
     /**
      * testForbiddenSwitchWithMultipleDefaultBlocks
      *
+     * @group forbiddenSwitchMultipleDefault
+     *
+     * @dataProvider dataForbiddenSwitchWithMultipleDefaultBlocks
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testForbiddenSwitchWithMultipleDefaultBlocks()
+    public function testForbiddenSwitchWithMultipleDefaultBlocks($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, 3, 'Switch statements can not have multiple default blocks since PHP 7.0');
+        $this->assertError($file, $line, 'Switch statements can not have multiple default blocks since PHP 7.0');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenSwitchWithMultipleDefaultBlocks()
+     *
+     * @return array
+     */
+    public function dataForbiddenSwitchWithMultipleDefaultBlocks()
+    {
+        return array(
+            array(3),
+            array(47),
+            array(56),
+        );
     }
 
 
     /**
      * testValidSwitchStatement
+     *
+     * @group forbiddenSwitchMultipleDefault
      *
      * @dataProvider dataValidSwitchStatement
      *

--- a/Tests/sniff-examples/forbidden_switch_with_multiple_default_blocks.php
+++ b/Tests/sniff-examples/forbidden_switch_with_multiple_default_blocks.php
@@ -43,3 +43,22 @@ switch ($foo) {
     default:
         echo "x\n";
 }
+
+switch ($something) {
+    case 1:
+    default:
+        break;
+    case 2:
+    default:
+        break;
+}
+
+switch ($something) {
+    case 1:
+        break;
+    case 2:
+        break;
+    default:
+    default:
+        break;
+}


### PR DESCRIPTION
* Determine whether or not a `default` belongs to this switch or to a nested switch based on token `level` attribute.
* Break out of the switch as soon as we've determined there is more than one `default` case. No need to continue walking through the rest of the switch code.
* Add two additional unit tests with case/fall through type code.
* As there are now more error cases, change the error test to a data provider.