### PR TITLE
Exclude `tests` directory alltogether from Scrutinizer config.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 filter:
     excluded_paths:
-        - 'Tests/sniff-examples/*'
+        - 'Tests/*'
 
 tools:
     php_sim: true


### PR DESCRIPTION
As the test methods and data providers are all very similar, Scrutinizer will report on these as if they were duplicates.
Also, it skews the quality score as that's supposed to be about the quality of the library itself, not about the tests covering the library.