### PR TITLE
Add newMagicMethods sniff.

### DIFF
--- a/Sniffs/PHP/NewMagicMethodsSniff.php
+++ b/Sniffs/PHP/NewMagicMethodsSniff.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff.
+ *
+ * Warns for non-magic behaviour of magic methods prior to becoming magic.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * A list of new magic methods, not considered magic in older versions.
+     *
+     * Method names in the array should be all *lowercase*.
+     * The array lists : version number with false (not magic) or true (magic).
+     * If's sufficient to list the first version where the method became magic.
+     *
+     * @var array(string => array(string => int|string|null))
+     */
+    protected $newMagicMethods = array(
+                               '__get' => array( // verified
+                                   '4.4' => false,
+                                   '5.0' => true,
+                               ),
+
+                               '__isset' => array( // verified
+                                   '5.0' => false,
+                                   '5.1' => true,
+                               ),
+                               '__unset' => array( // verified
+                                   '5.0' => false,
+                                   '5.1' => true,
+                               ),
+                               '__set_state' => array( // verified
+                                   '5.0' => false,
+                                   '5.1' => true,
+                               ),
+
+                               '__callstatic' => array( // verified
+                                   '5.2' => false,
+                                   '5.3' => true,
+                               ),
+                               '__invoke' => array( // verified
+                                   '5.2' => false,
+                                   '5.3' => true,
+                               ),
+
+                               '__debuginfo' => array( // verified
+                                   '5.5' => false,
+                                   '5.6' => true,
+                               ),
+
+                               // Special case - only became properly magical in 5.2.0,
+                               // before that it was only called for echo and print.
+                               '__tostring' => array(
+                                   '5.1' => false,
+                                   '5.2' => true,
+                                   'message' => 'The method %s() was not truly magical in PHP version %s and earlier. The associated magic functionality will only be called when directly combined with echo or print.',
+                               ),
+                              );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_FUNCTION);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $functionName   = $phpcsFile->getDeclarationName($stackPtr);
+        $functionNameLc = strtolower($functionName);
+
+        if (isset($this->newMagicMethods[$functionNameLc]) === false) {
+            return;
+        }
+
+        if ($this->inClassScope($phpcsFile, $stackPtr, false) === false) {
+            return;
+        }
+
+        $lastVersionBelow = '';
+        foreach ($this->newMagicMethods[$functionNameLc] as $version => $magic) {
+            if ($version !== 'message' && $magic === false && $this->supportsBelow($version)) {
+                $lastVersionBelow = $version;
+            }
+        }
+
+        if ($lastVersionBelow !== '') {
+            $error = 'The method %s() was not magical in PHP version %s and earlier. The associated magic functionality will not be invoked.';
+            if (empty($this->newMagicMethods[$functionNameLc]['message']) === false) {
+                $error = $this->newMagicMethods[$functionNameLc]['message'];
+            }
+
+            $data  = array(
+                $functionName,
+                $lastVersionBelow,
+            );
+
+            $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
+        }
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * New Magic Methods Sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New Magic Methods Sniff tests.
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewMagicMethodsSniffTest extends BaseSniffTest
+{
+    /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+            self::$recognizesTraits = false;
+        }
+    }
+
+
+    /**
+     * Get the correct test file.
+     *
+     * (@internal
+     * The test file has been split into two:
+     * - one covering classes and interfaces
+     * - one covering traits
+     *
+     * This is to avoid test failing because PHPCS 1.x gets confused about the scope
+     * openers/closers when run on PHP 5.3 or lower.
+     * In a 'normal' situation you won't often find classes, interfaces and traits all
+     * mixed in one file anyway, so this issue for which this is a work-around,
+     * should not cause real world issues anyway.}}
+     *
+     * @param bool   $isTrait     Whether to load the class/interface test file or the trait test file.
+     * @param string $testVersion Value of 'testVersion' to set on PHPCS object.
+     *
+     * @return PHP_CodeSniffer_File File object|false
+     */
+    protected function getTestFile($isTrait, $testVersion = null) {
+        if ($isTrait === false) {
+            return $this->sniffFile('sniff-examples/new_magic_methods.php', $testVersion);
+        }
+        else {
+            return $this->sniffFile('sniff-examples/new_magic_methods_traits.php', $testVersion);
+        }
+    }
+
+
+    /**
+     * Test magic methods that shouldn't be flagged by this sniff.
+     *
+     * @group newMagicMethods
+     *
+     * @dataProvider dataMagicMethodsThatShouldntBeFlagged
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testMagicMethodsThatShouldntBeFlagged($line)
+    {
+        $file = $this->getTestFile(false, '5.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMagicMethodsThatShouldntBeFlagged()
+     *
+     * @return array
+     */
+    public function dataMagicMethodsThatShouldntBeFlagged() {
+        return array(
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+        );
+    }
+
+
+    /**
+     * testNewMagicMethod
+     *
+     * @group newMagicMethods
+     *
+     * @dataProvider dataNewMagicMethod
+     *
+     * @param string $methodName        Name of the method.
+     * @param string $lastVersionBefore The PHP version just *before* the method became magic.
+     * @param array  $lines             The line numbers in the test file which apply to this method.
+     * @param string $okVersion         A PHP version in which the method was magic.
+     * @param bool   $isTrait           Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testNewMagicMethod($methodName, $lastVersionBefore, $lines, $okVersion, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait, $lastVersionBefore);
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.");
+        }
+
+        $file = $this->getTestFile($isTrait, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewMagicMethod()
+     *
+     * @return array
+     */
+    public function dataNewMagicMethod() {
+        return array(
+            // new_magic_methods.php
+            array('__get', '4.4', array(22, 34), '5.0'),
+            array('__isset', '5.0', array(23, 35), '5.1'),
+            array('__unset', '5.0', array(24, 36), '5.1'),
+            array('__set_state', '5.0', array(25, 37), '5.1'),
+            array('__callStatic', '5.2', array(27, 39), '5.3'),
+            array('__invoke', '5.2', array(28, 40), '5.3'),
+
+            // new_magic_methods_traits.php
+            array('__get', '4.4', array(5), '5.0', true),
+            array('__isset', '5.0', array(6), '5.1', true),
+            array('__unset', '5.0', array(7), '5.1', true),
+            array('__set_state', '5.0', array(8), '5.1', true),
+            array('__callStatic', '5.2', array(10), '5.3', true),
+            array('__invoke', '5.2', array(11), '5.3', true),
+        );
+    }
+
+
+    /**
+     * testNewDebugInfo
+     *
+     * {@internal Separate test for __debugInfo() as the noViolation check needs a wrapper
+	 * for PHPCS 2.5.1 as the Naming Convention sniff in PHPCS < 2.5.1 does not recognize
+	 * __debugInfo() yet, causing the noViolation sniff to fail.
+     *
+     * @group newMagicMethods
+     *
+     * @dataProvider dataNewDebugInfo
+     *
+     * @param string $methodName        Name of the method.
+     * @param string $lastVersionBefore The PHP version just *before* the method became magic.
+     * @param array  $lines             The line numbers in the test file which apply to this method.
+     * @param string $okVersion         A PHP version in which the method was magic.
+     * @param bool   $isTrait           Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testNewDebugInfo($methodName, $lastVersionBefore, $lines, $okVersion, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait, $lastVersionBefore);
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.");
+        }
+
+		if (version_compare(PHP_CodeSniffer::VERSION, '2.5.1', '>=')) {
+	        $file = $this->getTestFile($isTrait, $okVersion);
+	        foreach ($lines as $line) {
+	            $this->assertNoViolation($file, $line);
+	        }
+		}
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewDebugInfo()
+     *
+     * @return array
+     */
+    public function dataNewDebugInfo() {
+        return array(
+            // new_magic_methods.php
+            array('__debugInfo', '5.5', array(29, 41), '5.6'),
+
+            // new_magic_methods_traits.php
+            array('__debugInfo', '5.5', array(12), '5.6', true),
+        );
+    }
+
+
+    /**
+     * testChangedToStringMethod
+     *
+     * @group newMagicMethods
+     *
+     * @dataProvider dataChangedToStringMethod
+     *
+     * @param int  $line    The line number.
+     * @param bool $isTrait Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testChangedToStringMethod($line, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait, '5.1');
+        $this->assertWarning($file, $line, "The method __toString() was not truly magical in PHP version 5.1 and earlier. The associated magic functionality will only be called when directly combined with echo or print.");
+
+        $file = $this->getTestFile($isTrait, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testChangedToStringMethod()
+     *
+     * @return array
+     */
+    public function dataChangedToStringMethod() {
+        return array(
+            // new_magic_methods.php
+            array(26),
+            array(38),
+
+            // new_magic_methods_traits.php
+            array(9, true),
+        );
+    }
+
+}

