### PR TITLE
Minor reorganization of test directory.

### DIFF
--- a/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -9,13 +9,13 @@
 /**
  * Function parameters function tests
  *
- * @uses BaseSniffTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  */
-class DoesFunctionCallHaveParametersTest extends BaseAbstractClassMethodTest
+class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestFrame
 {
 
-	public $filename = 'sniff-examples/utility-functions/does_function_call_have_parameters.php';
+	public $filename = '../sniff-examples/utility-functions/does_function_call_have_parameters.php';
 
     /**
      * testDoesFunctionCallHaveParameters
@@ -23,6 +23,8 @@ class DoesFunctionCallHaveParametersTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataDoesFunctionCallHaveParameters
+     *
+     * @covers PHPCompatibility_Sniff::doesFunctionCallHaveParameters
      *
      * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
      * @param string $expected The expected fully qualified class name.

--- a/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
@@ -9,13 +9,13 @@
 /**
  * Classname determination from double colon token function tests
  *
- * @uses    BaseAbstractClassMethodTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  */
-class GetFQClassNameFromDoubleColonTokenTest extends BaseAbstractClassMethodTest
+class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = 'sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php';
+    public $filename = '../sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php';
 
     /**
      * testGetFQClassNameFromDoubleColonToken
@@ -25,6 +25,8 @@ class GetFQClassNameFromDoubleColonTokenTest extends BaseAbstractClassMethodTest
      * @requires PHP 5.3
      *
      * @dataProvider dataGetFQClassNameFromDoubleColonToken
+     *
+     * @covers PHPCompatibility_Sniff::getFQClassNameFromDoubleColonToken
      *
      * @param int    $stackPtr Stack pointer for a T_DOUBLE_COLON token in the test file.
      * @param string $expected The expected fully qualified class name.

--- a/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
@@ -9,13 +9,13 @@
 /**
  * Classname determination function tests
  *
- * @uses BaseSniffTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  */
-class GetFQClassNameFromNewTokenTest extends BaseAbstractClassMethodTest
+class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = 'sniff-examples/utility-functions/get_fqclassname_from_new_token.php';
+    public $filename = '../sniff-examples/utility-functions/get_fqclassname_from_new_token.php';
 
     /**
      * testGetFQClassNameFromNewToken
@@ -25,6 +25,8 @@ class GetFQClassNameFromNewTokenTest extends BaseAbstractClassMethodTest
      * @requires PHP 5.3
      *
      * @dataProvider dataGetFQClassNameFromNewToken
+     *
+     * @covers PHPCompatibility_Sniff::getFQClassNameFromNewToken
      *
      * @param int    $stackPtr Stack pointer for a T_NEW token in the test file.
      * @param string $expected The expected fully qualified class name.

--- a/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -9,13 +9,13 @@
 /**
  * Extended class name determination function tests
  *
- * @uses BaseSniffTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  */
-class GetFQExtendedClassNameTest extends BaseAbstractClassMethodTest
+class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = 'sniff-examples/utility-functions/get_fqextended_classname.php';
+    public $filename = '../sniff-examples/utility-functions/get_fqextended_classname.php';
 
     /**
      * testGetFQExtendedClassName
@@ -25,6 +25,8 @@ class GetFQExtendedClassNameTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataGetFQExtendedClassName
+     *
+     * @covers PHPCompatibility_Sniff::getFQExtendedClassName
      *
      * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
      * @param string $expected The expected fully qualified class name.

--- a/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/Tests/BaseClass/GetFunctionParametersTest.php
@@ -9,14 +9,14 @@
 /**
  * Function parameters count function tests
  *
- * @uses    BaseSniffTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class GetFunctionParametersTest extends BaseAbstractClassMethodTest
+class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = 'sniff-examples/utility-functions/get_function_parameters.php';
+    public $filename = '../sniff-examples/utility-functions/get_function_parameters.php';
 
     /**
      * testGetFunctionCallParameters
@@ -24,6 +24,8 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataGetFunctionCallParameters
+     *
+     * @covers PHPCompatibility_Sniff::getFunctionCallParameters
      *
      * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
      * @param string $expected The expected fully qualified class name.
@@ -154,6 +156,8 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
      *
      * @dataProvider dataGetFunctionCallParameter
      *
+     * @covers PHPCompatibility_Sniff::getFunctionCallParameter
+     *
      * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
      * @param string $expected The expected fully qualified class name.
      */
@@ -207,6 +211,8 @@ class GetFunctionParametersTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataGetFunctionCallParameterCount
+     *
+     * @covers PHPCompatibility_Sniff::getFunctionCallParameterCount
      *
      * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
      * @param string $expected The expected fully qualified class name.

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -5,14 +5,17 @@
  * @package PHPCompatibility
  */
 
+if (class_exists('BaseSniffTest', true) === false) {
+    require_once dirname(dirname(__FILE__)) . '/BaseSniffTest.php';
+}
 
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
  *
- * @uses BaseSniffTest
+ * @uses    BaseSniffTest
  * @package PHPCompatibility
  */
-abstract class BaseAbstractClassMethodTest extends BaseSniffTest
+abstract class BaseClass_MethodTestFrame extends BaseSniffTest
 {
 
     public $filename;
@@ -41,7 +44,7 @@ abstract class BaseAbstractClassMethodTest extends BaseSniffTest
     {
         parent::setUp();
 
-        $this->helperClass = new TestHelperPHPCompatibility;
+        $this->helperClass = new BaseClass_TestHelperPHPCompatibility;
 
         $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->filename;
         $phpcs    = new PHP_CodeSniffer();

--- a/Tests/BaseClass/TestHelperPHPCompatibility.php
+++ b/Tests/BaseClass/TestHelperPHPCompatibility.php
@@ -6,7 +6,7 @@
  */
 
 if (class_exists('PHPCompatibility_Sniff', true) === false) {
-    require_once dirname( dirname(__FILE__) ) . '/Sniff.php';
+    require_once dirname(dirname(dirname(__FILE__))) . '/Sniff.php';
 }
 
 /**
@@ -15,7 +15,7 @@ if (class_exists('PHPCompatibility_Sniff', true) === false) {
  * @uses BaseSniffTest
  * @package PHPCompatibility
  */
-class TestHelperPHPCompatibility extends PHPCompatibility_Sniff {
+class BaseClass_TestHelperPHPCompatibility extends PHPCompatibility_Sniff {
 	public function register() {}
 	public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr) {}
 }

--- a/Tests/BaseClass/TokenHasScopeTest.php
+++ b/Tests/BaseClass/TokenHasScopeTest.php
@@ -9,14 +9,14 @@
 /**
  * Token scope function tests
  *
- * @uses    BaseSniffTest
+ * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class TokenScopeTest extends BaseAbstractClassMethodTest
+class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = 'sniff-examples/utility-functions/token_has_scope.php';
+    public $filename = '../sniff-examples/utility-functions/token_has_scope.php';
 
     /**
      * testTokenHasScope
@@ -24,6 +24,8 @@ class TokenScopeTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataTokenHasScope
+     *
+     * @covers PHPCompatibility_Sniff::tokenHasScope
      *
      * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
      * @param string $expected The expected boolean return value.
@@ -85,6 +87,8 @@ class TokenScopeTest extends BaseAbstractClassMethodTest
      * @group utilityFunctions
      *
      * @dataProvider dataInClassScope
+     *
+     * @covers PHPCompatibility_Sniff::inClassScope
      *
      * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
      * @param string $expected The expected boolean return value.

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -35,4 +35,4 @@ else {
 }
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';
-require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseAbstractClassMethodTest.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseClass' . DIRECTORY_SEPARATOR . 'MethodTestFrame.php';


### PR DESCRIPTION
* Move files containing tests for methods in the abstract base class `PHPCompatibility_Sniff` to their own subdirectory.
* Move related support files to that same subdirectory.
* Rename the test base class for these tests to a slightly more intuitive name.
* Add `@covers` annotations for each of these tests.