### PR TITLE
Adjust error level for invalid execution directives to warning.

### DIFF
--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -123,7 +123,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
                 return;
             }
 
-            $this->addErrorOnInvalidValue($phpcsFile, $valuePtr, $directiveContent);
+            $this->addWarningOnInvalidValue($phpcsFile, $valuePtr, $directiveContent);
         }
 
     }//end process()
@@ -193,7 +193,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
      *
      * @return void
      */
-    protected function addErrorOnInvalidValue($phpcsFile, $stackPtr, $directive)
+    protected function addWarningOnInvalidValue($phpcsFile, $stackPtr, $directive)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -221,7 +221,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
                 $directive,
                 $value,
             );
-            $phpcsFile->addError($error, $stackPtr, 'InvalidDirectiveValueFound', $data);
+            $phpcsFile->addWarning($error, $stackPtr, 'InvalidDirectiveValueFound', $data);
         }
     }// addErrorOnInvalidValue()
 

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -104,7 +104,7 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
      */
     public function testInvalidDirectiveValue($directive, $value, $line)
     {
-        $this->assertError($this->_sniffFile, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
+        $this->assertWarning($this->_sniffFile, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
     }
 
     /**
@@ -140,7 +140,7 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
     public function testInvalidEncodingDirectiveValue($directive, $value, $line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
-        $this->assertError($file, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
+        $this->assertWarning($file, $line, "The execution directive {$directive} does not seem to have a valid value. Please review. Found: {$value}");
     }
 
     /**


### PR DESCRIPTION
Changed error level for the invalid value checks for execution directives from error to warning as it doesn't directly translate to a compatibility issue.

Alternatively, these "valid value" checks could be removed if that would be preferred, though it is doubtful anyone who knows what they're doing will ever see them anyway.