--- a/Tests/sniff-examples/new_magic_methods.php
+++ b/Tests/sniff-examples/new_magic_methods.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * These magic methods should not be flagged. Introduced prior to PHP 5.
+ */
+class MyOkClass
+{
+    public function __construct() {}
+    public function __destruct() {}
+    public function __call($name, $arguments) {}
+    public function __set($name, $value) {}
+    public function __sleep() {}
+    public function __wakeup() {}
+    public function __clone() {}
+}
+
+/**
+ * These magic methods should all be flagged.
+ */
+class MyClass
+{
+    public function __get($name) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public static function __set_state($properties) {}
+    public function __toString() {}
+    public static function __callStatic($name, $arguments) {}
+    public function __invoke($x) {}
+    public function __debugInfo() {}
+}
+
+interface MyInterface
+{
+    public function __get($name);
+    public function __isset($name);
+    public function __unset($name);
+    public static function __set_state($properties);
+    public function __toString();
+    public static function __callStatic($name, $arguments);
+    public function __invoke($x);
+    public function __debugInfo();
+}

--- a/Tests/sniff-examples/new_magic_methods_traits.php
+++ b/Tests/sniff-examples/new_magic_methods_traits.php
@@ -1,0 +1,13 @@
+<?php
+
+trait MyTrait
+{
+    public function __get($name) {}
+    public function __isset($name) {}
+    public function __unset($name) {}
+    public static function __set_state($properties) {}
+    public function __toString() {}
+    public static function __callStatic($name, $arguments) {}
+    public function __invoke($x) {}
+    public function __debugInfo() {}
+}


### PR DESCRIPTION
Closes #64.

This sniff checks for the definition of magic methods and warns that their magic behaviour will not be invoked prior to the version it was introduced in.

For the `__toString()`  method it has a distinct message which describes the changed behaviour of the magic method between PHP 5.1 and 5.2

Includes unit tests.
Similar to PR #174, the unit test cases are split into two files - one covering classes and interfaces, one covering traits. The trait related unit tests will be skipped on PHPCS 1.x combined with PHP 5.3 or lower.