### PR TITLE
Add new `stripQuotes()` method.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -108,6 +108,21 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         }
     }//end supportsBelow()
 
+
+    /**
+     * Strip quotes surrounding an arbitrary string.
+     *
+     * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING.
+     *
+     * @param string $string The raw string.
+     *
+     * @return string String without quotes around it.
+     */
+    public function stripQuotes($string) {
+        return preg_replace('`^([\'"])(.*)\1$`Ds', '$2', $string);
+    }
+
+
     /**
      * Returns the name(s) of the interface(s) that the specified class implements.
      *

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -231,7 +231,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             return;
         }
 
-        $filteredToken = trim($iniToken['raw'], '\'"');
+        $filteredToken = $this->stripQuotes($iniToken['raw']);
         if (isset($this->deprecatedIniDirectives[$filteredToken]) === false) {
             return;
         }

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -251,7 +251,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
         }
 
         $defineName = strtolower($firstParam['raw']);
-        $defineName = trim($defineName, '\'"');
+        $defineName = $this->stripQuotes($defineName);
 
         if (isset($this->invalidNames[$defineName]) && $this->supportsAbove($this->invalidNames[$defineName])) {
             $error = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since PHP version %s)";

--- a/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -82,11 +82,11 @@ class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompa
         /**
          * Get the content of any string tokens in the options parameter and remove the quotes.
          */
-        $options = trim($tokens[$stringToken]['content'], '\'"');
+        $options = $this->stripQuotes($tokens[$stringToken]['content']);
         if ($stringToken !== $optionsParam['end']) {
             while ($stringToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stringToken + 1, $optionsParam['end'] + 1)) {
                 if ($tokens[$stringToken]['code'] === T_CONSTANT_ENCAPSED_STRING) {
-                    $options .= trim($tokens[$stringToken]['content'], '\'"');
+                    $options .= $this->stripQuotes($tokens[$stringToken]['content']);
                 }
             }
         }

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -199,7 +199,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
 
         $value = $tokens[$stackPtr]['content'];
         if ($tokens[$stackPtr]['code'] === T_CONSTANT_ENCAPSED_STRING) {
-            $value = trim($value, '\'"');
+            $value = $this->stripQuotes($value);
         }
 
         $isError = false;

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -511,7 +511,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             return;
         }
 
-        $filteredToken = trim($iniToken['raw'], '\'"');
+        $filteredToken = $this->stripQuotes($iniToken['raw']);
         if (isset($this->newIniDirectives[$filteredToken]) === false) {
             return;
         }

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -96,7 +96,7 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
          * and end will still be strings. And as that's all we're concerned with,
          * just use the raw content of the first parameter for further processing.
          */
-        $regex = trim($firstParam['raw'], '\'"');
+        $regex = $this->stripQuotes($firstParam['raw']);
 
         $regexFirstChar = substr($regex, 0, 1);
         if (isset($this->doublesSeparators[$regexFirstChar])) {

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -77,7 +77,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
                  * Algorithm is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes
                  */
                 $algo = strtolower($tokens[$firstParam]['content']);
-                $algo = substr($algo, 1, strlen($algo) - 2);
+                $algo = $this->stripQuotes($algo);
                 switch ($algo) {
                     case 'salsa10':
                     case 'salsa20':

--- a/Sniffs/PHP/ValidIntegersSniff.php
+++ b/Sniffs/PHP/ValidIntegersSniff.php
@@ -198,7 +198,7 @@ class PHPCompatibility_Sniffs_PHP_ValidIntegersSniff extends PHPCompatibility_Sn
     private function isHexidecimalNumericString($tokens, $stackPtr) {
         $token = $tokens[$stackPtr];
 
-        if ($token['code'] === T_CONSTANT_ENCAPSED_STRING && preg_match('`^([\'"])0x[a-f0-9]+\1$`iD', $token['content']) === 1) {
+        if ($token['code'] === T_CONSTANT_ENCAPSED_STRING && preg_match('`^0x[a-f0-9]+$`iD', $this->stripQuotes($token['content'])) === 1) {
             return true;
         }
 

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Generic sniff functions test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Generic sniff functions sniff tests
+ *
+ * @uses    PHPUnit_Framework_TestCase
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * A wrapper for the abstract PHPCompatibility sniff.
+     *
+     * @var PHPCompatibility_Sniff
+     */
+    protected $helperClass;
+
+
+    public static function setUpBeforeClass()
+    {
+        require_once dirname(__FILE__) . '/TestHelperPHPCompatibility.php';
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->helperClass = new BaseClass_TestHelperPHPCompatibility;
+    }
+
+
+   /**
+     * testStripQuotes
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataStripQuotes
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected function output.
+     */
+    public function testStripQuotes($input, $expected)
+    {
+        $this->assertSame($expected, $this->helperClass->stripQuotes($input));
+    }
+
+    /**
+     * dataStripQuotes
+     *
+     * @see testStripQuotes()
+     *
+     * @return array
+     */
+    public function dataStripQuotes()
+    {
+        return array(
+            array('"dir_name"', 'dir_name'),
+            array("'soap.wsdl_cache'", 'soap.wsdl_cache'),
+            array('"arbitrary-\'string\" with\' quotes within"', 'arbitrary-\'string\" with\' quotes within'),
+            array('"\'quoted_name\'"', "'quoted_name'"),
+            array("'\"quoted\" start of string'", '"quoted" start of string'),
+        );
+    }
+
+}


### PR DESCRIPTION
... to strip quotes which surround `T_CONSTANT_ENCAPSED_STRING`s in a consistent manner.

Includes unit tests for the newly introduced function.