### PR TITLE
Fix compatibility issues with PHP 5.2.

### DIFF
--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -239,7 +239,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             if ($version !== 'alternative') {
                 if ($this->supportsAbove($version)) {
                     if ($forbidden === true) {
-                        $isError = ($function != 'ini_get') ?: false;
+                        $isError = ($function !== 'ini_get') ? true : false;
                         $error .= " forbidden";
                     } else {
                         $isError = false;

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -62,6 +62,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends 
      * @var array
      */
     protected $targetedStringTokens = array(
+        'goto' => '5.3',
+        'namespace' => '5.3',
         'callable' => '5.4',
         'insteadof' => '5.4',
         'trait' => '5.4',

--- a/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -97,9 +97,15 @@ class PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff extends PHPComp
         else if ($openTag['code'] === T_INLINE_HTML
             && preg_match('`((?:<s)?cript (?:[^>]+)?language=[\'"]?php[\'"]?(?:[^>]+)?>)`i', $content, $match) === 1
         ) {
+            $found = $match[1];
+            if (version_compare(phpversion(), '5.3', '<')) {
+                // Add the missing '<s' at the start of the match for PHP 5.2.
+                $found = '<s' . $match[1];
+            }
+
             $data = array(
                 'Script',
-                $match[1],
+                $found,
             );
             $errorCode = 'ScriptOpenTagFound';
         }

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -57,7 +57,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
             self::$phpcs->cli->setCommandLineValues(array('-pq', '--colors'));
         }
 
-        self::$phpcs->process(array(), __DIR__ . '/../');
+        self::$phpcs->process(array(), dirname( __FILE__ ) . '/../');
         self::$phpcs->setIgnorePatterns(array());
     }
 


### PR DESCRIPTION
* Fix two parse errors
  - use of ternary without middle.
  - use of `__DIR__`.
* Back-compat of unrecognized tokens in `ForbiddenNamesAsInvokedFunctions` sniff.
* Fix error message consistency for PHP 5.2 for the `RemovedAlternativePHPTags` sniff.