### PR TITLE
Fix `TernaryOperators` sniff (code review).

### DIFF
--- a/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -47,20 +47,20 @@ class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (!$this->supportsAbove('5.3')) {
-            $tokens = $phpcsFile->getTokens();
+        if ($this->supportsBelow('5.2') === false) {
+            return;
+        }
 
-            // Get next non-whitespace token, and check it isn't the related inline else
-            // symbol, which is not allowed prior to PHP 5.3.
-            $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens,
-                                         ($stackPtr + 1), null, true);
+        $tokens = $phpcsFile->getTokens();
 
-            if ($tokens[$next]['code'] == T_INLINE_ELSE) {
-                $error = sprintf(
-                    "Middle may not be omitted from ternary operators in PHP < 5.3"
-                );
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+        // Get next non-whitespace token, and check it isn't the related inline else
+        // symbol, which is not allowed prior to PHP 5.3.
+        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens,
+                                     ($stackPtr + 1), null, true);
+
+        if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
+            $error = 'Middle may not be omitted from ternary operators in PHP < 5.3';
+            $phpcsFile->addWarning($error, $stackPtr);
         }
     }
 }

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -25,6 +25,8 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     /**
      * Test ternary operators that are acceptable in all PHP versions.
      *
+     * @group ternaryOperators
+     *
      * @return void
      */
     public function testStandardTernaryOperators()
@@ -36,17 +38,23 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     /**
      * 5.2 doesn't support elvis operator.
      *
+     * @group ternaryOperators
+     *
      * @return void
      */
     public function testMissingMiddleExpression5dot2()
     {
-        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.2');
+        $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.2-5.4');
         $this->assertWarning($this->_sniffFile, 8,
+                "Middle may not be omitted from ternary operators in PHP < 5.3");
+        $this->assertWarning($this->_sniffFile, 10,
                 "Middle may not be omitted from ternary operators in PHP < 5.3");
     }
 
     /**
      * 5.3 does support elvis operator.
+     *
+     * @group ternaryOperators
      *
      * @return void
      */
@@ -54,6 +62,8 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     {
         $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.3');
         $this->assertNoViolation($this->_sniffFile, 8,
+                "Middle may not be omitted from ternary operators in PHP < 5.3");
+        $this->assertNoViolation($this->_sniffFile, 10,
                 "Middle may not be omitted from ternary operators in PHP < 5.3");
     }
 

--- a/Tests/sniff-examples/ternary_operator.php
+++ b/Tests/sniff-examples/ternary_operator.php
@@ -6,3 +6,5 @@ $a ? $b : $c;
 
 // Only in 5.3 and above:
 $a ?: $c;
+
+$isError = ($function != 'ini_get') ?: false;


### PR DESCRIPTION
* The sniff was not reporting errors for ranges which included 5.2 or lower, but also included 5.3  or higher. Logic for version testing was using the wrong method.
* Remove unnecessary `sprintf()`

* Added additional unit test - code taken from this sniff library which was not being reported which was the reason I started looking into this one.