### PR TITLE
Rewrite the `ShortArray` sniff.

### DIFF
--- a/Sniffs/PHP/ShortArraySniff.php
+++ b/Sniffs/PHP/ShortArraySniff.php
@@ -2,17 +2,6 @@
 
 class PHPCompatibility_Sniffs_PHP_ShortArraySniff extends PHPCompatibility_Sniff
 {
-    /** @var array */
-    protected $supportByVersion = array(
-        '5.3' => false,
-        '5.4' => true
-    );
-
-    /** @var array */
-    protected $errorByForbiddenTokens = array(
-        'T_OPEN_SHORT_ARRAY' => 'Short array syntax (open)',
-        'T_CLOSE_SHORT_ARRAY' => 'Short array syntax (close)'
-    );
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -21,7 +10,10 @@ class PHPCompatibility_Sniffs_PHP_ShortArraySniff extends PHPCompatibility_Sniff
      */
     public function register()
     {
-        return array(T_OPEN_TAG);
+        return array(
+            T_OPEN_SHORT_ARRAY,
+            T_CLOSE_SHORT_ARRAY,
+        );
     }//end register()
 
 
@@ -36,24 +28,24 @@ class PHPCompatibility_Sniffs_PHP_ShortArraySniff extends PHPCompatibility_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
-        foreach ($tokens as $currentToken) {
-            if (!isset($this->errorByForbiddenTokens[$currentToken['type']])) {
-                continue;
-            }
-
-            foreach ($this->supportByVersion as $version => $support) {
-                if ($this->supportsBelow($version)) {
-                    if ($support) {
-                        continue;
-                    }
-
-                    $error = $this->errorByForbiddenTokens[$currentToken['type']] . ' is available since 5.4';
-                    $phpcsFile->addError($error, $stackPtr);
-                }
-            }
+        if ($this->supportsBelow('5.3') === false) {
+            return;
         }
+
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+
+        $error = '%s is available since 5.4';
+        $data  = array();
+
+        if ($token['type'] === 'T_OPEN_SHORT_ARRAY' ) {
+            $data[] = 'Short array syntax (open)';
+        } elseif ($token['type'] === 'T_CLOSE_SHORT_ARRAY' ) {
+            $data[] = 'Short array syntax (close)';
+        }
+
+        $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
     }//end process()
 
 }//end class

--- a/Tests/Sniffs/PHP/ShortArraySniffTest.php
+++ b/Tests/Sniffs/PHP/ShortArraySniffTest.php
@@ -14,46 +14,76 @@
  */
 class ShortArraySniffTest extends BaseSniffTest
 {
-    /** @var string */
-    protected $_sniffFileName;
-
-    /** @var int */
-    protected $_lineNumber = 1;
+    const TEST_FILE = 'sniff-examples/short_array.php';
 
     /**
+     * testViolation
      *
+     * @group shortArraySyntax
+     *
+     * @dataProvider dataViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
      */
-    public function setUp()
+    public function testViolation($line)
     {
-        parent::setUp();
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Short array syntax (open) is available since 5.4');
+        $this->assertError($file, $line, 'Short array syntax (close) is available since 5.4');
 
-        $this->_sniffFileName = 'sniff-examples/short_array.php';
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
+     * Data provider.
      *
+     * @see testViolation()
+     *
+     * @return array
      */
-    public function testNoViolation()
+    public function dataViolation()
     {
-        $file = $this->sniffFile($this->_sniffFileName, '5.4');
-        $this->assertNoViolation($file, $this->_lineNumber);
-        $file = $this->sniffFile($this->_sniffFileName, '5.5');
-        $this->assertNoViolation($file, $this->_lineNumber);
-        $file = $this->sniffFile($this->_sniffFileName, '5.6');
-        $this->assertNoViolation($file, $this->_lineNumber);
+        return array(
+            array(12),
+            array(13),
+            array(14),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group shortArraySyntax
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
     }
 
     /**
+     * Data provider.
      *
+     * @see testNoViolation()
+     *
+     * @return array
      */
-    public function testViolation()
+    public function dataNoViolation()
     {
-        $file = $this->sniffFile($this->_sniffFileName, '5.3');
-        $this->assertError($file, $this->_lineNumber, 'Short array syntax (open) is available since 5.4');
-        $this->assertError($file, $this->_lineNumber, 'Short array syntax (close) is available since 5.4');
-
-        $file = $this->sniffFile($this->_sniffFileName, '5.2');
-        $this->assertError($file, $this->_lineNumber, 'Short array syntax (open) is available since 5.4');
-        $this->assertError($file, $this->_lineNumber, 'Short array syntax (close) is available since 5.4');
+        return array(
+            array(5),
+            array(6),
+            array(7),
+        );
     }
 }

--- a/Tests/sniff-examples/short_array.php
+++ b/Tests/sniff-examples/short_array.php
@@ -1,3 +1,14 @@
 <?php
+/**
+ * These should be ok.
+ */
 $str = 'This is fake array: []';
+$arr = array();
+$arr[] = 'add a value';
+
+/**
+ * These should be flagged.
+ */
 $arr = [];
+$arr = [1,2,3];
+$arr[] = ['A','B'];


### PR DESCRIPTION
This sniff was using unnecessary nested loops and walking a complete file from the PHP open tag down instead of sniffing for the actual short array tags.

This simplifies the sniff immensely and should make the sniff faster.

Includes some additional unit test cases.

Also:
* Refactored the unit tests to data providers.
* Check the violation case properly against version for violation/noViolation.
* Check non-offending syntaxes for false positives through an improved noViolation test.

----

~~_**Note**: the unit tests are currently failing against master. That is unrelated to this PR, but has to do with a change upstream which affects the test framework.
See https://github.com/wimg/PHPCompatibility/pull/235#issuecomment-249254988 for more info._~~ Fixed upstream. Unit tests should pass again.