### PR TITLE
ParameterShadowSuperGlobalsSniff should only do a case-sensitive check.

### DIFF
--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -36,9 +36,6 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
      * @return array
      */
     public function register() {
-        // Prepare for case-insensitive compare.
-        $this->superglobals = array_map('strtolower', $this->superglobals);
-
         return array(T_FUNCTION);
     }
 
@@ -62,9 +59,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
         }
 
         foreach ($parameters as $param) {
-            $paramNameLc = strtolower($param['name']);
-
-            if (in_array($paramNameLc, $this->superglobals, true)) {
+            if (in_array($param['name'], $this->superglobals, true)) {
                 $error = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
                 $data  = array($param['name']);
                 $phpcsFile->addError($error, $stackPtr, 'Found', $data);

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -25,11 +25,8 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
      *
      * @dataProvider dataParameterShadowSuperGlobals
      *
-     * @param int    $line  Line number where the error should occur.
-     * @param string $octal (Start of) Binary number as a string.
-     * @param bool   $testNoViolation Whether or not to test for noViolation.
-     *               Defaults to true. Set to false if another error is
-     *               expected on the same line (invalid binary)
+     * @param string $superglobal Parameter name.
+     * @param int    $line        Line number where the error should occur.
      *
      * @return void
      */
@@ -62,8 +59,6 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
             array('$_SESSION', 10),
             array('$_REQUEST', 11),
             array('$_ENV', 12),
-            array('$globals', 15),
-            array('$_post', 16),
         );
     }
 
@@ -73,11 +68,32 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
      *
      * @group parameterShadowSuperGlobals
      *
+     * @dataProvider dataValidParameter
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testValidParameter() {
+    public function testValidParameter($line)
+    {
         $file = $this->sniffFile(self::TEST_FILE);
-        $this->assertNoViolation($file , 19);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testValidParameter()
+     *
+     * @return array
+     */
+    public function dataValidParameter()
+    {
+        return array(
+            array(15),
+            array(16),
+            array(17),
+        );
     }
 
 }

--- a/Tests/sniff-examples/parameter_shadow_superglobals.php
+++ b/Tests/sniff-examples/parameter_shadow_superglobals.php
@@ -11,9 +11,7 @@ function testingG( $_SESSION ) {}
 function testingH( $_REQUEST ) {}
 function testingI( $_ENV ) {}
 
-// Test case-insensitive compare.
+// This should be ok.
 function testingJ( $globals ) {}
 function testingK( $_post ) {}
-
-// This should be ok.
 function testingL( $POST ) {}


### PR DESCRIPTION
Fixes #214

* Check for variables names is now only done in a case-sensitive manner.
* The lowercase test cases have been moved to the 'testValidParameter()' unit test and so annotated in the test case file.
* As there are now more `noViolation` tests, the `testValidParameter()` method has been changed to use a dataprovider.
* Also fixes some copy/paste artifacts in the test documentation of the `testParameterShadowSuperGlobals()` method.