### PR TITLE
Improve `NonStaticMagicMethods` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -16,50 +16,73 @@
 class NonStaticMagicMethodsSniffTest extends BaseSniffTest
 {
     /**
-     * Sniffed file
+     * Whether or not traits will be recognized in PHPCS.
      *
-     * @var PHP_CodeSniffer_File
+     * @var bool
      */
-    protected $_sniffFile;
+    protected static $recognizesTraits = true;
+
 
     /**
-     * setUp
-     *
-     * @return void
+     * Set up skip condition.
      */
-    public function setUp()
+    public static function setUpBeforeClass()
     {
-        parent::setUp();
-
-        $this->_sniffFile = $this->sniffFile('sniff-examples/nonstatic_magic_methods.php');
+        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+            self::$recognizesTraits = false;
+        }
     }
 
 
     /**
-     * helperAssertNoViolation
+     * Get the correct test file.
      *
-     * @param int $line The line number.
+     * (@internal
+     * The test file has been split into two:
+     * - one covering classes and interfaces
+     * - one covering traits
      *
-     * @return void
+     * This is to avoid test failing because PHPCS 1.x gets confused about the scope
+     * openers/closers when run on PHP 5.3 or lower.
+     * In a 'normal' situation you won't often find classes, interfaces and traits all
+     * mixed in one file anyway, so this issue for which this is a work-around,
+     * should not cause real world issues anyway.}}
+     *
+     * @param bool $isTrait Whether to load the class/interface test file or the trait test file.
+     *
+     * @return PHP_CodeSniffer_File File object|false
      */
-    private function helperAssertNoViolation($line)
-    {
-        $this->assertNoViolation($this->_sniffFile, $line);
+    protected function getTestFile($isTrait) {
+        if ($isTrait === false) {
+            return $this->sniffFile('sniff-examples/nonstatic_magic_methods.php');
+        }
+        else {
+            return $this->sniffFile('sniff-examples/nonstatic_magic_methods_traits.php');
+        }
     }
-
 
     /**
      * testCorrectImplementation
      *
+     * @group MagicMethods
+     *
      * @dataProvider dataCorrectImplementation
      *
-     * @param int $line The line number.
+     * @param int  $line    The line number.
+     * @param bool $isTrait Whether to load the class/interface test file or the trait test file.
      *
      * @return void
      */
-    public function testCorrectImplementation($line)
+    public function testCorrectImplementation($line, $isTrait = false)
     {
-        $this->helperAssertNoViolation($line);
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait);
+        $this->assertNoViolation($file, $line);
     }
 
     /**
@@ -72,302 +95,289 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public function dataCorrectImplementation()
     {
         return array(
+            /*
+             * nonstatic_magic_methods.php
+             */
+            // Plain class.
             array(5),
             array(6),
             array(7),
             array(8),
             array(9),
-            array(14),
-            array(15),
-            array(16),
-            array(17),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            // Normal class.
             array(18),
             array(19),
-        );
-    }
-
-
-    /**
-     * testClassWithPrivateMagicMethods
-     *
-     * @dataProvider dataClassWithPrivateMagicMethods
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithPrivateMagicMethods($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithPrivateMagicMethods()
-     *
-     * @return array
-     */
-    public function dataClassWithPrivateMagicMethods()
-    {
-        return array(
+            array(20),
+            array(21),
+            array(22),
+            array(23),
             array(24),
             array(25),
             array(26),
             array(27),
-            array(28),
-        );
-    }
 
+            // Alternative property order & stacked.
+            array(58),
 
