### PR TITLE
Add section about testing other sniff libs to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ on the sniffs, the following installation steps are required.
    PHPCompatibility. It will read the `phpunit.xml` file and execute the tests
 
 
+#### Issues when running the PHPCS Unit tests for another standard
+
+This sniff library uses it's own PHPUnit setup rather than the PHPCS native unit testing framework to allow for testing the sniffs with various config settings for the `testVersion` variable.
+
+If you are running the PHPCS native unit tests or the unit tests for another sniff library which uses the PHPCS native unit testing framework, PHPUnit might throw errors related to this sniff library depending on your setup.
+
+This will generally only happen if you have both PHPCompatibility as well as another custom sniff library in your PHPCS `installed_paths` setting.
+
+To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the following to the `phpunit.xml` file for the sniff library you are testing:
+```xml
+	<php>
+		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility"/>
+	</php>
+```
+
+This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.
+
+
 License
 -------
 This code is released under the GNU Lesser General Public License (LGPL). For more information, visit http://www.gnu.org/copyleft/lesser.html

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ on the sniffs, the following installation steps are required.
 
 #### Issues when running the PHPCS Unit tests for another standard
 
-This sniff library uses it's own PHPUnit setup rather than the PHPCS native unit testing framework to allow for testing the sniffs with various config settings for the `testVersion` variable.
+This sniff library uses its own PHPUnit setup rather than the PHPCS native unit testing framework to allow for testing the sniffs with various config settings for the `testVersion` variable.
 
 If you are running the PHPCS native unit tests or the unit tests for another sniff library which uses the PHPCS native unit testing framework, PHPUnit might throw errors related to this sniff library depending on your setup.
 


### PR DESCRIPTION
I was running into issues when locally testing other sniff libs which do use the PHPCS native testing framework.
The short of it was that this would result in a fatal error before any unit tests would be run as PHPCS was trying to load the PHPCompatibility unit test and sniff files and the setup is differently from what PHPCS expects.

I've figured out a solution for this which resulted in PR https://github.com/squizlabs/PHP_CodeSniffer/pull/1146

Once that PR is merged, the loading of the PHPCompatibility unit tests can be bypassed allowing for the testing of other sniff libraries without running into problems.

This PR adds a section to the Readme explaining how to apply the bypass for other developers who work on both PHPCompatibility as well as other sniff libs.