### PR TITLE
Improve the `ForbiddenCallTimePassByReference` sniff (code review).

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -15,6 +15,8 @@
  */
 class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/call_time_pass_by_reference.php';
+
     /**
      * Sniffed file
      *
@@ -31,105 +33,96 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
     {
         parent::setUp();
 
-        $this->_sniffFile = $this->sniffFile('sniff-examples/call_time_pass_by_reference.php');
+        $this->_sniffFile = $this->sniffFile(self::TEST_FILE);
     }
 
+
     /**
-     * Test declare parameter by reference
+     * testForbiddenCallTimePassByReference
+     *
+     * @group forbiddenCallTimePassByReference
+     *
+     * @dataProvider dataForbiddenCallTimePassByReference
+     *
+     * @param int    $line  Line number where the error should occur.
      *
      * @return void
      */
-    public function testDeclareParameterByReference()
+    public function testForbiddenCallTimePassByReference($line)
     {
-        $this->assertNoViolation($this->_sniffFile, 9);
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Using a call-time pass-by-reference is deprecated since PHP 5.3');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, 'Using a call-time pass-by-reference is deprecated since PHP 5.3 and prohibited since PHP 5.4');
     }
 
     /**
-     * testCallTimeNormal
+     * dataForbiddenCallTimePassByReference
+     *
+     * @see testForbiddenCallTimePassByReference()
+     *
+     * @return array
+     */
+    public function dataForbiddenCallTimePassByReference() {
+        return array(
+            array(10), // Bad: call time pass by reference.
+            array(14), // Bad: call time pass by reference with multi-parameter call.
+            array(17), // Bad: nested call time pass by reference.
+            array(25), // Bad: call time pass by reference with space.
+            array(44), // Bad: call time pass by reference.
+            array(45), // Bad: call time pass by reference.
+            array(49), // Bad: multiple call time pass by reference.
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group forbiddenCallTimePassByReference
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testCallTimeNormal()
+    public function testNoViolation($line)
     {
-        $this->assertNoViolation($this->_sniffFile, 14);
+        $this->assertNoViolation($this->_sniffFile, $line);
     }
 
     /**
-     * testCallTimePassByReferenceSingleParam
+     * Data provider.
      *
-     * @return void
+     * @see testNoViolation()
+     *
+     * @return array
      */
-    public function testCallTimePassByReferenceSingleParam()
+    public function dataNoViolation()
     {
-        $this->assertError($this->_sniffFile, 15, 'Using a call-time pass-by-reference is prohibited since php 5.4');
+        return array(
+            array(4), // OK: Declaring a parameter by reference.
+            array(9), // OK: Call time passing without reference.
+
+            // OK: Bitwise operations as parameter.
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(39),
+            array(40),
+            //array(41), // Currently not yet covered.
+
+            array(51), // OK: No variables.
+            array(51), // OK: Outside scope of this sniff.
+        );
     }
 
-    /**
-     * testCallTimePassByReferenceMultiParam
-     *
-     * @return void
-     */
-    public function testCallTimePassByReferenceMultiParam()
-    {
-        $this->assertError($this->_sniffFile, 19, 'Using a call-time pass-by-reference is prohibited since php 5.4');
-    }
-
-    /**
-     * testCallTimePassByReferenceNested
-     *
-     * @return void
-     */
-    public function testCallTimePassByReferenceNested()
-    {
-        $this->assertError($this->_sniffFile, 22, 'Using a call-time pass-by-reference is prohibited since php 5.4');
-    }
-
-    /**
-     * testCallTimePassByReferenceGlobal
-     *
-     * @return void
-     */
-    public function testCallTimePassByReferenceGlobal()
-    {
-        $this->assertError($this->_sniffFile, 44, 'Using a call-time pass-by-reference is prohibited since php 5.4');
-    }
-
-    /**
-     * testBitwiseOperationsAsParameter
-     *
-     * @return void
-     */
-    public function testBitwiseOperationsAsParameter()
-    {
-        $this->assertNoViolation($this->_sniffFile, 24);
-        $this->assertNoViolation($this->_sniffFile, 25);
-        $this->assertNoViolation($this->_sniffFile, 26);
-        $this->assertNoViolation($this->_sniffFile, 27);
-        $this->assertNoViolation($this->_sniffFile, 28);
-        $this->assertNoViolation($this->_sniffFile, 40);
-        $this->assertNoViolation($this->_sniffFile, 41);
-    }
-
-    /**
-     * testCallTimePassByReferenceWithWhiteSpace
-     *
-     * @return void
-     */
-    public function testCallTimePassByReferenceWithWhiteSpace()
-    {
-        $this->assertError($this->_sniffFile, 29, 'Using a call-time pass-by-reference is prohibited since php 5.4');
-    }
-
-    /**
-     * testSettingTestVersion
-     *
-     * @return void
-     */
-    public function testSettingTestVersion()
-    {
-        $file = $this->sniffFile('sniff-examples/call_time_pass_by_reference.php', '5.2');
-
-        $this->assertNoViolation($file, 29);
-    }
 }
 

--- a/Tests/sniff-examples/call_time_pass_by_reference.php
+++ b/Tests/sniff-examples/call_time_pass_by_reference.php
@@ -1,32 +1,28 @@
 <?php
 
-$a = 1;
-
-class MoneyBags
-{
-}
-
+// Ok: Declare parameter by reference.
 function abc(&$foobar)
 {
     return $foobar;
 }
 
-$right = abc($a);
-$wrong = abc(&$a);
+$right = abc($a); // Ok: no reference.
+$wrong = abc(&$a); // Bad: pass by reference.
 
 $a = E_STRICT; // Sniffer checks strings, and returns if no left paren afterwards
 
 abc($x, $y, $z, &$a);
 
-// nested function call
+// Nested function call.
 preg_replace($a, $b, trim(&$a));
 
+// Ok: Bitwise operations as parameter.
 foobar(3 & $a); // LNUMBER + &
 foobar($a & $b); // variable + &
 foobar($b[0] & $a); // square bracket + &
 foobar(($a) & $b); // parenthesis + &
 foobar(intval(3) & $b); // function + &
-foobar(& $b);
+foobar(& $b); // Bad: pass by reference with space.
 
 define('MY_CONST', 0);
 
@@ -37,11 +33,21 @@ class MoreRefs
 
     public function bar($arg)
     {
+        // Ok: Bitwise operations as parameter.
         $a = sprintf(
             '%s %s %s'
             , self::MYCONST & $arg ? 1 : 2
             , $this->attribute & $arg ? 5 : 6
             , MY_CONST & $arg ? 7 : 8
         );
+
+        $b = $this->foo(&$var); // Bad: pass by reference.
+        $c = self::foobar(&$var); // Bad: pass by reference.
     }
 }