-    /**
-     * testClassWithProtectedMagicMethods
-     *
-     * @dataProvider dataClassWithProtectedMagicMethods
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithProtectedMagicMethods($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithProtectedMagicMethods()
-     *
-     * @return array
-     */
-    public function dataClassWithProtectedMagicMethods()
-    {
-        return array(
-            array(33),
-            array(34),
-            array(35),
-            array(36),
-            array(37),
-        );
-    }
-
-
-    /**
-     * testClassWithStaticMagicMethods
-     *
-     * @dataProvider dataClassWithStaticMagicMethods
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithStaticMagicMethods($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods cannot be static (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithStaticMagicMethods()
-     *
-     * @return array
-     */
-    public function dataClassWithStaticMagicMethods()
-    {
-        return array(
-            array(42),
-            array(43),
-            array(44),
-            array(45),
-            array(46),
-        );
-    }
-
-
-    /**
-     * testClassWithStaticPublicMagicMethod
-     *
-     * @dataProvider dataClassWithStaticPublicMagicMethod
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithStaticPublicMagicMethod($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods cannot be static (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithStaticPublicMagicMethod()
-     *
-     * @return array
-     */
-    public function dataClassWithStaticPublicMagicMethod()
-    {
-        return array(
-            array(51),
-            array(56),
-        );
-    }
-
-
-    /**
-     * testClassWithPrivateStaticMagicMethod
-     *
-     * @dataProvider dataClassWithPrivateStaticMagicMethod
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithPrivateStaticMagicMethod($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public and cannot be static (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithPrivateStaticMagicMethod()
-     *
-     * @return array
-     */
-    public function dataClassWithPrivateStaticMagicMethod()
-    {
-        return array(
-            array(61),
-            array(66),
-        );
-    }
-
-
-    /**
-     * testClassWithProtectedStaticMagicMethod
-     *
-     * @dataProvider dataClassWithProtectedStaticMagicMethod
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithProtectedStaticMagicMethod($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public and cannot be static (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithProtectedStaticMagicMethod()
-     *
-     * @return array
-     */
-    public function dataClassWithProtectedStaticMagicMethod()
-    {
-        return array(
+            // Plain interface.
             array(71),
+            array(72),
+            array(73),
+            array(74),
+            array(75),
             array(76),
-        );
-    }
-
-
-    /**
-     * testClassWithPrivateStaticMagicMethodAndWhitespace
-     *
-     * @dataProvider dataClassWithPrivateStaticMagicMethodAndWhitespace
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testClassWithPrivateStaticMagicMethodAndWhitespace($line)
-    {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public and cannot be static (since PHP 5.3)');
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testClassWithPrivateStaticMagicMethodAndWhitespace()
-     *
-     * @return array
-     */
-    public function dataClassWithPrivateStaticMagicMethodAndWhitespace()
-    {
-        return array(
-            array(83),
-        );
-    }
-
-
-    /**
-     * testCorrectInterface
-     *
-     * @dataProvider dataCorrectInterface
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testCorrectInterface($line)
-    {
-        $this->helperAssertNoViolation($line);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testCorrectInterface()
-     *
-     * @return array
-     */
-    public function dataCorrectInterface()
-    {
-        return array(
+            array(77),
+            array(78),
+            array(79),
+            // Normal interface.
+            array(84),
+            array(85),
+            array(86),
+            array(87),
+            array(88),
             array(89),
             array(90),
             array(91),
             array(92),
             array(93),
-            array(98),
-            array(99),
-            array(100),
-            array(101),
-            array(102),
-            array(103),
+
+            /*
+             * nonstatic_magic_methods_traits.php
+             */
+            // Plain trait.
+            array(5, true),
+            array(6, true),
+            array(7, true),
+            array(8, true),
+            array(9, true),
+            array(10, true),
+            array(11, true),
+            array(12, true),
+            array(13, true),
+            // Normal trait.
+            array(18, true),
+            array(19, true),
+            array(20, true),
+            array(21, true),
+            array(22, true),
+            array(23, true),
+            array(24, true),
+            array(25, true),
+            array(26, true),
+            array(27, true),
+
         );
     }
 
+
     /**
-     * testInterfaceWithPrivateMagicMethod
+     * testWrongMethodVisibility
      *
-     * @dataProvider dataInterfaceWithPrivateMagicMethod
+     * @group MagicMethods
      *
-     * @param int $line The line number.
+     * @dataProvider dataWrongMethodVisibility
+     *
+     * @param string $methodName        Method name.
+     * @param string $desiredVisibility The visibility the method should have.
+     * @param string $testVisibility    The visibility the method actually has in the test.
+     * @param int    $line              The line number.
+     * @param bool   $isTrait           Whether the test relates to method in a trait.
      *
      * @return void
      */
