### PR TITLE
Minor fix for `NewInterfaces` sniff.

### DIFF
--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -136,7 +136,7 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
                 $nextFunc = $stackPtr;
                 while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
                     $funcName = strtolower($phpcsFile->getDeclarationName($nextFunc));
-                    if (is_string($funcName) === false) {
+                    if ($funcName === '') {
                         continue;
                     }
 


### PR DESCRIPTION
`strtolower()` turns everything into a string, so the `is_string()` check would always return `true`. Checking for an empty string instead fixes this.

Alternatively I could separate the two function calls `strtolower($phpcsFile->getDeclarationName())` into two separate lines to make it easier to understand for someone reading the code.