### PR TITLE
Add sniff for detecting alternative PHP open tags.

### DIFF
--- a/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTags.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTags.
+ *
+ * Check for usage of alternative PHP tags - removed in PHP 7.0.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ *
+ * Based on `Generic_Sniffs_PHP_DisallowAlternativePHPTags` by Juliette Reinders Folmer
+ * which was merged into PHPCS 2.7.0.
+ */
+class PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Whether ASP tags are enabled or not.
+     *
+     * @var bool
+     */
+    private $_aspTags = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        if (version_compare(phpversion(), '7.0', '<') === true) {
+            $this->_aspTags = (boolean) ini_get('asp_tags');
+        }
+
+        return array(
+                T_OPEN_TAG,
+                T_OPEN_TAG_WITH_ECHO,
+                T_INLINE_HTML,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.0') === false) {
+            return;
+        }
+
+        $tokens  = $phpcsFile->getTokens();
+        $openTag = $tokens[$stackPtr];
+        $content = trim($openTag['content']);
+
+        if ($content === '' || $content === '<?php') {
+            return;
+        }
+
+        if ($openTag['code'] === T_OPEN_TAG || $openTag['code'] === T_OPEN_TAG_WITH_ECHO) {
+
+            if ($content === '<%' || $content === '<%=') {
+                $data = array(
+                    'ASP',
+                    $content,
+                );
+                $errorCode = 'ASPOpenTagFound';
+            }
+            else if (strpos($content, '<script ') !== false) {
+                $data = array(
+                    'Script',
+                    $content,
+                );
+                $errorCode = 'ScriptOpenTagFound';
+            }
+            else {
+                return;
+            }
+        }
+        // Account for incorrect script open tags.
+        // The "(?:<s)?" in the regex is to work-around a bug in the tokenizer in PHP 5.2.
+        else if ($openTag['code'] === T_INLINE_HTML
+            && preg_match('`((?:<s)?cript (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
+        ) {
+            $data = array(
+                'Script',
+                $match[1],
+            );
+            $errorCode = 'ScriptOpenTagFound';
+        }
+
+        if (isset($errorCode, $data)) {
+            $error = '%s style opening tags have been removed in PHP 7.0. Found "%s"';
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+            return;
+        }
+
+
+        // If we're still here, we can't be sure if what we find was really intended as ASP open tags.
+        if ($openTag['code'] === T_INLINE_HTML && $this->_aspTags === false) {
+            if (strpos($content, '<%') !== false) {
+                $error   = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: %s';
+                $snippet = $this->getSnippet($content, '<%');
+                $data    = array('<%'.$snippet);
+
+                $phpcsFile->addWarning($error, $stackPtr, 'MaybeASPOpenTagFound', $data);
+            }
+        }
+
+    }//end process()
+
+
+    /**
+     * Get a snippet from a HTML token.
+     *
+     * @param string $content  The content of the HTML token.
+     * @param string $start_at Partial string to use as a starting point for the snippet.
+     * @param int    $length   The target length of the snippet to get. Defaults to 25.
+     *
+     * @return string
+     */
+    protected function getSnippet($content, $start_at = '', $length = 25)
+    {
+        $start_pos = 0;
+
+        if ($start_at !== '') {
+            $start_pos = strpos($content, $start_at);
+            if ($start_pos !== false) {
+                $start_pos += strlen($start_at);
+            }
+        }
+
+        $snippet = substr($content, $start_pos, $length);
+        if ((strlen($content) - $start_pos) > $length) {
+            $snippet .= '...';
+        }
+
+        return $snippet;
+
+    }//end getSnippet()
+
+}//end class

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Removed alternative PHP tags sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Removed alternative PHP tags sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/removed_alternative_phptags.php';
+
+    /**
+     * Whether or not ASP tags are on.
+     *
+     * @var bool
+     */
+    protected static $aspTags = false;
+
+
+    /**
+     * Set up skip condition.
+     */
+    public static function setUpBeforeClass()
+    {
+        if (version_compare(phpversion(), '7.0', '<')) {
+            self::$aspTags = (boolean) ini_get('asp_tags');
+        }
+    }
+
+
+    /**
+     * testAlternativePHPTags
+     *
+     * @group alternativePHPTags
+     *
+     * @dataProvider dataAlternativePHPTags
+     *
+     * @param string $type    The type of opening tags, either ASP or Script.
+     * @param string $snippet The text string found.
+     * @param int    $line    The line number.
+     *
+     * @return void
+     */
+    public function testAlternativePHPTags($type, $snippet, $line)
+    {
+        if ($type === 'ASP' && self::$aspTags === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, $type . ' style opening tags have been removed in PHP 7.0. Found "' . $snippet . '"');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testAlternativePHPTags()
+     *
+     * @return array
+     */
+    public function dataAlternativePHPTags()
+    {
+        return array(
+            array('Script', '<script language="php">', 7),
+            array('Script', "<script language='php'>", 10),
+            array('Script', '<script type="text/php" language="php">', 13),
+            array('Script', "<script language='PHP' type='text/php'>", 16),
+            array('ASP', '<%', 21),
+            array('ASP', '<%', 22),
+            array('ASP', '<%=', 23),
+            array('ASP', '<%=', 24),
+        );
+    }
+
+
+    /**
+     * testMaybeASPOpenTag
+     *
+     * @group alternativePHPTags
+     *
+     * @dataProvider dataMaybeASPOpenTag
+     *
+     * @param int    $line    The line number.
+     * @param string $snippet Part of the text string found.
+     *
+     * @return void
+     */
+    public function testMaybeASPOpenTag($line, $snippet)
+    {
+        if (self::$aspTags === true) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertWarning($file, $line, 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: ' . $snippet);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMaybeASPOpenTag()
+     *
+     * @return array
+     */
+    public function dataMaybeASPOpenTag()
+    {
+        return array(
+            array(21, '<% echo $var; %>'),
+            array(22, '<% echo $var; %> and some m...'),
+            array(23, '<%= $var . \' and some more ...'),
+            array(24, '<%= $var %> and some more t...'),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group alternativePHPTags
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(3),
+        );
+    }
+}

--- a/Tests/sniff-examples/removed_alternative_phptags.php
+++ b/Tests/sniff-examples/removed_alternative_phptags.php
@@ -1,0 +1,26 @@
+<div>
+<!-- Ok. -->
+<?php echo $var; ?>
+Some content here.
+
+<!-- Bad. Script style open tags. -->
+<script language="php">
+echo $var;
+</script>
+<script language='php'>echo $var;</script>
+
+<!-- Bad. Invalid script style open tags. -->
+<script type="text/php" language="php">
+echo $var;
+</script>
+<script language='PHP' type='text/php'>
+echo $var;
+</script>
+
+<!-- Bad. ASP style open tags. -->
+<% echo $var; %>
+<p>Some text <% echo $var; %> and some more text</p>
+<%= $var . ' and some more text to make sure the snippet works'; %>
+<p>Some text <%= $var %> and some more text</p>
+
+</div>


### PR DESCRIPTION
ASP and Script open tags were removed in PHP 7.

Based on a similar sniff I wrote for PHPCS and WPCS, but adjusted to PHPCompatibility type of check.

Closes #127