### PR TITLE
More PHPUnit bootstrap tweaks.

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -9,8 +9,14 @@ if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     define('PHP_CODESNIFFER_IN_TESTS', true);
 }
 
-// See if we are in a PEAR install or PHPCS.
-$phpcsDir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+// Get the PHPCS dir from an environment variable.
+$phpcsDir = getenv('PHPCS_DIR') . DIRECTORY_SEPARATOR;
+
+if ($phpcsDir === false) {
+    // Ok, no environment variable set, so this might be a PEAR install of PHPCS.
+    $phpcsDir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR;
+}
+
 if (file_exists($phpcsDir . 'CodeSniffer.php')) {
     require $phpcsDir . 'CodeSniffer.php';
 }
@@ -19,10 +25,11 @@ else {
     $vendorDir = __DIR__ . '/../vendor';
 
     if (!@include($vendorDir . '/autoload.php')) {
-        die("You must set up the project dependencies, run the following commands:
+        echo 'You must set up the project dependencies, run the following commands:
     wget http://getcomposer.org/composer.phar
     php composer.phar install
-    ");
+    ';
+        die(1);
     }
 }
 


### PR DESCRIPTION
* Make travis build fail if PHPCS cannot be found. Currently if PHPCS could not be found, PHPUnit would exit with 0 and the travis build would pass. With this change it will exit with 1 and the travis build will fail.
* Allow for PHPUnit to be run when PHPCS has been set up in an arbitrary location.
Location can be passed via the phpunit.xml file or via other means of setting environment options.

Via phpunit config - add the following to the phpunit.xml file:
```xml
	<php>
		<env name="PHPCS_DIR" value="/path/to/phpcs"/>
	</php>
```