### PR TITLE
Fix reversed logic in the `NewAnonymousClasses` sniff.

### DIFF
--- a/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -46,17 +46,18 @@ class PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff extends PHPCompatibil
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if ($this->supportsBelow('5.6') === false) {
+            return;
+        }
+
         $whitespace = $phpcsFile->findNext(T_WHITESPACE, $stackPtr + 1, $stackPtr + 2);
         $class      = $phpcsFile->findNext(T_ANON_CLASS, $stackPtr + 2, $stackPtr + 3);
         if ($whitespace === false || $class === false) {
             return;
         }
 
-        if ($this->supportsAbove('7.0')) {
-            return;
-        } else {
-            $phpcsFile->addError('Anonymous classes are not supported in PHP 5.6 or earlier', $stackPtr);
-        }
+        $phpcsFile->addError('Anonymous classes are not supported in PHP 5.6 or earlier', $stackPtr);
+
     }//end process()
 
 


### PR DESCRIPTION
The reversed logic caused the error not to be reported when using test ranges.