-    public function testInterfaceWithPrivateMagicMethod($line)
+    public function testWrongMethodVisibility($methodName, $desiredVisibility, $testVisibility, $line, $isTrait = false)
     {
-        $this->assertError($this->_sniffFile, $line, 'Magic methods must be public (since PHP 5.3)');
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait);
+        $this->assertError($file, $line, "Visibility for magic method {$methodName} must be {$desiredVisibility}. Found: {$testVisibility}");
     }
 
     /**
      * Data provider.
      *
-     * @see testInterfaceWithPrivateMagicMethod()
+     * @see testWrongMethodVisibility()
      *
      * @return array
      */
-    public function dataInterfaceWithPrivateMagicMethod()
+    public function dataWrongMethodVisibility()
     {
         return array(
-            array(109),
+            /*
+             * nonstatic_magic_methods.php
+             */
+            // Class.
+            array('__get', 'public', 'private', 32),
+            array('__set', 'public', 'protected', 33),
+            array('__isset', 'public', 'private', 34),
+            array('__unset', 'public', 'protected', 35),
+            array('__call', 'public', 'private', 36),
+            array('__callStatic', 'public', 'protected', 37),
+            array('__sleep', 'public', 'private', 38),
+            array('__toString', 'public', 'protected', 39),
+
+            // Alternative property order & stacked.
+            array('__set', 'public', 'protected', 56),
+            array('__isset', 'public', 'private', 57),
+            array('__get', 'public', 'private', 65),
+
+            // Interface.
+            array('__get', 'public', 'protected', 98),
+            array('__set', 'public', 'private', 99),
+            array('__isset', 'public', 'protected', 100),
+            array('__unset', 'public', 'private', 101),
+            array('__call', 'public', 'protected', 102),
+            array('__callStatic', 'public', 'private', 103),
+            array('__sleep', 'public', 'protected', 104),
+            array('__toString', 'public', 'private', 105),
+
+            /*
+             * nonstatic_magic_methods_traits.php
+             */
+            // Trait.
+            array('__get', 'public', 'private', 32, true),
+            array('__set', 'public', 'protected', 33, true),
+            array('__isset', 'public', 'private', 34, true),
+            array('__unset', 'public', 'protected', 35, true),
+            array('__call', 'public', 'private', 36, true),
+            array('__callStatic', 'public', 'protected', 37, true),
+            array('__sleep', 'public', 'private', 38, true),
+            array('__toString', 'public', 'protected', 39, true),
+
+        );
+    }
+
+
+    /**
+     * testWrongStaticMethod
+     *
+     * @group MagicMethods
+     *
+     * @dataProvider dataWrongStaticMethod
+     *
+     * @param string $methodName Method name.
+     * @param int    $line       The line number.
+     * @param bool   $isTrait    Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testWrongStaticMethod($methodName, $line, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait);
+        $this->assertError($file, $line, "Magic method {$methodName} cannot be defined as static.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testWrongStaticMethod()
+     *
+     * @return array
+     */
+    public function dataWrongStaticMethod()
+    {
+        return array(
+            /*
+             * nonstatic_magic_methods.php
+             */
+            // Class.
+            array('__get', 44),
+            array('__set', 45),
+            array('__isset', 46),
+            array('__unset', 47),
+            array('__call', 48),
+
+            // Alternative property order & stacked.
+            array('__get', 55),
+            array('__set', 56),
+            array('__isset', 57),
+            array('__get', 65),
+
+            // Interface.
+            array('__get', 110),
+            array('__set', 111),
+            array('__isset', 112),
+            array('__unset', 113),
+            array('__call', 114),
+
+            /*
+             * nonstatic_magic_methods_traits.php
+             */
+            // Trait.
+            array('__get', 44, true),
+            array('__set', 45, true),
+            array('__isset', 46, true),
+            array('__unset', 47, true),
+            array('__call', 48, true),
+
+        );
+    }
+
+
+    /**
+     * testWrongNonStaticMethod
+     *
+     * @group MagicMethods
+     *
+     * @dataProvider dataWrongNonStaticMethod
+     *
+     * @param string $methodName Method name.
+     * @param int    $line       The line number.
+     * @param bool   $isTrait    Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testWrongNonStaticMethod($methodName, $line, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait);
+        $this->assertError($file, $line, "Magic method {$methodName} must be defined as static.");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testWrongNonStaticMethod()
+     *
+     * @return array
+     */
+    public function dataWrongNonStaticMethod()
+    {
+        return array(
+            /*
+             * nonstatic_magic_methods.php
+             */
+            // Class.
+            array('__callStatic', 49),
+            array('__set_state', 50),
+
+            // Interface.
+            array('__callStatic', 115),
+            array('__set_state', 116),
+
+            /*
+             * nonstatic_magic_methods_traits.php
+             */
+            // Trait.
+            array('__callStatic', 49, true),
+            array('__set_state', 50, true),
+
         );
     }
 

