### PR TITLE
Minor improvements to the `ForbiddenFunctionParametersWithSameName` sniff (code review).

### DIFF
--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -45,24 +45,33 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0')) {
-            $tokens = $phpcsFile->getTokens();
-            $token  = $tokens[$stackPtr];
-            // Skip function without body.
-            if (isset($token['scope_opener']) === false) {
-                return;
-            }
-
-            // Get all parameters from method signature.
-            $paramNames = array();
-            foreach ($phpcsFile->getMethodParameters($stackPtr) as $param) {
-                $paramNames[] = strtolower($param['name']);
-            }
-
-            if (count($paramNames) != count(array_unique($paramNames))) {
-                $phpcsFile->addError('Functions can not have multiple parameters with the same name since PHP 7.0', $stackPtr);
-            }
+        if ($this->supportsAbove('7.0') === false) {
+            return;
         }
+
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+        // Skip function without body.
+        if (isset($token['scope_opener']) === false) {
+            return;
+        }
+
+        // Get all parameters from method signature.
+        $parameters = $phpcsFile->getMethodParameters($stackPtr);
+        if (empty($parameters) || is_array($parameters) === false) {
+            return;
+        }
+
+
+        $paramNames = array();
+        foreach ($parameters as $param) {
+            $paramNames[] = strtolower($param['name']);
+        }
+
+        if (count($paramNames) != count(array_unique($paramNames))) {
+            $phpcsFile->addError('Functions can not have multiple parameters with the same name since PHP 7.0', $stackPtr);
+        }
+
     }//end process()
 
 }//end class

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -13,10 +13,12 @@
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
  */
-class ForbiddenForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
+class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
 {
     /**
      * testSettingTestVersion
+     *
+     * @group forbiddenFunctionParamsSameName
      *
      * @return void
      */


### PR DESCRIPTION
* Don't use function call in loop construct.
* `getMethodParameters()` could return false or an empty array. Bow out early in that case.