### PR TITLE
Use upstream rule to check for methods using a double underscore.

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,5 +1,23 @@
 <?xml version="1.0"?>
 
 <ruleset name="PHPCompatibility">
- <description>Coding Standard that checks for PHP version compatibility.</description>
+    <description>Coding Standard that checks for PHP version compatibility.</description>
+
+    <!-- This rule covers checking for non-magic methods using __ prefix. -->
+    <!-- Covers part 2 of issue 64: https://github.com/wimg/PHPCompatibility/issues/64 -->
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps" />
+        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps" />
+    </rule>
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.MethodDoubleUnderscore">
+        <type>warning</type>
+        <!-- Original message: Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore -->
+        <message>Method name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use</message>
+    </rule>
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.FunctionDoubleUnderscore">
+        <type>warning</type>
+        <!-- Original message: Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore -->
+        <message>Function name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use</message>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
Relates to: https://github.com/wimg/PHPCompatibility/issues/64

> the sniff should report if there any class method that begin with a double-underscore but which are not one of the magic methods as defined by PHP, as these are reserved for future use. Their presence may result in code breakage in future PHP versions.

The upstream sniff covers this well and as this particular check does not need the `supportsAbove()` or `supportsBelow()` methods, there is no need to duplicate code maintenance efforts.