### PR TITLE
Travis test on PHP 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ matrix:
   fast_finish: true
   include:
 
+    - php: 5.2
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION="1.5.6"
+    - php: 5.2
+      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION="master"
+
     - php: 5.3
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.3
@@ -36,18 +41,23 @@ matrix:
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0,<=2.6.1"
     - php: 7.0
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
+
 
 before_script:
   - phpenv rehash
 
 install:
-  - composer self-update
-  - composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}
-  - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
-  - composer install
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer self-update; fi
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer require squizlabs/php_codesniffer:${PHPCS_VERSION}; fi
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer install; fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_BIN=$(if [[ $PHPCS_VERSION == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi); fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_VERSION $PHPCS_DIR; fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then $PHPCS_BIN --config-set installed_paths $(pwd); fi
 
 script:
-  - ln -s `pwd` vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then ln -s `pwd` vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; fi
   - mkdir -p build/logs
   - phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml
 

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -41,6 +41,10 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '7.0');
         $this->assertNoViolation($file, 9);
-        $this->assertNoViolation($file, 20);
+
+        if (version_compare(phpversion(), '5.3', '>=')) {
+            // Will only be no violation if namespaces are recognized.
+            $this->assertNoViolation($file, 20);
+        }
     }
 }

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -77,8 +77,7 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
      */
     public function usecaseProvider()
     {
-        return array(
-            array('namespace'),
+        $data = array(
             array('use'),
             array('use-as'),
             array('class'),
@@ -90,6 +89,11 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
             array('const'),
             array('define'),
         );
+        if (version_compare(phpversion(), '5.3', '>=')) {
+            $data[] = array('namespace');
+        }
+
+        return $data;
     }
 
     /**

--- a/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -31,6 +31,8 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
     /**
      * testGroupUseDeclaration
      *
+     * @requires PHP 5.3
+     *
      * @dataProvider dataGroupUseDeclaration
      *
      * @param int $line The line number.

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -18,6 +18,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test allow_url_include
      *
+     * @requires PHP 5.3
      * @return void
      */
     public function testDirMagicConstant()
@@ -43,6 +44,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test namespace keyword
      *
+     * @requires PHP 5.3
      * @return void
      */
     public function testNamespaceKeyword()
@@ -55,6 +57,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testNamespaceConstant
      *
+     * @requires PHP 5.3
      * @return void
      */
     public function testNamespaceConstant()
@@ -160,16 +163,25 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testHaltCompiler
      *
-     * Usage of `__halt_compiler()` cannot be tested on its own token as the compiler will be halted...
-     * So testing that any violations created *after* the compiler is halted will not be reported.
-     *
-     * @requires PHP 5.1
+     * @requires PHP 5.3
      * @return void
      */
     public function testHaltCompiler()
     {
-        $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.2');
-
-        $this->assertNoViolation($file, 53);
+        if (version_compare(phpversion(), '5.3', '=')) {
+            // PHP 5.3 actually shows the warning.
+            $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.0');
+            $this->assertError($file, 50, "\"__halt_compiler\" keyword is not present in PHP version 5.0 or earlier");
+        }
+        else {
+            /*
+             * Usage of `__halt_compiler()` cannot be tested on its own token as the compiler
+             * will be halted...
+             * So testing that any violations created *after* the compiler is halted will
+             * not be reported.
+             */
+            $file = $this->sniffFile('sniff-examples/new_keywords.php', '5.2');
+            $this->assertNoViolation($file, 53);
+        }
     }
 }

--- a/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -22,6 +22,8 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
      *
      * @group NewLanguageConstructs
      *
+     * @requires PHP 5.3
+     *
      * @return void
      */
     public function testNamespaceSeparator()

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -108,7 +108,13 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertWarning($file, $line, 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: ' . $snippet);
+        if (version_compare(phpversion(), '5.3', '<')) {
+            // PHP 5.2 does not generate the snippet correctly.
+            $warning = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: <%';
+        } else {
+            $warning = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: ' . $snippet;
+        }
+        $this->assertWarning($file, $line, $warning);
     }
 
     /**


### PR DESCRIPTION
* Set up travis to enable testing on PHP 5.2
* Fix unit tests for testing on PHP 5.2 - this is practice means that some tests will be skipped on 5.3.

As composer is not available on PHP 5.2, just pulling in the repos straight from GitHub.

As a side-note, I find the time difference this makes (the main difference is the whole coveralls repo + run) quite significant...