--- a/Tests/sniff-examples/nonstatic_magic_methods.php
+++ b/Tests/sniff-examples/nonstatic_magic_methods.php
@@ -7,6 +7,10 @@ class Plain
     function __isset($name) {}
     function __unset($name) {}
     function __call($name, $arguments) {}
+    static function __callStatic($name, $arguments) {}
+    function __sleep() {}
+    function __toString() {}
+    static function __set_state($properties) {}
 }
 
 class Normal
@@ -17,63 +21,41 @@ class Normal
     public function __isset($name) {}
     public function __unset($name) {}
     public function __call($name, $arguments) {}
+    public static function __callStatic($name, $arguments) {}
+    public function __sleep() {}
+    public function __toString() {}
+    public static function __set_state($properties) {}
 }
 
-class TooPrivate
+class WrongVisibility
 {
     private function __get($name) {}
-    private function __set($name, $value) {}
-    private function __isset($name) {}
-    private function __unset($name) {}
-    private function __call($name, $arguments) {}
-}
-
-class TooProtected
-{
-    protected function __get($name) {}
     protected function __set($name, $value) {}
-    protected function __isset($name) {}
+    private function __isset($name) {}
     protected function __unset($name) {}
-    protected function __call($name, $arguments) {}
+    private function __call($name, $arguments) {}
+    protected static function __callStatic($name, $arguments) {}
+    private function __sleep() {}
+    protected function __toString() {}
 }
 
-class TooStatic
+class WrongStatic
 {
     static function __get($name) {}
     static function __set($name, $value) {}
     static function __isset($name) {}
     static function __unset($name) {}
     static function __call($name, $arguments) {}
+    function __callStatic($name, $arguments) {}
+    function __set_state($properties) {}
 }
 
-class TooStaticPublic
+class AlternativePropertyOrder
 {
-    static public function __get($name) {}
-}
-
-class TooPublicStatic
-{
-    public static function __get($name) {}
-}
-
-class TooStaticPrivate
-{
-    static private function __get($name) {}
-}
-
-class TooPrivateStatic
-{
-    private static function __get($name) {}
-}
-
-class TooStaticProtected
-{
-    static protected function __get($name) {}
-}
-
-class TooProtectedStatic
-{
-    protected static function __get($name) {}
+    static public function __get($name) {} // Bad: static.
+    static protected function __set($name, $value) {} // Bad: static & protected.
+    static private function __isset($name) {} // Bad: static & private.
+    static public function __callStatic($name, $arguments) {} // Ok.
 }
 
 class StackedStaticPrivate
@@ -91,6 +73,10 @@ interface PlainInterface
     function __isset($name);
     function __unset($name);
     function __call($name, $arguments);
+    static function __callStatic($name, $arguments);
+    function __sleep();
+    function __toString();
+    static function __set_state($properties);
 }
 
 interface NormalInterface
@@ -101,10 +87,31 @@ interface NormalInterface
     public function __isset($name);
     public function __unset($name);
     public function __call($name, $arguments);
+    public static function __callStatic($name, $arguments);
+    public function __sleep();
+    public function __toString();
+    public static function __set_state($properties);
 }
 
