### PR TITLE
Improve `ParameterShadowSuperGlobals` sniff (code review).

### DIFF
--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -11,9 +11,12 @@
  * @author     Declan Kelly <declankelly90@gmail.com>
  * @copyright  2015 Declan Kelly
  */
-class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff implements PHP_CodeSniffer_Sniff {
+class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCompatibility_Sniff
+{
     /**
      * List of superglobals as an array of strings.
+     *
+     * @var array
      */
     protected $superglobals = array(
         '$GLOBALS',
@@ -28,12 +31,14 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff implements PH
     );
 
     /**
-     * Returns array of tokens, in this case array containing
-     * T_FUNCTION
+     * Register the tokens to listen for.
      *
      * @return array
      */
     public function register() {
+        // Prepare for case-insensitive compare.
+        $this->superglobals = array_map('strtolower', $this->superglobals);
+
         return array(T_FUNCTION);
     }
 
@@ -46,26 +51,24 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff implements PH
      * @return void
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {
-        if (
-            is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-            ||
-            (
-                !is_null(PHP_CodeSniffer::getConfigData('testVersion'))
-                &&
-                version_compare(PHP_CodeSniffer::getConfigData('testVersion'), '5.4') >= 0
-            )
-        ) {
-            $tokens = $phpcsFile->getTokens();
-            $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
-            $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
+        if ($this->supportsAbove('5.4') === false) {
+            return;
+        }
 
-            for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
-                $variable = $tokens[$i]['content'];
-                if (in_array($variable, $this->superglobals)) {
-                    $phpcsFile->addError("Parameter shadowing super global ($variable) causes fatal error since PHP 5.4", $i);
-                }
+        // Get all parameters from function signature.
+        $parameters = $phpcsFile->getMethodParameters($stackPtr);
+        if (empty($parameters) || is_array($parameters) === false) {
+            return;
+        }
+
+        foreach ($parameters as $param) {
+            $paramNameLc = strtolower($param['name']);
+
+            if (in_array($paramNameLc, $this->superglobals, true)) {
+                $error = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
+                $data  = array($param['name']);
+                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
             }
-
         }
     }
 }

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * ParameterShadowSuperGlobalsSniffTest
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * ParameterShadowSuperGlobalsSniffTest
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/parameter_shadow_superglobals.php';
+
+    /**
+     * testParameterShadowSuperGlobals
+     *
+     * @group parameterShadowSuperGlobals
+     *
+     * @dataProvider dataParameterShadowSuperGlobals
+     *
+     * @param int    $line  Line number where the error should occur.
+     * @param string $octal (Start of) Binary number as a string.
+     * @param bool   $testNoViolation Whether or not to test for noViolation.
+     *               Defaults to true. Set to false if another error is
+     *               expected on the same line (invalid binary)
+     *
+     * @return void
+     */
+    public function testParameterShadowSuperGlobal($superglobal, $line)
+    {
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, "Parameter shadowing super global ({$superglobal}) causes fatal error since PHP 5.4");
+    }
+
+    /**
+     * dataParameterShadowSuperGlobals
+     *
+     * @see testParameterShadowSuperGlobals()
+     *
+     * @return array
+     */
+    public function dataParameterShadowSuperGlobals() {
+        return array(
+            array('$GLOBALS', 4),
+            array('$_SERVER', 5),
+            array('$_GET', 6),
+            array('$_POST', 7),
+            array('$_FILES', 8),
+            array('$_COOKIE', 9),
+            array('$_SESSION', 10),
+            array('$_REQUEST', 11),
+            array('$_ENV', 12),
+            array('$globals', 15),
+            array('$_post', 16),
+        );
+    }
+
+
+    /**
+     * testValidParameter
+     *
+     * @group parameterShadowSuperGlobals
+     *
+     * @return void
+     */
+    public function testValidParameter() {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file , 19);
+    }
+
+}

--- a/Tests/sniff-examples/parameter_shadow_superglobals.php
+++ b/Tests/sniff-examples/parameter_shadow_superglobals.php
@@ -1,0 +1,19 @@
+<?php
+
+// These should all be flagged.
+function testingA( $GLOBALS ) {}
+function testingB( $_SERVER ) {}
+function testingC( $_GET ) {}
+function testingD( $_POST ) {}
+function testingE( $_FILES ) {}
+function testingF( $_COOKIE ) {}
+function testingG( $_SESSION ) {}
+function testingH( $_REQUEST ) {}
+function testingI( $_ENV ) {}
+
+// Test case-insensitive compare.
+function testingJ( $globals ) {}
+function testingK( $_post ) {}
+
+// This should be ok.
+function testingL( $POST ) {}


### PR DESCRIPTION
It seems this sniff was missed both when implementing the `PHPCompatibility_Sniff` base class as well as when the unit tests were added.
This PR fixes that.

Changes:
* Let class extend `PHPCompatibility_Sniff`.
* Use the `supportsAbove()` function for the compatibility check.
* Defer to the PHPCS native `getMethodParameters()` method for getting the parameter names.
* Do a case-insensitive parameter name compare. While variable names are case-insensitive in PHP, it would still be a really bad idea to bypass the "parameter shadowing super globals" issue by using a lowercase version of the variable name.
* Add unit tests.