### PR TITLE
Added note about PHP version support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ PHP Version Support
 
 The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
 
-Although we do not intend to work on it ourselves, we will accept pull requests that check for compatibility issues in PHP4 code (in particular between PHP 4 and PHP 5.0) as there may still be situations where people need help upgrading legacy systems.  However, coverage for changes introduced in PHP up to and including 5.0 will remain patchy as supporting older versions is not a primary aim at this time.
+Pull requests that check for compatibility issues in PHP4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
 
-The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results across different testing systems.
+The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results independently of the PHP version used in your test environment.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the
 
 This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.
 
+PHP Version Support
+-------
+
+The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
+
+Although we do not intend to work on it ourselves, we will accept pull requests that check for compatibility issues in PHP4 code (in particular between PHP 4 and PHP 5.0) as there may still be situations where people need help upgrading legacy systems.  However, coverage for changes introduced in PHP up to and including 5.0 will remain patchy as supporting older versions is not a primary aim at this time.
+
+The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results across different testing systems.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This is a set of sniffs for [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffe
 It will allow you to analyse your code for compatibility with higher and lower versions of PHP. 
 
 
+PHP Version Support
+-------
+
+The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
+
+Pull requests that check for compatibility issues in PHP4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
+
+The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results independently of the PHP version used in your test environment.
+
 Thank you
 ---------
 Thanks to all contributors for their valuable contributions.
@@ -151,15 +160,6 @@ To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the
 ```
 
 This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.
-
-PHP Version Support
--------
-
-The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
-
-Pull requests that check for compatibility issues in PHP4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
-
-The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer.  Therefore you should get consistent results independently of the PHP version used in your test environment.
 
 License
 -------


### PR DESCRIPTION
As discussed in #141 it would be sensible to document what versions of PHP are supported, both for running the sniff and for the compatibility checks it contains.

I hope I have accurately captured the current state of the project in this regard, but please amend as necessary.