### PR TITLE
Sniff methods too in `NewFunctionArrayDereferencing` sniff.

### DIFF
--- a/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -22,15 +22,35 @@ class NewFunctionArrayDereferencingSniffTest extends BaseSniffTest
      *
      * @group functionArrayDereferencing
      *
+     * @dataProvider dataArrayDereferencing
+     *
+     * @param int $line Line number with valid code.
+     *
      * @return void
      */
-    public function testArrayDereferencing()
+    public function testArrayDereferencing($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, 3, 'Function array dereferencing is not present in PHP version 5.3 or earlier');
+        $this->assertError($file, $line, 'Function array dereferencing is not present in PHP version 5.3 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
-        $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataArrayDereferencing
+     *
+     * @see testArrayDereferencing()
+     *
+     * @return array
+     */
+    public function dataArrayDereferencing() {
+        return array(
+            array(3),
+            array(14),
+            array(15),
+            array(16),
+        );
     }
 
 
@@ -65,7 +85,7 @@ class NewFunctionArrayDereferencingSniffTest extends BaseSniffTest
             array(9),
             array(10),
             array(11),
-            array(14),
+            array(19),
         );
     }
 }

--- a/Tests/sniff-examples/new_function_array_dereferencing.php
+++ b/Tests/sniff-examples/new_function_array_dereferencing.php
@@ -10,5 +10,10 @@ if (dol_strlen(trim($this->object->address)) == 0) $this->tpl['address'] = $objs
 dol_htmloutput_errors((is_numeric($GLOBALS['error'])?'':$GLOBALS['error']),$GLOBALS['errors']);
 if ((! is_numeric($records) || $records != 0) && (! isset($records['count']) || $records['count'] > 0)) {}
 
+// Issue #227 - these should all throw an error.
+echo $foo->bar()[1];
+echo $foo->bar()->baz()[2];
+echo testClass::another_test()[0];
+
 // Don't throw errors during live code review.
 echo test(


### PR DESCRIPTION
Includes additional unit tests.

Fixes #227