### PR TITLE
Add new `NewHashAlgorithms` sniff.

### DIFF
--- a/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * New hash algorithms sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New hash algorithms sniff tests.
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewHashAlgorithmsSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_hash_algorithms.php';
+
+    /**
+     * testNewHashAlgorithms
+     *
+     * @group hashAlgorithms
+     *
+     * @dataProvider dataNewHashAlgorithms
+     *
+     * @param string $algorithm         Name of the algorithm.
+     * @param string $lastVersionBefore The PHP version just *before* the algorithm was introduced.
+     * @param array  $lines             The line number in the test file on which an error should occur.
+     * @param string $okVersion         A PHP version in which the algorithm was valid.
+     *
+     * @return void
+     */
+    public function testNewHashAlgorithms($algorithm, $lastVersionBefore, $line, $okVersion)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $this->assertError($file, $line, "The {$algorithm} hash algorithm is not present in PHP version {$lastVersionBefore} or earlier");
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewHashAlgorithms()
+     *
+     * @return array
+     */
+    public function dataNewHashAlgorithms()
+    {
+        return array(
+            array('md2', '5.2', 13, '5.3'),
+            array('ripemd256', '5.2', 14, '5.3'),
+            array('ripemd320', '5.2', 15, '5.3'),
+            array('salsa10', '5.2', 16, '5.3'),
+            array('salsa20', '5.2', 18, '5.3'),
+            array('snefru256', '5.2', 19, '5.3'),
+            array('sha224', '5.2', 20, '5.3'),
+            array('joaat', '5.3', 22, '5.4'),
+            array('fnv132', '5.3', 23, '5.4'),
+            array('fnv164', '5.3', 24, '5.4'),
+            array('gost-crypto', '5.5', 26, '5.6'),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group hashAlgorithms
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.0-99.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+        );
+    }
+
+}

--- a/Tests/sniff-examples/new_hash_algorithms.php
+++ b/Tests/sniff-examples/new_hash_algorithms.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * These should all be fine.
+ */
+hash_file("something"); // Not one of the targetted algorithms.
+hash("1st param", "md2"); // Not the right parameter.
+hash_init; // Not a function call.
+
+/**
+ * These should all be flagged.
+ */
+hash_file('md2');
+hash_file('ripemd256');
+hash_file("ripemd320");
+hash_file( "salsa10" );
+
+hash_hmac(     "salsa20"      );
+hash_hmac_file("snefru256");
+hash_init(   'sha224'  );
+
+hash("joaat");
+hash("fnv132", "2nd param", 3, false);
+hash("fnv164");
+
+hash_pbkdf2('gost-crypto');


### PR DESCRIPTION
Sister-sniff to the `RemovedHashAlgorithms` sniff, this sniff checks for hash algorithms which were newly introduced in PHP.

Ref: http://php.net/manual/en/function.hash-algos.php

Moved the algorithm name determination out of the the `RemovedHashAlgorithms` sniff to the base sniff to prevent code duplication as we need to do exactly the same in this sniff.

Includes unit tests.