### PR TITLE
Make `NewClasses` sniff case-insensitive.

### DIFF
--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -193,6 +193,11 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
      */
     public function register()
     {
+        // Handle case-insensitivity of class names.
+        $keys = array_keys( $this->newClasses );
+        $keys = array_map( 'strtolower', $keys );
+        $this->newClasses = array_combine( $keys, $this->newClasses );
+
         return array(
                 T_NEW,
                 T_CLASS,
@@ -234,9 +239,10 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
             return;
         }
 
-        $className = substr($FQClassName, 1); // Remove global namespace indicator.
+        $className   = substr($FQClassName, 1); // Remove global namespace indicator.
+        $classNameLc = strtolower($className);
 
-        if (array_key_exists($className, $this->newClasses) === false) {
+        if (isset($this->newClasses[$classNameLc]) === false) {
             return;
         }
 
@@ -257,10 +263,11 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
      */
     protected function addError($phpcsFile, $stackPtr, $className)
     {
-        $error = '';
+        $error       = '';
+        $isError     = false;
+        $classNameLc = strtolower($className);
 
-        $isError = false;
-        foreach ($this->newClasses[$className] as $version => $present) {
+        foreach ($this->newClasses[$classNameLc] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
                     $isError = true;

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -21,6 +21,8 @@ class NewClassesSniffTest extends BaseSniffTest
     /**
      * testNewClass
      *
+     * @group newClasses
+     *
      * @dataProvider dataNewClass
      *
      * @param string $className         Class name.
@@ -89,12 +91,18 @@ class NewClassesSniffTest extends BaseSniffTest
             array('IntlBreakIterator', '5.4', array(58, 98, 138), '5.5'),
             array('IntlRuleBasedBreakIterator', '5.4', array(59, 99, 139), '5.5'),
             array('IntlCodePointBreakIterator', '5.4', array(60, 100, 140), '5.5'),
+            
+            array('DATETIME', '5.1', array(146), '5.2'),
+            array('datetime', '5.1', array(147), '5.2'),
+            array('dATeTiMe', '5.1', array(148), '5.2'),
         );
     }
 
 
     /**
      * testNoViolation
+     *
+     * @group newClasses
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -11,7 +11,7 @@ $okay = namespace\DateTime::static_method();
 
 /*
  * 1. Verify instantiation without parameters is being flagged.
- * 2. + 3. Verify that instation with spacing/comments between elements is being flagged.
+ * 2. + 3. Verify that instantion with spacing/comments between elements is being flagged.
  * 4. Verify that instation with global namespace indicator is being flagged.
  */
 $test = new DateInterval;
@@ -138,3 +138,11 @@ IntlTimeZone::$static_property;
 IntlBreakIterator::$static_property;
 IntlRuleBasedBreakIterator::$static_property;
 IntlCodePointBreakIterator::$static_property;
+
+
+/**
+ * These should all be flagged too as classnames are case-insensitive.
+ */
+$test = new DATETIME(); // Uppercase.
+class MyDateTime extends datetime {} // Lowercase.
+dATeTiMe::static_method(); // Mixed case.


### PR DESCRIPTION
Class names in PHP are case-insensitive, so this check should be done in a case-insensitive manner.

Includes additional unit test.


----

~~_**Note**: the unit tests are currently failing against master. That is unrelated to this PR, but has to do with a change upstream which affects the test framework.
See https://github.com/wimg/PHPCompatibility/pull/235#issuecomment-249254988 for more info._~~ Fixed upstream. Unit tests should pass again.