### PR TITLE
Improve the `RemovedHashAlgorithms` sniff (code review).

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -22,6 +22,24 @@
 abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 {
 
+    /**
+     * List of functions using hash algorithm as parameter (always the first parameter).
+     *
+     * Used by the new/removed hash algorithm sniffs.
+     * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @var array
+     */
+    protected $hashAlgoFunctions = array(
+        'hash_file'      => 1,
+        'hash_hmac_file' => 1,
+        'hash_hmac'      => 1,
+        'hash_init'      => 1,
+        'hash_pbkdf2'    => 1,
+        'hash'           => 1,
+    );
+
+
 /* The testVersion configuration variable may be in any of the following formats:
  * 1) Omitted/empty, in which case no version is specified.  This effectively
  *    disables all the checks provided by this standard.

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -13,7 +13,7 @@
 /**
  * PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff.
  *
- * Discourages the use of deprecated and removed hash algorithms
+ * Discourages the use of deprecated and removed hash algorithms.
  *
  * PHP version 5.4
  *
@@ -26,16 +26,20 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
 {
 
     /**
-     * List of functions using the algorithm as parameter (always the first parameter)
+     * A list of removed hash algorithms, which were present in older versions.
      *
-     * @var array
+     * The array lists : version number with false (deprecated) and true (removed).
+     * If's sufficient to list the first version where the hash algorithm was deprecated/removed.
+     *
+     * @var array(string => array(string => bool))
      */
-    protected $algoFunctions = array(
-        'hash_file',
-        'hash_hmac_file',
-        'hash_hmac',
-        'hash_init',
-        'hash'
+    protected $removedAlgorithms = array(
+        'salsa10' => array(
+            '5.4' => true,
+        ),
+        'salsa20' => array(
+            '5.4' => true,
+        ),
     );
 
     /**
@@ -61,36 +65,111 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.4')) {
-            $tokens = $phpcsFile->getTokens();
+        $tokens         = $phpcsFile->getTokens();
+        $functionName   = $tokens[$stackPtr]['content'];
+        $functionNameLc = strtolower($functionName);
 
-            if (in_array($tokens[$stackPtr]['content'], $this->algoFunctions) === true) {
-                $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
-
-                if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
-                    return;
-                }
-
-                $firstParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($openBracket + 1), null, true);
-
-                /**
-                 * Algorithm is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes
-                 */
-                $algo = strtolower($tokens[$firstParam]['content']);
-                $algo = $this->stripQuotes($algo);
-                switch ($algo) {
-                    case 'salsa10':
-                    case 'salsa20':
-                        $error = 'The Salsa10 and Salsa20 hash algorithms have been removed since PHP 5.4';
-                        $phpcsFile->addError($error, $stackPtr);
-                        break;
-                }
-
-            }
+        // Bow out if not one of the functions we're targetting.
+        if (isset($this->hashAlgoFunctions[$functionNameLc]) === false) {
+            return;
         }
 
+        // Get the parameter from the function call which should contain the algorithm name.
+        $algoParam = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->hashAlgoFunctions[$functionNameLc]);
+        if ($algoParam === false) {
+            return;
+        }
+
+        /**
+         * Algorithm is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes.
+         */
+        $algo = strtolower(trim($algoParam['raw']));
+        $algo = $this->stripQuotes($algo);
+
+
+        // Bow out if not one of the algorithms we're targetting.
+        if (isset($this->removedAlgorithms[$algo]) === false) {
+            return;
+        }
+
+        // Check if the algorithm used is deprecated or removed.
+        $errorInfo = $this->getErrorInfo($algo);
+
+        if ($errorInfo['deprecated'] !== '' || $errorInfo['removed'] !== '') {
+            $this->addError($phpcsFile, $algoParam['start'], $algo, $errorInfo);
+        }
 
     }//end process()
 
