### PR TITLE
Make `DeprecatedPHP4StyleConstructors` sniff case-insensitive.

### DIFF
--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -58,6 +58,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
         }
 
         $nextFunc            = $stackPtr;
+        $classNameLc         = strtolower($className);
         $newConstructorFound = false;
         $oldConstructorFound = false;
         $oldConstructorPos   = -1;
@@ -67,18 +68,20 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
                 continue;
             }
 
-            if ($funcName === '__construct') {
+            $funcNameLc = strtolower($funcName);
+
+            if ($funcNameLc === '__construct') {
                 $newConstructorFound = true;
             }
 
-            if ($funcName === $className) {
+            if ($funcNameLc === $classNameLc) {
                 $oldConstructorFound = true;
                 $oldConstructorPos   = $phpcsFile->findNext(T_STRING, $nextFunc);
             }
         }
 
         if ($newConstructorFound === false && $oldConstructorFound === true) {
-            $phpcsFile->addError('Deprecated PHP4 style constructor are not supported since PHP7', $oldConstructorPos);
+            $phpcsFile->addError('Use of deprecated PHP4 style class constructor is not supported since PHP 7', $oldConstructorPos);
         }
     }
 }

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -14,37 +14,79 @@
  */
 class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/deprecated_php4style_constructors.php';
+
     /**
      * Test PHP4 style constructors.
      *
      * @group deprecatedPHP4Constructors
      *
+     * @dataProvider dataIsDeprecated
+     *
+     * @param int $line Line number where the error should occur.
+     *
      * @return void
      */
-    public function testIsDeprecated()
+    public function testIsDeprecated($line)
     {
-        $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '5.6');
-        $this->assertNoViolation($file, 3);
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
 
-        $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '7.0');
-        $this->assertError($file, 3, 'Deprecated PHP4 style constructor are not supported since PHP7');
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Use of deprecated PHP4 style class constructor is not supported since PHP 7');
     }
+
+    /**
+     * dataIsDeprecated
+     *
+     * @see testIsDeprecated()
+     *
+     * @return array
+     */
+    public function dataIsDeprecated()
+	{
+        return array(
+            array(3),
+            array(18),
+        );
+    }
+
 
     /**
      * Test valid methods with the same name as the class.
      *
      * @group deprecatedPHP4Constructors
      *
+     * @dataProvider dataValidMethods
+     *
+     * @param int $line Line number where the error should occur.
+     *
      * @return void
      */
-    public function testValidMethods()
+    public function testValidMethods($line)
     {
-        $file = $this->sniffFile('sniff-examples/deprecated_php4style_constructors.php', '7.0');
-        $this->assertNoViolation($file, 9);
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
 
+    /**
+     * dataValidMethods
+     *
+     * @see testValidMethods()
+     *
+     * @return array
+     */
+    public function dataValidMethods()
+	{
+        $testCases = array(
+            array(9),
+        );
+
+        // Add an additional testscase which will only be 'no violation' if namespaces are recognized.
         if (version_compare(phpversion(), '5.3', '>=')) {
-            // Will only be no violation if namespaces are recognized.
-            $this->assertNoViolation($file, 20);
+            $testCases[] = array(26);
         }
+
+        return $testCases;
     }
 }

--- a/Tests/sniff-examples/deprecated_php4style_constructors.php
+++ b/Tests/sniff-examples/deprecated_php4style_constructors.php
@@ -14,6 +14,12 @@ class bar {
     }
 }
 
+class barFOO {
+    function BARfoo() {
+        echo 'I am the constructor - but I shouldn\'t be';
+    }
+}
+
 namespace foobar {
 
     class foobar {


### PR DESCRIPTION
Both class names as well as function names in PHP are case-insensitive, so this check should be done in a case-insensitive manner.

Includes additional unit test.

Also:
* As there are now more unit tests, refactored the test file to use data providers in line with other test files.
* The error message was grammatically incorrect. This has now been fixed.

----

~~_**Note**: the unit tests are currently failing against master. That is unrelated to this PR, but has to do with a change upstream which affects the test framework.
See https://github.com/wimg/PHPCompatibility/pull/235#issuecomment-249254988 for more info._~~ Fixed upstream. Unit tests should pass again.