### PR TITLE
New sniff to check for use of the Mbstring regex e modifier.

### DIFF
--- a/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * Key is the function name, value the parameter position of the options parameter.
+     *
+     * @var array
+     */
+    protected $functions = array(
+        'mb_ereg_replace'      => 4,
+        'mb_eregi_replace'     => 4,
+        'mb_regex_set_options' => 1,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STRING);
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.1') === false) {
+            return;
+        }
+
+        $tokens         = $phpcsFile->getTokens();
+        $functionNameLc = strtolower($tokens[$stackPtr]['content']);
+
+        // Bow out if not one of the functions we're targetting.
+        if ( isset($this->functions[$functionNameLc]) === false ) {
+            return;
+        }
+
+        // Get the options parameter in the function call.
+        $optionsParam = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->functions[$functionNameLc]);
+        if ($optionsParam === false) {
+            return;
+        }
+
+        $stringToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $optionsParam['start'], $optionsParam['end'] + 1);
+        if ($stringToken === false) {
+            // No string token found in the options parameter, so skip it (e.g. variable passed in).
+            return;
+        }
+
+        /**
+         * Get the content of any string tokens in the options parameter and remove the quotes.
+         */
+        $options = trim($tokens[$stringToken]['content'], '\'"');
+        if ($stringToken !== $optionsParam['end']) {
+            while ($stringToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stringToken + 1, $optionsParam['end'] + 1)) {
+                if ($tokens[$stringToken]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+                    $options .= trim($tokens[$stringToken]['content'], '\'"');
+                }
+            }
+        }
+
+        if (strpos($options, 'e') !== false) {
+            $error = 'The Mbstring regex "e" modifier is deprecated since PHP 7.1.';
+
+            // The alternative mb_ereg_replace_callback() function is only available since 5.4.1
+            if ($this->supportsBelow('5.4.1') === false) {
+                $error .= ' Use mb_ereg_replace_callback() instead (PHP 5.4.1+).';
+            }
+
+            $phpcsFile->addError($error, $stackPtr, 'Found');
+        }
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Deprecated Mbstring regex replace e modifier sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Deprecated Mbstring regex replace e modifier test file.
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class MbstringReplaceEModifierSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/mbstring_replace_e_modifier.php';
+
+    /**
+     * testMbstringEModifier
+     *
+     * @group mbstringEModifier
+     *
+     * @dataProvider dataMbstringEModifier
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testMbstringEModifier($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3-7.1');
+        $this->assertError($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertError($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1. Use mb_ereg_replace_callback() instead (PHP 5.4.1+).');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testMbstringEModifier()
+     *
+     * @return array
+     */
+    public function dataMbstringEModifier()
+    {
+        return array(
+            array(14),
+            array(15),
+            array(16),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group mbstringEModifier
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(6),
+            array(9),
+            array(10),
+            array(11),
+        );
+    }
+}

--- a/Tests/sniff-examples/mbstring_replace_e_modifier.php
+++ b/Tests/sniff-examples/mbstring_replace_e_modifier.php
@@ -1,0 +1,16 @@
+<?php
+
+// These should all be ignored as we're passing in a variable.
+mb_ereg_replace( $pattern, $replace, $subject, $options );
+mb_eregi_replace( $pattern, $replace, $subject, $options );
+mb_regex_set_options( $options );
+
+// These should be ignored as they contain valid options.
+mb_ereg_replace( $pattern, $replace, $subject, 'msi' );
+mb_eregi_replace( $pattern, $replace, $subject, 'sim' );
+mb_regex_set_options( 'ims' );
+
+// These should all be flagged.
+mb_ereg_replace( $pattern, $replace, $subject, 'e' );
+mb_eregi_replace( $pattern, $replace, $subject, "seim" );
+mb_regex_set_options( 'im' . 'se' );


### PR DESCRIPTION
... which will be deprecated in PHP 7.1
Ref: https://wiki.php.net/rfc/deprecate_mb_ereg_replace_eval_option