+
+    /**
+     * Retrieve the relevant (version) information for the error message.
+     *
+     * @param string $algorithm The name of the algorithm.
+     *
+     * @return array
+     */
+    protected function getErrorInfo($algorithm)
+    {
+        $errorInfo  = array(
+            'deprecated'  => '',
+            'removed'     => '',
+            'error'       => false,
+        );
+
+        foreach ($this->removedAlgorithms[$algorithm] as $version => $removed) {
+            if ($this->supportsAbove($version)) {
+                if ($removed === true && $errorInfo['removed'] === '') {
+                    $errorInfo['removed'] = $version;
+                    $errorInfo['error']   = true;
+                } elseif ($errorInfo['deprecated'] === '') {
+                    $errorInfo['deprecated'] = $version;
+                }
+            }
+        }
+
+        return $errorInfo;
+
+    }//end getErrorInfo()
+
+
+    /**
+     * Generates the error or warning for this sniff.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the function
+     *                                        in the token array.
+     * @param string               $algorithm The name of the algorithm.
+     * @param array                $errorInfo Array with details about the versions
+     *                                        in which the algorithm was deprecated
+     *                                        and/or removed.
+     *
+     * @return void
+     */
+    protected function addError($phpcsFile, $stackPtr, $algorithm, $errorInfo)
+    {
+        $error     = 'The %s hash algorithm is ';
+        $errorCode = $algorithm . 'Found';
+        $data      = array($algorithm);
+
+        if ($errorInfo['deprecated'] !== '') {
+            $error .= 'deprecated since PHP version %s and ';
+            $data[] = $errorInfo['deprecated'];
+        }
+        if ($errorInfo['removed'] !== '') {
+            $error .= 'removed since PHP version %s and ';
+            $data[] = $errorInfo['removed'];
+        }
+
+        // Remove the last 'and' from the message.
+        $error = substr($error, 0, strlen($error) - 5);
+
+        if ($errorInfo['error'] === true) {
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+        } else {
+            $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
+        }
+
+    }//end addError()
 
 }//end class

--- a/Tests/sniff-examples/removed_hash_algorithms.php
+++ b/Tests/sniff-examples/removed_hash_algorithms.php
@@ -1,18 +1,25 @@
 <?php
 
-hash_file("something");
+/**
+ * These should all be fine.
+ */
+hash_file("something"); // Not one of the targetted algorithms.
+hash("1st param", "salsa10"); // Not the right parameter.
+hash_hmac; // Not a function call.
+
+/**
+ * These should all be flagged.
+ */
 hash_file("salsa10");
 hash_file("salsa20");
 hash_file('salsa10');
 hash_file('salsa20');
 
 hash_hmac_file("salsa10");
-
-hash_hmac("salsa20");
-
-hash_init("salsa20");
+hash_hmac( "salsa20" );
+hash_init(   'salsa10'  );
 
 hash("salsa10");
 hash("salsa10", "2nd param", 3, false);
-hash("1st param", "salsa10");
-hash_hmac;
+
+hash_pbkdf2('salsa20'); // Needs to be tested separately as the function was only introduced in PHP 5.5.


### PR DESCRIPTION
* Add `hash_pbkdf2()` function to the list of functions to check + added unit test to that effect.
* Moved the functions list to the main `PHPCompatibility_Sniff` in anticipation of a `NewHashAlgorithms` sniff (upcoming).
* Do the function name comparison in a case-insensitive manner.
* Use the `PHPCompatibility_Sniff::getFunctionCallParameter()` method to get the target algorithm parameter.
* Refactored the sniff to be more flexible.
   - The algorithms to sniff for have been moved to an array with version numbers similar to most other sniffs. This allows for the adding of additional removed algorithms with different PHP removal versions in the future.
   - Allow for algorithms being deprecated before being removed.
   - The error message now specifically references the algorithm encountered.
* Reordered and added documentation to the unit test cases.
* Refactored the test file to use data providers in line with other earlier refactors.

_Note: This refactored sniff already contains a split between the checking whether something needs to be flagged and the actually flagging. This is (again) in anticipation of - yet another - upcoming PR which will do this for a lot more sniffs and subsequently remove a lot of duplicate code._

----

~~_**Note**: the unit tests are currently failing against master. That is unrelated to this PR, but has to do with a change upstream which affects the test framework.
See https://github.com/wimg/PHPCompatibility/pull/235#issuecomment-249254988 for more info._~~ Fixed upstream. Unit tests should pass again.