### PR TITLE
Revert the case-insensitivity of the `RemovedGlobalVariables` sniff.

### DIFF
--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -56,14 +56,14 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens    = $phpcsFile->getTokens();
-        $varNameUc = strtoupper(substr($tokens[$stackPtr]['content'], 1));
+        $tokens  = $phpcsFile->getTokens();
+        $varName = substr($tokens[$stackPtr]['content'], 1);
 
-        if (isset($this->removedGlobalVariables[$varNameUc]) === false) {
+        if (isset($this->removedGlobalVariables[$varName]) === false) {
             return;
         }
 
-        $versionList = $this->removedGlobalVariables[$varNameUc];
+        $versionList = $this->removedGlobalVariables[$varName];
 
         $error = '';
         $isError = false;

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -15,20 +15,76 @@
  */
 class RemovedGlobalVariablesSniffTest  extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/removed_global_variables.php';
+
     /**
-     * HTTP_RAW_POST_DATA
+     * testRemovedGlobalVariables
+     *
+     * @group removedGlobalVariables
+     *
+     * @dataProvider dataRemovedGlobalVariables
+     *
+     * @param string $varName The name of the removed global variable.
+     * @param int    $line    The line number where the error is expected.
      *
      * @return void
      */
-    public function testHttpRawPostData()
+    public function testRemovedGlobalVariables($varName, $line)
     {
-        $file = $this->sniffFile('sniff-examples/removed_global_variables.php', '5.5');
-        $this->assertNoViolation($file);
-        
-        $file = $this->sniffFile('sniff-examples/removed_global_variables.php', '5.6');
-        $this->assertWarning($file, 3, 'Global variable \'$HTTP_RAW_POST_DATA\' is deprecated since PHP 5.6 - use php://input instead');
-        
-        $file = $this->sniffFile('sniff-examples/removed_global_variables.php', '7.0');
-        $this->assertError($file, 3, 'Global variable \'$HTTP_RAW_POST_DATA\' is deprecated since PHP 5.6 and removed since PHP 7.0 - use php://input instead');
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertWarning($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6 - use php://input instead");
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6 and removed since PHP 7.0 - use php://input instead");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testRemovedGlobalVariables()
+     *
+     * @return array
+     */
+    public function dataRemovedGlobalVariables()
+    {
+        return array(
+            array('HTTP_RAW_POST_DATA', 3),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group removedGlobalVariables
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(5),
+            array(6),
+        );
     }
 }

--- a/Tests/sniff-examples/removed_global_variables.php
+++ b/Tests/sniff-examples/removed_global_variables.php
@@ -1,3 +1,6 @@
 <?php
 
-echo $HTTP_RAW_POST_DATA;
+echo $HTTP_RAW_POST_DATA; // Bad.
+
+echo $http_raw_post_data; // Ok.
+echo $HTTP_Raw_Post_Data; // Ok.


### PR DESCRIPTION
Similar to the `ParameterShadowSuperGlobals` sniff, I'd inadvertently made the `RemovedGlobalVariables` sniff case-insensitive as well.
As variables are case-sensitive in PHP, this should be reverted.

Added some additional unit tests to safe-guard this and reworked the unit tests to dataproviders.