### PR TITLE
Fix: namespace declarations can be nested within scoped declare() {} statements.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -652,8 +652,8 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                     if ($namespace !== false) {
                         return $namespace;
                     }
+                    break; // Nested namespaces is not possible.
                 }
-                break; // We only need to check the highest level condition.
             }
         }
 


### PR DESCRIPTION
Account for the fact that namespaces cannot be nested, but they **_can_** be contained within another scope, i.e. the `declare()` scope when used with braces.