### PR TITLE
Add new sniff to check for use of `empty()` with non-variable arguments.

### DIFF
--- a/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff.
+ *
+ * Verify that nothing but variables are passed to empty().
+ *
+ * PHP version 5.5
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * List of tokens to check against.
+     *
+     * @var array
+     */
+    protected $tokenBlackList = array();
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Set the token blacklist only once.
+        $this->tokenBlackList = array_unique(array_merge(
+            PHP_CodeSniffer_Tokens::$assignmentTokens,
+            PHP_CodeSniffer_Tokens::$equalityTokens,
+            PHP_CodeSniffer_Tokens::$comparisonTokens,
+            PHP_CodeSniffer_Tokens::$operators,
+            PHP_CodeSniffer_Tokens::$booleanOperators,
+            PHP_CodeSniffer_Tokens::$castTokens,
+            array(T_OPEN_PARENTHESIS, T_STRING_CONCAT)
+        ));
+
+        return array(T_EMPTY);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $open = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr, null, false, null, true);
+        if ($open === false || isset($tokens[$open]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $close = $tokens[$open]['parenthesis_closer'];
+
+        // If no variable at all was found, then it's definitely a no-no.
+        $hasVariable = $phpcsFile->findNext(T_VARIABLE, $open + 1, $close);
+        if ($hasVariable === false) {
+            $this->addError($phpcsFile, $stackPtr);
+            return;
+        }
+
+        // Check if the variable found is at the right level. Deeper levels are always an error.
+        if (isset($tokens[$open + 1]['nested_parenthesis'], $tokens[$hasVariable]['nested_parenthesis'])) {
+            $nestingLevel = count($tokens[$open + 1]['nested_parenthesis']);
+            if (count($tokens[$hasVariable]['nested_parenthesis']) !== $nestingLevel) {
+                $this->addError($phpcsFile, $stackPtr);
+                return;
+            }
+        }
+
+        // Ok, so the first variable is at the right level, now are there any
+        // blacklisted tokens within the empty() ?
+        $hasBadToken = $phpcsFile->findNext($this->tokenBlackList, $open + 1, $close);
+        if ($hasBadToken !== false) {
+            $this->addError($phpcsFile, $stackPtr);
+            return;
+        }
+    }
+
+
+    /**
+     * Add the error message.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function addError($phpcsFile, $stackPtr)
+    {
+        $error = 'Only variables can be passed to empty() prior to PHP 5.5.';
+        $phpcsFile->addError($error, $stackPtr, 'Found');
+    }
+}

--- a/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Empty with non variable sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Empty with non variable sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class EmptyNonVariableSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/empty_non_variable.php';
+
+    /**
+     * testEmptyNonVariable
+     *
+     * @group emptyNonVariable
+     *
+     * @dataProvider dataEmptyNonVariable
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testEmptyNonVariable($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, 'Only variables can be passed to empty() prior to PHP 5.5.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testEmptyNonVariable()
+     *
+     * @return array
+     */
+    public function dataEmptyNonVariable()
+    {
+        return array(
+            array(17),
+            array(18),
+
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+
+            array(25),
+            array(26),
+            array(27),
+            array(28),
+            array(29),
+            array(30),
+            array(31),
+            array(32),
+
+            array(34),
+            array(35),
+            array(37),
+            array(38),
+            array(39),
+            array(40),
+
+            array(42),
+            array(43),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group emptyNonVariable
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+        );
+    }
+}

--- a/Tests/sniff-examples/empty_non_variable.php
+++ b/Tests/sniff-examples/empty_non_variable.php
@@ -1,0 +1,46 @@
+<?php
+
+// These are ok.
+empty($variable);
+empty( $variable );
+empty($variable[1]);
+empty($variable['offset']);
+empty($variable[$offset]);
+empty(stdClass::$property);
+empty($myObject->property);
+empty($_GET['var']);
+empty(${$variable});
+empty(${$variable}->property);
+empty($variable /* this is fine*/ );
+
+// These should be all flagged.
+empty(($variable));
+empty(array($variable));
+
+empty(trim($name));
+empty(str_replace('_', '', $variable));
+empty($myObject->some_method($variable));
+empty(${$variable}->some_method());
+
+empty(SOME_CONSTANT);
+empty(null);
+empty(true);
+empty(123);
+empty(123.123);
+empty('');
+empty(array());
+empty(new stdClass);
+
+empty( (int) $variable );
+empty( $variable + 0 );
+empty( $variable . '' );
+empty( $variableA && $variableB );
+empty( $variableA > $variableB );
+empty( $variableA = $variableB );
+empty( $variableA === $variableB );
+
+empty();
+empty( /*comment*/ );
+
+// Unclosed - live coding, don't examine.
+empty(


### PR DESCRIPTION
> Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error. In other words, the following will not work: empty(trim($name)). Instead, use trim($name) == false.

Ref: http://php.net/manual/en/function.empty.php

Includes unit tests.

The checks in the sniff feel a bit simplistic to me, but it works for all the test cases I could come up with. If anyone can think of some more distinct test cases, please let me know!