### PR TITLE
Fix reversed version logic.

### DIFF
--- a/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -37,6 +37,10 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if ($this->supportsBelow('5.3') === false) {
+            return;
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         $ignore = array(
@@ -55,9 +59,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
         if (isset($tokens[$stackPtr + 1]) && $tokens[$stackPtr + 1]['type'] == 'T_OPEN_PARENTHESIS') {
             $closeParenthesis = $tokens[$stackPtr + 1]['parenthesis_closer'];
             if ($tokens[$closeParenthesis + 1]['type'] == 'T_OPEN_SQUARE_BRACKET') {
-                if (!$this->supportsAbove('5.2')) {
-                    $phpcsFile->addError('Function array dereferencing is not present in PHP version 5.3 or earlier', $stackPtr + 3);
-                }
+                $phpcsFile->addError('Function array dereferencing is not present in PHP version 5.3 or earlier', $stackPtr + 3);
             }
         }
     }//end process()


### PR DESCRIPTION
Logic was inadvertently reversed in https://github.com/wimg/PHPCompatibility/commit/26d0b6cf0921f75d93a4faaf09c390f386dde9ff

SupportsAbove = false is not the same as SupportsBelow = true. Using it like that will break on testVersion ranges.
I understand the preference for SupportsAbove though, but that's to do with a different bug altogether - see issue #142. I'd be happy to fix that if someone could confirm the intended behaviour for me.