### PR TITLE
Fix reversed version logic in the `NewGroupUseDeclarations` sniff.

### DIFF
--- a/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
+++ b/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
@@ -44,7 +44,7 @@ class PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff extends PHPCompat
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (!$this->supportsAbove('7.0')) {
+        if ($this->supportsBelow('5.6')) {
             $phpcsFile->addError('Group use declarations are not allowed in PHP 5.6 or earlier', $stackPtr);
         }
     }//end process()


### PR DESCRIPTION
The reversed logic caused the error not to be reported when using test ranges.