### PR TITLE
Minor improvements to `ConstantArraysUsingDefine` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -15,21 +15,73 @@
  */
 class ConstantArraysUsingDefineSniffTest  extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/constant_arrays_using_define.php';
+
     /**
      * Verify that checking for a specific version works
      *
+     * @group constantArraysUsingDefine
+     *
+     * @dataProvider dataConstantArraysUsingDefine
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testConstantArraysUsingDefine()
+    public function testConstantArraysUsingDefine($line)
     {
-        $file = $this->sniffFile('sniff-examples/constant_arrays_using_define.php', '7.0');
-        $this->assertNoViolation($file, 3);
-        $this->assertNoViolation($file, 9);
-        $this->assertNoViolation($file, 15);
-        
-        $file = $this->sniffFile('sniff-examples/constant_arrays_using_define.php', '5.6');
-        $this->assertError($file, 3, "Constant arrays using define are not allowed in PHP 5.6 or earlier");
-        $this->assertError($file, 9, "Constant arrays using define are not allowed in PHP 5.6 or earlier");
-        $this->assertNoViolation($file, 15);
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertError($file, $line, 'Constant arrays using define are not allowed in PHP 5.6 or earlier');
     }
+
+    /**
+     * Data provider dataConstantArraysUsingDefine.
+     *
+     * @see testConstantArraysUsingDefine()
+     *
+     * @return array
+     */
+    public function dataConstantArraysUsingDefine()
+    {
+        return array(
+            array(3),
+            array(9),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group constantArraysUsingDefine
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(15),
+        );
+    }
+
 }


### PR DESCRIPTION
* Fix bug in version check - `if ($this->supportsAbove('7.0') === false)` is not the same as `if ($this->supportsBelow('5.6') === true)`. This was not caught by the unit tests as they use single versions, but the difference is basically that if `$testVersion` was set to `5.4-7.0`, the message would previously not show and now it will.
* Exit early if the check is not relevant.
* Use the new `getFunctionCallParameter()` method to get the relevant parameter.
* Separate violation and noViolation unit tests and set them up to use data providers.