### PR TITLE
Add php linting to the travis run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
 script:
   - ln -s `pwd` vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility
   - mkdir -p build/logs
+  - find -L . -path ./Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   - phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml
 
 after_script:


### PR DESCRIPTION
Tests for syntax errors in the Sniff and Test files.
Excludes the test case files and the `vendor` directory.