### PR TITLE
Fix `EmptyNonVariable` sniff combined with variable variables.

### DIFF
--- a/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -115,6 +115,26 @@ class EmptyNonVariableSniffTest extends BaseSniffTest
             array(12),
             array(13),
             array(14),
+
+            // Issue #210.
+            array(47),
+            array(48),
+            array(49),
+            array(50),
+            array(51),
+            array(52),
+            array(53),
+            array(54),
+            array(55),
+            array(56),
+            array(57),
+            array(58),
+            array(59),
+            array(60),
+            array(61),
+
+            // Live coding.
+            array(65),
         );
     }
 }

--- a/Tests/sniff-examples/empty_non_variable.php
+++ b/Tests/sniff-examples/empty_non_variable.php
@@ -42,5 +42,24 @@ empty( $variableA === $variableB );
 empty();
 empty( /*comment*/ );
 
+
+// Issue #210 + some extra variants - should all be ok as well.
+empty(${$a . $b });
+empty($a[$b . 'c']);
+empty($a->{$b . 'c'});
+empty($a[$b->c()]);
+empty($a[$b->{$c}()]);
+empty($a[$b + 2]);
+empty($a->{$b + 2});
+empty($a[$b && $c]);
+empty($a->{$b && $c});
+empty($a[(int) $b]);
+empty($a->{(string) $c});
+empty(a::${$b});
+empty($a::${$b});
+empty(a::${$b . 'c'});
+empty($a::${$b . 'c'});
+
+
 // Unclosed - live coding, don't examine.
 empty(


### PR DESCRIPTION
Closes #210.

* Disregards tokens within variable variable brackets/array key brackets.
* Includes additional unit tests.