+
+abcd(&$x, &$y, $z, &$aa = false); // Bad: multiple pass by reference.
+
+bcd(10, true, MYCONST); // OK: does not contain variables.
+
+cde((&$abc)); // OK: outside of the scope of this sniff - will result in parse error.


### PR DESCRIPTION
* Fix PHP version - was 5.4+, but the feature was already deprecated in 5.3. The error message will reflect this now too.
* Prevent errors during live code review.
* Prevent false positives for interface and trait declarations.
* Use the new `getFunctionCallParameters()` method for more precise walking of the parameters.
* Abstracted the actual CTPbR determination out to it's own method.
* Stricter variable checking.
* Added some more test cases and added additional documentation for the test cases.
* Added additional version based tests. The error cases were only tested for throwing an error, now they are also tested for *not* throwing an error in PHP 5.2 and throwing the slightly adjusted error in PHP 5.3.
* Removed a false positive unit test (test case is still there) - bitwise operations with a global constant should not be regarded as CTPbR, but is currently not excluded. So this *will* give an error, but shouldn't. If at some point, this would be sorted, it should be uncommented in the noViolation dataProvider, but testing that it *does* throw an error (which was the old situation) is misleading.
* Reworked the unit tests to dataProviders.

Note: I've not spend any real time on the yes/no function call logic as that's part of another upcoming PR.