### PR TITLE
Minor improvement to the `getFunctionCallParameters()` method.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -266,7 +266,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         // Ok, we know we have a T_STRING with parameters and valid open & close parenthesis.
         $tokens = $phpcsFile->getTokens();
 
-        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis  = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
 
         // Which nesting level is the one we are interested in ?
@@ -279,20 +279,33 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         $nextComma  = $openParenthesis;
         $paramStart = $openParenthesis + 1;
         $cnt        = 1;
-        while ($nextComma = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS), $nextComma + 1, $closeParenthesis + 1)) {
+        while ($nextComma = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS, T_OPEN_SHORT_ARRAY), $nextComma + 1, $closeParenthesis + 1)) {
+            // Ignore anything within short array definition brackets.
+            if (
+                $tokens[$nextComma]['type'] === 'T_OPEN_SHORT_ARRAY'
+                &&
+                ( isset($tokens[$nextComma]['bracket_opener']) && $tokens[$nextComma]['bracket_opener'] === $nextComma )
+                &&
+                isset($tokens[$nextComma]['bracket_closer'])
+            ) {
+                // Skip forward to the end of the short array definition.
+                $nextComma = $tokens[$nextComma]['bracket_closer'];
+                continue;
+            }
+
             // Ignore comma's at a lower nesting level.
             if (
-                $tokens[$nextComma]['type'] == 'T_COMMA'
+                $tokens[$nextComma]['type'] === 'T_COMMA'
                 &&
                 isset($tokens[$nextComma]['nested_parenthesis'])
                 &&
-                count($tokens[$nextComma]['nested_parenthesis']) != $nestedParenthesisCount
+                count($tokens[$nextComma]['nested_parenthesis']) !== $nestedParenthesisCount
             ) {
                 continue;
             }
 
             // Ignore closing parenthesis if not 'ours'.
-            if ($tokens[$nextComma]['type'] == 'T_CLOSE_PARENTHESIS' && $nextComma != $closeParenthesis) {
+            if ($tokens[$nextComma]['type'] === 'T_CLOSE_PARENTHESIS' && $nextComma !== $closeParenthesis) {
                 continue;
             }
 

--- a/Sniff.php
+++ b/Sniff.php
@@ -301,6 +301,14 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             $parameters[$cnt]['end']   = $nextComma - 1;
             $parameters[$cnt]['raw']   = trim($phpcsFile->getTokensAsString($paramStart, ($nextComma - $paramStart)));
 
+            // Check if there are more tokens before the closing parenthesis.
+            // Prevents code like the following from setting a third parameter:
+            // functionCall( $param1, $param2, );
+            $hasNextParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextComma + 1, $closeParenthesis, true, null, true);
+            if ($hasNextParam === false) {
+                break;
+            }
+
             // Prepare for the next parameter.
             $paramStart = $nextComma + 1;
             $cnt++;

--- a/Tests/GetFunctionParametersTest.php
+++ b/Tests/GetFunctionParametersTest.php
@@ -134,6 +134,15 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
                        ),
 
             ),
+            array(577, array(
+                        1 => array(
+                              'start' => 579,
+                              'end'   => 611,
+                              'raw'   => '[\'a\' => $a,] + (isset($b) ? [\'b\' => $b,] : [])',
+                             ),
+                       ),
+
+            ),
         );
     }
 
@@ -243,6 +252,30 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
             array(499, 3),
             array(518, 1),
             array(535, 1),
+
+            // Issue #211.
+            array(551, 1),
+            array(564, 1),
+            array(577, 1),
+            array(615, 1),
+            array(660, 1),
+            array(710, 1),
+            array(761, 1),
+            array(818, 1),
+            array(874, 1),
+            array(894, 1),
+            array(910, 1),
+            array(930, 1),
+            array(964, 1),
+            array(984, 1),
+            array(1008, 1),
+            array(1038, 1),
+            array(1074, 1),
+            array(1111, 1),
+            array(1154, 1),
+            array(1184, 1),
+            array(1215, 1),
+            array(1241, 1),
         );
     }
 

--- a/Tests/GetFunctionParametersTest.php
+++ b/Tests/GetFunctionParametersTest.php
@@ -125,6 +125,15 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
                        ),
 
             ),
+            array(535, array(
+                        1 => array(
+                              'start' => 537,
+                              'end'   => 540,
+                              'raw'   => 'array()',
+                             ),
+                       ),
+
+            ),
         );
     }
 
@@ -233,6 +242,7 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
             array(454, 6),
             array(499, 3),
             array(518, 1),
+            array(535, 1),
         );
     }
 

--- a/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -35,10 +35,15 @@ mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
  */
 filter_input_array(
     INPUT_POST,
-	$args,
-	false
+    $args,
+    false
 ); // 3
 
 gettimeofday (
                true
-			 ); // 1
+             ); // 1
+
+/*
+ * Deal with unnecessary comma after last param.
+ */
+json_encode( array(), );

--- a/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -47,3 +47,29 @@ gettimeofday (
  * Deal with unnecessary comma after last param.
  */
 json_encode( array(), );
+
+/*
+ * Issue #211 - deal with short array syntax
+ */
+json_encode(['a' => 'b',]);
+json_encode(['a' => $a,]);
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []));
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b, 'c' => $c,] : []));
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d] : []));
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d,] : []));
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d, $c => 'c'] : []));
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []) + ['c' => $c, 'd' => $d,]);
+json_encode(['a' => 'b', 'c' => 'd',]);
+json_encode(['a' => ['b',],]);
+json_encode(['a' => ['b' => 'c',],]);
+json_encode(['a' => ['b' => 'c',], 'd' => ['e' => 'f',],]);
+json_encode(['a' => $a, 'b' => $b,]);
+json_encode(['a' => $a,] + ['b' => $b,]);
+json_encode(['a' => $a] + ['b' => $b, 'c' => $c,]);
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d]);
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d,]);
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d, $c => 'c']);
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c]);
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c,]);
+json_encode(['a' => $a, 'b' => $b, 'c' => $c]);
+json_encode(['a' => $a, 'b' => $b, 'c' => $c,] + ['c' => $c, 'd' => $d,]);


### PR DESCRIPTION
Prevent code like the following from setting a third parameter in the return value of `getFunctionCallParameters()`:
```php
functionCall( $param1, $param2, );
```

Includes unit tests.

Inspired by #211 - this was the only type of code I could come up with, with which I could reproduce the issue mentioned in #211.
For a real solution to #211 proper, we need more input from the issue reporter.

--------

**Update:** I've added a second commit to this PR which fixes the actual issue as reported in #211 which turned out to be about the short array syntax.

"Normal" array syntax adds a parenthesis nesting level, however the short array syntax does not. So this has to be dealt with separately in the logic to determine where a parameter starts and ends.

Includes unit tests.

Closes #211