-interface TooPrivateInterface
+interface WrongVisibilityInterface
 {
-    private function getId();
-    private function __get($name);
+    protected function __get($name);
+    private function __set($name, $value);
+    protected function __isset($name);
+    private function __unset($name);
+    protected function __call($name, $arguments);
+    private static function __callStatic($name, $arguments);
+    protected function __sleep();
+    private function __toString();
+}
+
+interface WrongStaticInterface
+{
+    static function __get($name);
+    static function __set($name, $value);
+    static function __isset($name);
+    static function __unset($name);
+    static function __call($name, $arguments);
+    function __callStatic($name, $arguments);
+    function __set_state($properties);
 }

--- a/Tests/sniff-examples/nonstatic_magic_methods_traits.php
+++ b/Tests/sniff-examples/nonstatic_magic_methods_traits.php
@@ -1,0 +1,52 @@
+<?php
+
+trait PlainTrait
+{
+    function __get($name) {}
+    function __set($name, $value) {}
+    function __isset($name) {}
+    function __unset($name) {}
+    function __call($name, $arguments) {}
+    static function __callStatic($name, $arguments) {}
+    function __sleep() {}
+    function __toString() {}
+    static function __set_state($properties) {}
+}
+
+trait NormalTrait
+{
+    public function getId() {}
+    public function __get($name) {}
+    public function __set($name, $value) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public function __call($name, $arguments) {}
+    public static function __callStatic($name, $arguments) {}
+    public function __sleep() {}
+    public function __toString() {}
+    public static function __set_state($properties) {}
+}
+
+trait WrongVisibilityTrait
+{
+    private function __get($name) {}
+    protected function __set($name, $value) {}
+    private function __isset($name) {}
+    protected function __unset($name) {}
+    private function __call($name, $arguments) {}
+    protected static function __callStatic($name, $arguments) {}
+    private function __sleep() {}
+    protected function __toString() {}
+}
+
+trait WrongStaticTrait
+{
+    static function __get($name) {}
+    static function __set($name, $value) {}
+    static function __isset($name) {}
+    static function __unset($name) {}
+    static function __call($name, $arguments) {}
+    function __callStatic($name, $arguments) {}
+    function __set_state($properties) {}
+}
+


### PR DESCRIPTION
* Also sniff `trait`s for magic methods.
* Do the method name comparison in a case-insensitive manner as functions and methods in PHP are handled case-insensitively.
* Changed the array format to allow for checking visibility and static requirements based on the requirements of individual functions.
* Added a number of extra PHP magic methods to the array.

   _For `__sleep()` and `__toString()` only the visibility is explicitly documented, for `__set_state()` only the fact that it has to be static. So currently only checking the documented requirements._
* Added the `SoapClient` magic methods to the array.

   _It does not seem to be explicitly documented whether these have a requirement of being non-static, so that's currently not checked._
* For the `SoapClient` methods no extra check is made to verify whether or not the current class extends `SoapClient` as all methods with a double underscore prefix are reserved for PHP anyway.
* Defer to PHPCS native methods to determine the method name and properties.
* As the messages will be used now to enforce both 'must be static/public' as well as the opposite, changed the message format to be more flexible.
* Removed the _'(since PHP 5.3)'_ part of the error message.
* Removed the 'all-in-one' message as with the extra message flexibility, this would become a quite complex message to create. (Can be brought back if you think it's important to have it)
* Overhauled the unit tests to reflect the above changes.
* Added additional unit tests for traits and for the additional magic methods added (both PHP and SoapClient)

### Open questions

**Regarding the version check**:
As far as I know, the visibility and static requirements of these methods did not change in PHP 5.3. It's just that PHP started throwing warnings about it from that version upwards.
So I'm tempted to remove the check for PHP 5.3+ altogether. Opinions ?

**Regarding the specific property checks**:
* Anyone knows whether the `__sleep()` and `__toString()` method have a requirement to be non-static ?
* Anyone knows whether the `__set_state()` method has a visibility requirement ?
* Anyone knows whether the `SoapClient` magic methods have a requirement regarding them being static/non-static ? I believe these should all be non-static as the native class has them as non-static, but would like a second opinion.

----

Similar to other sniffs, the name of this sniff now no longer covers the functionality and the sniff should be renamed. I'd suggest `MagicMethodPropertyRequirements` as an alternative name.