### PR TITLE
Add new sniff to detect Late Static Binding.

### DIFF
--- a/Sniffs/PHP/LateStaticBindingSniff.php
+++ b/Sniffs/PHP/LateStaticBindingSniff.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STATIC);
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        if ($nextNonEmpty === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[$nextNonEmpty]['code'] !== T_DOUBLE_COLON) {
+            return;
+        }
+
+        $inClass = $this->inClassScope($phpcsFile, $stackPtr, false);
+
+        if ($inClass === true && $this->supportsBelow('5.2') === true) {
+            $error = 'Late static binding is not supported in PHP 5.2 or earlier.';
+            $phpcsFile->addError($error, $stackPtr, 'Found');
+        }
+
+        if ($inClass === false) {
+            $error = 'Late static binding is not supported outside of class scope.';
+            $phpcsFile->addError($error, $stackPtr, 'OutsideClassScope');
+        }
+
+    }//end process()
+
+
+}//end class

--- a/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
+++ b/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Late static binding sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Late static binding sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class LateStaticBindingSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/late_static_binding.php';
+
+    /**
+     * testLateStaticBinding
+     *
+     * @group lateStaticBinding
+     *
+     * @dataProvider dataLateStaticBinding
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testLateStaticBinding($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertError($file, $line, 'Late static binding is not supported in PHP 5.2 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testLateStaticBinding()
+     *
+     * @return array
+     */
+    public function dataLateStaticBinding()
+    {
+        return array(
+            array(8),
+            array(9),
+        );
+    }
+
+
+    /**
+     * testLateStaticBindingOutsideClassScope
+     *
+     * @group lateStaticBinding
+     *
+     * @dataProvider dataLateStaticBindingOutsideClassScope
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testLateStaticBindingOutsideClassScope($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertError($file, $line, 'Late static binding is not supported outside of class scope.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testLateStaticBindingOutsideClassScope()
+     *
+     * @return array
+     */
+    public function dataLateStaticBindingOutsideClassScope()
+    {
+        return array(
+            array(19),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group lateStaticBinding
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(7),
+            array(12),
+            array(15),
+            array(16),
+        );
+    }
+}

--- a/Tests/sniff-examples/late_static_binding.php
+++ b/Tests/sniff-examples/late_static_binding.php
@@ -1,0 +1,19 @@
+<?php
+
+class LateStatic {
+    private $bar;
+
+    public function test() {
+        self::foo(); // Ok.
+        static::foo(); // Late static binding.
+        echo static::$bar; // Late static binding.
+    }
+
+    public static function foo() {} // Ok.
+}
+
+static function testing() { // Ok.
+    static $var; //Ok.
+}
+
+static::testing(); // Bad. Outside class scope.


### PR DESCRIPTION
Late static binding is only available on PHP 5.3 +.
Ref: http://php.net/manual/en/language.oop5.late-static-bindings.php

This sniff throws two new errors:
1. For LSB detected inside class/interface/trait scope and PHP < 5.3.
2. For LSB detected outside of class/interface/trait scope (not supported).

Includes unit tests.