### PR TITLE
Minor improvements to `ForbiddenNegativeBitshift` sniff.

### DIFF
--- a/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -12,7 +12,7 @@
 /**
  * PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshift.
  *
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0
+ * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -43,15 +43,25 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff extends PHPComp
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('7.0')) {
-            $tokens = $phpcsFile->getTokens();
-
-            $nextNumber = $phpcsFile->findNext(T_LNUMBER, $stackPtr, null, false, null, true);
-            if ($tokens[$nextNumber - 1]['code'] == T_MINUS) {
-                $error = 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0';
-                $phpcsFile->addError($error, $nextNumber - 1);
-            }
+        if ($this->supportsAbove('7.0') === false) {
+            return;
         }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNumber = $phpcsFile->findNext(T_LNUMBER, $stackPtr + 1, null, false, null, true);
+        if($nextNumber === false || ($stackPtr + 1) === $nextNumber) {
+            return;
+        }
+
+        $hasMinusSign = $phpcsFile->findNext(T_MINUS, $stackPtr + 1, $nextNumber, false, null, true);
+        if($hasMinusSign === false) {
+            return;
+        }
+
+        $error = 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0';
+        $phpcsFile->addError($error, $hasMinusSign);
+
     }//end process()
 
 }//end class

--- a/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0
+ * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
  * @package PHPCompatibility
  */
 
 
 /**
- * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0
+ * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
  * @uses BaseSniffTest
  * @package PHPCompatibility
@@ -15,20 +15,76 @@
  */
 class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/forbidden_negative_bitshift.php';
+
     /**
-     * testSettingTestVersion
+     * testForbiddenNegativeBitshift
+     *
+     * @group forbiddenNegativeBitshift
+     *
+     * @dataProvider dataForbiddenNegativeBitshift
+     *
+     * @param int $line Line number where the error should occur.
      *
      * @return void
      */
-    public function testSettingTestVersion()
+    public function testForbiddenNegativeBitshift($line)
     {
-        $file = $this->sniffFile('sniff-examples/forbidden_negative_bitshift.php', '5.6');
-        $this->assertNoViolation($file, 3);
-        $this->assertNoViolation($file, 5);
-        
-        $file = $this->sniffFile('sniff-examples/forbidden_negative_bitshift.php', '7.0');
-        $this->assertError($file, 3, 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0');
-        $this->assertNoViolation($file, 5);
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0');
+    }
+
+    /**
+     * dataForbiddenNegativeBitshift
+     *
+     * @see testForbiddenNegativeBitshift()
+     *
+     * @return array
+     */
+    public function dataForbiddenNegativeBitshift() {
+        return array(
+            array(3),
+            array(4),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group forbiddenNegativeBitshift
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+            //array(9), - currently gives a false positive, @todo: uncomment when fixed.
+            array(12),
+        );
     }
 }
 

--- a/Tests/sniff-examples/forbidden_negative_bitshift.php
+++ b/Tests/sniff-examples/forbidden_negative_bitshift.php
@@ -1,5 +1,12 @@
 <?php
 
-var_dump(1 >> -1);
+var_dump(1 >> -1); // Bad.
+var_dump(1 >> - 1); // Bad.
 
-var_dump(1 >> 1);
+var_dump(1 >> 1); // Ok.
+var_dump(1 >> $variable); // Ok.
+var_dump(1 >> - $variable); // Ok - as we don't know whether the contents of $variable is positive or negative.
+var_dump(1 >> ($variable - 1)); // Ok - as we don't know whether the contents of $variable is positive or negative.
+
+// Don't throw errors on live code review.
+var_dump(1 >>


### PR DESCRIPTION
* Prevent undefined index notice when no LNUMBER can be found.
* Prevent undefined index notice on live code review.
* More precise token walking.

Includes additional unit tests for the above.
As there are now more unit tests, these have been reworked to data providers.

The PR contains one additional unit test which still yields a false positive. This has been so annotated.