### PR TITLE
Supported sniff for break/continue 0

### DIFF
--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -24,8 +24,8 @@
  */
 class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff extends PHPCompatibility_Sniff
 {
-    const ERROR_TYPE_VARIABLE = 'variable argument';
-    const ERROR_TYPE_ZERO = 'zero value argument';
+    const ERROR_TYPE_VARIABLE = 'a variable argument';
+    const ERROR_TYPE_ZERO = '0 as an argument';
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -81,7 +81,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
         }
 
         if ($isError === true && !empty($errorType)) {
-            $error = 'Using a ' . $errorType . ' on break or continue is forbidden since PHP 5.4';
+            $error = 'Using ' . $errorType . ' on break or continue is forbidden since PHP 5.4';
             $phpcsFile->addError($error, $stackPtr);
         }
 

--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -24,6 +24,8 @@
  */
 class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff extends PHPCompatibility_Sniff
 {
+    const ERROR_TYPE_VARIABLE = 'variable argument';
+    const ERROR_TYPE_ZERO = 'zero value argument';
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -54,6 +56,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
         $tokens             = $phpcsFile->getTokens();
         $nextSemicolonToken = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr), null, false);
         $isError            = false;
+        $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
             if ($tokens[$curToken]['type'] === 'T_STRING') {
                 // If the next non-whitespace token after the string
@@ -61,17 +64,24 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
                 $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $curToken + 1, null, true);
                 if ($tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS) {
                     $isError = true;
+                    $errorType = self::ERROR_TYPE_VARIABLE;
                     break;
                 }
             }
-            else if(in_array($tokens[$curToken]['type'], array('T_VARIABLE', 'T_FUNCTION', 'T_CLOSURE'), true)) {
+            else if (in_array($tokens[$curToken]['type'], array('T_VARIABLE', 'T_FUNCTION', 'T_CLOSURE'), true)) {
                 $isError = true;
+                $errorType = self::ERROR_TYPE_VARIABLE;
+                break;
+            }
+            else if ($tokens[$curToken]['type'] === 'T_LNUMBER' && $tokens[$curToken]['content'] === '0') {
+                $isError = true;
+                $errorType = self::ERROR_TYPE_ZERO;
                 break;
             }
         }
 
-        if ($isError === true) {
-            $error = 'Using a variable argument on break or continue is forbidden since PHP 5.4';
+        if ($isError === true && !empty($errorType)) {
+            $error = 'Using a ' . $errorType . ' on break or continue is forbidden since PHP 5.4';
             $phpcsFile->addError($error, $stackPtr);
         }
 

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -20,6 +20,8 @@
 class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 {
     const TEST_FILE = 'sniff-examples/forbidden_break_continue_variable_argument.php';
+    const ERROR_TYPE_VARIABLE = 'variable argument';
+    const ERROR_TYPE_ZERO = 'zero value argument';
 
     /**
      * Sniffed file
@@ -65,12 +67,13 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
      * @dataProvider dataBreakAndContinueVariableArgument
      *
      * @param int $line The line number.
+     * @param string $errorType The error type.
      *
      * @return void
      */
-    public function testBreakAndContinueVariableArgument($line)
+    public function testBreakAndContinueVariableArgument($line, $errorType)
     {
-        $this->assertError($this->_sniffFile, $line, 'Using a variable argument on break or continue is forbidden since PHP 5.4');
+        $this->assertError($this->_sniffFile, $line, 'Using a ' . $errorType . ' on break or continue is forbidden since PHP 5.4');
     }
 
     /**
@@ -83,18 +86,20 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
     public function dataBreakAndContinueVariableArgument()
     {
         return array(
-            array(53),
-            array(57),
-            array(62),
-            array(66),
-            array(71),
-            array(75),
-            array(80),
-            array(84),
-            array(89),
-            array(93),
-            array(98),
-            array(102),
+            array(53, self::ERROR_TYPE_VARIABLE),
+            array(57, self::ERROR_TYPE_VARIABLE),
+            array(62, self::ERROR_TYPE_VARIABLE),
+            array(66, self::ERROR_TYPE_VARIABLE),
+            array(71, self::ERROR_TYPE_VARIABLE),
+            array(75, self::ERROR_TYPE_VARIABLE),
+            array(80, self::ERROR_TYPE_VARIABLE),
+            array(84, self::ERROR_TYPE_VARIABLE),
+            array(89, self::ERROR_TYPE_VARIABLE),
+            array(93, self::ERROR_TYPE_VARIABLE),
+            array(98, self::ERROR_TYPE_VARIABLE),
+            array(102, self::ERROR_TYPE_VARIABLE),
+            array(107, self::ERROR_TYPE_ZERO),
+            array(111, self::ERROR_TYPE_ZERO),
         );
     }
 

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -20,8 +20,8 @@
 class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 {
     const TEST_FILE = 'sniff-examples/forbidden_break_continue_variable_argument.php';
-    const ERROR_TYPE_VARIABLE = 'variable argument';
-    const ERROR_TYPE_ZERO = 'zero value argument';
+    const ERROR_TYPE_VARIABLE = 'a variable argument';
+    const ERROR_TYPE_ZERO = '0 as an argument';
 
     /**
      * Sniffed file
@@ -73,7 +73,7 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
      */
     public function testBreakAndContinueVariableArgument($line, $errorType)
     {
-        $this->assertError($this->_sniffFile, $line, 'Using a ' . $errorType . ' on break or continue is forbidden since PHP 5.4');
+        $this->assertError($this->_sniffFile, $line, 'Using ' . $errorType . ' on break or continue is forbidden since PHP 5.4');
     }
 
     /**

--- a/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
+++ b/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
@@ -101,6 +101,14 @@ for ($i = 0; $i < 20; $i++) {
         if ($i < 10) {
             continue MyNamespace\myFunction(); // Bad.
         }
+
+        // Bad: Break/continue with zero value.
+        if ($i == 1) {
+            break 0;
+        }
+
+        if ($i < 20) {
+            continue 0;
+        }
     }
 }
-


### PR DESCRIPTION
# What is this

Since PHP 5.4, statements like `break 0;` and `continue 0;` is no longer supported.

This PR is supported for this in `Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php`.

>The break and continue statements no longer accept variable arguments (e.g., break 1 + foo() * $bar;). Static arguments still work, such as break 2;. As a side effect of this change break 0; and continue 0; are no longer allowed.
http://php.net/manual/en/migration54.incompatible.php

What do you think?
Thank you for good tools 🙇 