### PR TITLE
Defer to upstream `findImplementedInterfaceNames()` method if available.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -123,8 +123,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      *
      * @return array|false
      */
-    public function findImplementedInterfaceNames($phpcsFile, $stackPtr)
+    public function findImplementedInterfaceNames(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if (method_exists($phpcsFile, 'findImplementedInterfaceNames')) {
+            return $phpcsFile->findImplementedInterfaceNames($stackPtr);
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         // Check for the existence of the token.


### PR DESCRIPTION
Upstream the PR for this method was merged and released in the 2.7.0 release.