### PR TITLE
Fix PHP Warning in `NewClasses` sniff.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -411,7 +411,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                  T_WHITESPACE,
                 );
 
-        $start     = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        // Bow out if the next token is a variable as we don't know where it was defined.
+        if ($tokens[$start]['code'] === T_VARIABLE) {
+            return '';
+        }
+
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true, null, true);
         $className = $phpcsFile->getTokensAsString($start, ($end - $start));
         $className = trim($className);
@@ -474,6 +479,11 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         }
 
         if ($tokens[$stackPtr]['code'] !== T_DOUBLE_COLON) {
+            return '';
+        }
+
+        // Nothing to do if previous token is a variable as we don't know where it was defined.
+        if ($tokens[$stackPtr - 1]['code'] === T_VARIABLE) {
             return '';
         }
 

--- a/Tests/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/Tests/GetFQClassNameFromDoubleColonTokenTest.php
@@ -9,7 +9,7 @@
 /**
  * Classname determination from double colon token function tests
  *
- * @uses BaseSniffTest
+ * @uses    BaseAbstractClassMethodTest
  * @package PHPCompatibility
  */
 class GetFQClassNameFromDoubleColonTokenTest extends BaseAbstractClassMethodTest
@@ -62,6 +62,7 @@ class GetFQClassNameFromDoubleColonTokenTest extends BaseAbstractClassMethodTest
             array(173, '\MyClass'),
             array(181, ''),
             array(187, ''),
+            array(247, ''),
         );
     }
 

--- a/Tests/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/GetFQClassNameFromNewTokenTest.php
@@ -57,6 +57,7 @@ class GetFQClassNameFromNewTokenTest extends BaseAbstractClassMethodTest
             array(104, '\DateTime'),
             array(109, '\DateTime'),
             array(115, '\AnotherTesting\DateTime'),
+            array(133, ''),
         );
     }
 

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
@@ -31,3 +31,12 @@ class MyClass {
 		static::test_function();
 	}
 }
+
+// Issue #205
+class Foo {
+    static public function bar($a) {
+        echo __METHOD__ . '() called with $a = ' . $a;
+    }
+}
+$theclass = 'Foo';
+$theclass::bar(42);

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
@@ -18,3 +18,7 @@ namespace AnotherTesting {
 new DateTime;
 new \DateTime;
 new \AnotherTesting\DateTime();
+
+// Variant on issue #205
+$className = 'DateTime';
+new $className;


### PR DESCRIPTION
Closes #205

* Adds the test case mentioned in the issue to the unit tests for the `getFQClassNameFromDoubleColonToken()` function  + adds a variant of it to the unit tests for the `getFQClassNameFromNewToken()` function.
* Fixes the issue in both functions.
* Unit tests for the `getFQClassNameFromDoubleColonToken()` function were not being run due to a file name error. Fixed that too.