### PR TITLE
Fix error message version check in the `NewIniDirectives` sniff.

### DIFF
--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -156,35 +156,29 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         ),
 
         'mbstring.strict_detection' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.1' => false,
             '5.1.2' => true,
         ),
         'mssql.charset' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.1' => false,
             '5.1.2' => true,
         ),
 
         'gd.jpeg_ignore_warning' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.2' => false,
             '5.1.3' => true,
         ),
 
         'fbsql.show_timestamp_decimals' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.4' => false,
             '5.1.5' => true,
         ),
         'soap.wsdl_cache' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.4' => false,
             '5.1.5' => true,
         ),
         'soap.wsdl_cache_limit' => array(
-            '5.0'   => false,
-            '5.1'   => false,
+            '5.1.4' => false,
             '5.1.5' => true,
         ),
 
@@ -214,26 +208,22 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         ),
 
         'cgi.check_shebang_line' => array(
-            '5.1' => false,
-            '5.2' => false,
+            '5.2.0' => false,
             '5.2.1' => true
         ),
 
         'max_input_nesting_level' => array(
-            '5.1' => false,
-            '5.2' => false,
+            '5.2.2' => false,
             '5.2.3' => true
         ),
 
         'mysqli.allow_local_infile' => array(
-            '5.1'   => false,
-            '5.2'   => false,
+            '5.2.3' => false,
             '5.2.4' => true,
         ),
 
         'max_file_uploads' => array(
-            '5.1'    => false,
-            '5.2'    => false,
+            '5.2.11' => false,
             '5.2.12' => true,
         ),
 
@@ -315,20 +305,17 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         ),
 
         'curl.cainfo' => array(
-            '5.2' => false,
-            '5.3' => false,
+            '5.3.6' => false,
             '5.3.7' => true,
         ),
 
         'max_input_vars' => array(
-            '5.2'   => false,
-            '5.3'   => false,
+            '5.3.8' => false,
             '5.3.9' => true,
         ),
 
         'sqlite3.extension_dir' => array(
-            '5.2'    => false,
-            '5.3'    => false,
+            '5.3.10' => false,
             '5.3.11' => true,
         ),
 
@@ -436,8 +423,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         ),
 
         'session.use_strict_mode' => array(
-            '5.4'   => false,
-            '5.5'   => false,
+            '5.5.1' => false,
             '5.5.2' => true,
         ),
 
@@ -516,25 +502,30 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             return;
         }
 
-        $error = '';
-
+        $notInVersion = '';
         foreach ($this->newIniDirectives[$filteredToken] as $version => $present) {
-            if ($version !== 'alternative') {
-                if ($this->supportsBelow($version)) {
-                    if ($present === true) {
-                        $error .= " not available before version " . $version;
-                    }
-                }
+            if ($version !== 'alternative' && $present === false && $this->supportsBelow($version)) {
+                $notInVersion = $version;
             }
         }
 
-        if (strlen($error) > 0) {
-            $error = "INI directive '" . $filteredToken . "' is" . $error;
+        if ($notInVersion !== '') {
+            $error   = "INI directive '%s' is not present in PHP version %s or earlier";
+            $isError = ($function !== 'ini_get') ? true : false;
+            $data    = array(
+                $filteredToken,
+                $notInVersion
+            );
             if (isset($this->newIniDirectives[$filteredToken]['alternative'])) {
-                $error .= ". This directive was previously called '" . $this->newIniDirectives[$filteredToken]['alternative'] . "'.";
+                $error .= ". This directive was previously called '%s'.";
+                $data[] = $this->newIniDirectives[$filteredToken]['alternative'];
             }
 
-            $phpcsFile->addWarning($error, $iniToken['end']);
+            if ($isError === true) {
+                $phpcsFile->addError($error, $iniToken['end'], 'Found', $data);
+            } else {
+                $phpcsFile->addWarning($error, $iniToken['end'], 'Found', $data);
+            }
         }
 
     }//end process()

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -23,16 +23,33 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
      *
      * @group IniDirectives
      *
+     * @dataProvider dataFunctionThatShouldntBeFlagged
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testFunctionThatShouldntBeFlagged()
+    public function testFunctionThatShouldntBeFlagged($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.1');
+        $this->assertNoViolation($file, $line);
+    }
 
-        $this->assertNoViolation($file, 2);
-        $this->assertNoViolation($file, 3);
-        $this->assertNoViolation($file, 4);
-        $this->assertNoViolation($file, 5);
+    /**
+     * Data provider.
+     *
+     * @see testFunctionThatShouldntBeFlagged()
+     *
+     * @return array
+     */
+    public function dataFunctionThatShouldntBeFlagged()
+    {
+        return array(
+            array(2),
+            array(3),
+            array(4),
+            array(5),
+        );
     }
 
 
@@ -43,20 +60,26 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
      *
      * @dataProvider dataNewIniDirectives
      *
-     * @param string $iniName        Name of the ini directive.
-     * @param string $fromVersion    The PHP version in which the ini directive was introduced.
-     * @param array  $lines          The line numbers in the test file which apply to this ini directive.
-     * @param string $warningVersion A PHP version in which the ini directive was not yet present.
-     * @param string $okVersion      A PHP version in which the ini directive was valid.
+     * @param string $iniName           Name of the ini directive.
+     * @param string $okVersion         A PHP version in which the ini directive was present.
+     * @param array  $lines             The line numbers in the test file which apply to this ini directive.
+     * @param string $lastVersionBefore The last PHP version in which the ini directive was not present.
+     * @param string $testVersion       Optional PHP version to test error/warning message with -
+     *                                  if different from the $lastVersionBeforeversion.
      *
      * @return void
      */
-    public function testNewIniDirectives($iniName, $fromVersion, $lines, $warningVersion, $okVersion)
+    public function testNewIniDirectives($iniName, $okVersion, $lines, $lastVersionBefore, $testVersion = null)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $warningVersion);
-        foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version {$fromVersion}");
+        if (isset($testVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $testVersion);
         }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        }
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier");
+
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach( $lines as $line ) {
@@ -74,121 +97,121 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     public function dataNewIniDirectives()
     {
         return array(
-            array('auto_globals_jit', '5.0', array(83, 84), '4.4', '5.1'),
-            array('com.code_page', '5.0', array(86, 87), '4.4', '5.1'),
-            array('date.default_latitude', '5.0', array(89, 90), '4.4', '5.1'),
-            array('date.default_longitude', '5.0', array(92, 93), '4.4', '5.1'),
-            array('date.sunrise_zenith', '5.0', array(95, 96), '4.4', '5.1'),
-            array('date.sunset_zenith', '5.0', array(98, 99), '4.4', '5.1'),
-            array('ibase.default_charset', '5.0', array(101, 102), '4.4', '5.1'),
-            array('ibase.default_db', '5.0', array(104, 105), '4.4', '5.1'),
-            array('mail.force_extra_parameters', '5.0', array(107, 108), '4.4', '5.1'),
-            array('mime_magic.debug', '5.0', array(110, 111), '4.4', '5.1'),
-            array('mysqli.max_links', '5.0', array(113, 114), '4.4', '5.1'),
-            array('mysqli.default_port', '5.0', array(116, 117), '4.4', '5.1'),
-            array('mysqli.default_socket', '5.0', array(119, 120), '4.4', '5.1'),
-            array('mysqli.default_host', '5.0', array(122, 123), '4.4', '5.1'),
-            array('mysqli.default_user', '5.0', array(125, 126), '4.4', '5.1'),
-            array('mysqli.default_pw', '5.0', array(128, 129), '4.4', '5.1'),
-            array('report_zend_debug', '5.0', array(131, 132), '4.4', '5.1'),
-            array('session.hash_bits_per_character', '5.0', array(134, 135), '4.4', '5.1'),
-            array('session.hash_function', '5.0', array(137, 138), '4.4', '5.1'),
-            array('soap.wsdl_cache_dir', '5.0', array(140, 141), '4.4', '5.1'),
-            array('soap.wsdl_cache_enabled', '5.0', array(143, 144), '4.4', '5.1'),
-            array('soap.wsdl_cache_ttl', '5.0', array(146, 147), '4.4', '5.1'),
-            array('sqlite.assoc_case', '5.0', array(149, 150), '4.4', '5.1'),
-            array('tidy.clean_output', '5.0', array(152, 153), '4.4', '5.1'),
-            array('tidy.default_config', '5.0', array(155, 156), '4.4', '5.1'),
-            array('zend.ze1_compatibility_mode', '5.0', array(158, 159), '4.4', '5.1'),
+            array('auto_globals_jit', '5.0', array(83, 84), '4.4'),
+            array('com.code_page', '5.0', array(86, 87), '4.4'),
+            array('date.default_latitude', '5.0', array(89, 90), '4.4'),
+            array('date.default_longitude', '5.0', array(92, 93), '4.4'),
+            array('date.sunrise_zenith', '5.0', array(95, 96), '4.4'),
+            array('date.sunset_zenith', '5.0', array(98, 99), '4.4'),
+            array('ibase.default_charset', '5.0', array(101, 102), '4.4'),
+            array('ibase.default_db', '5.0', array(104, 105), '4.4'),
+            array('mail.force_extra_parameters', '5.0', array(107, 108), '4.4'),
+            array('mime_magic.debug', '5.0', array(110, 111), '4.4'),
+            array('mysqli.max_links', '5.0', array(113, 114), '4.4'),
+            array('mysqli.default_port', '5.0', array(116, 117), '4.4'),
+            array('mysqli.default_socket', '5.0', array(119, 120), '4.4'),
+            array('mysqli.default_host', '5.0', array(122, 123), '4.4'),
+            array('mysqli.default_user', '5.0', array(125, 126), '4.4'),
+            array('mysqli.default_pw', '5.0', array(128, 129), '4.4'),
+            array('report_zend_debug', '5.0', array(131, 132), '4.4'),
+            array('session.hash_bits_per_character', '5.0', array(134, 135), '4.4'),
+            array('session.hash_function', '5.0', array(137, 138), '4.4'),
+            array('soap.wsdl_cache_dir', '5.0', array(140, 141), '4.4'),
+            array('soap.wsdl_cache_enabled', '5.0', array(143, 144), '4.4'),
+            array('soap.wsdl_cache_ttl', '5.0', array(146, 147), '4.4'),
+            array('sqlite.assoc_case', '5.0', array(149, 150), '4.4'),
+            array('tidy.clean_output', '5.0', array(152, 153), '4.4'),
+            array('tidy.default_config', '5.0', array(155, 156), '4.4'),
+            array('zend.ze1_compatibility_mode', '5.0', array(158, 159), '4.4'),
 
-            array('date.timezone', '5.1', array(161, 162), '5.0', '5.2'),
-            array('detect_unicode', '5.1', array(164, 165), '5.0', '5.2'),
-            array('realpath_cache_size', '5.1', array(170, 171), '5.0', '5.2'),
-            array('realpath_cache_ttl', '5.1', array(173, 174), '5.0', '5.2'),
+            array('date.timezone', '5.1', array(161, 162), '5.0'),
+            array('detect_unicode', '5.1', array(164, 165), '5.0'),
+            array('realpath_cache_size', '5.1', array(170, 171), '5.0'),
+            array('realpath_cache_ttl', '5.1', array(173, 174), '5.0'),
 
-            array('mbstring.strict_detection', '5.1.2', array(176, 177), '5.1', '5.2'),
-            array('mssql.charset', '5.1.2', array(179, 180), '5.1', '5.2'),
+            array('mbstring.strict_detection', '5.2', array(176, 177), '5.1.1', '5.1'),
+            array('mssql.charset', '5.2', array(179, 180), '5.1.1', '5.1'),
 
-            array('gd.jpeg_ignore_warning', '5.1.3', array(182, 183), '5.1', '5.2'),
+            array('gd.jpeg_ignore_warning', '5.2', array(182, 183), '5.1.2', '5.1'),
 
-            array('fbsql.show_timestamp_decimals', '5.1.5', array(185, 186), '5.1', '5.2'),
-            array('soap.wsdl_cache', '5.1.5', array(188, 189), '5.1', '5.2'),
-            array('soap.wsdl_cache_limit', '5.1.5', array(191, 192), '5.1', '5.2'),
+            array('fbsql.show_timestamp_decimals', '5.2', array(185, 186), '5.1.4', '5.1'),
+            array('soap.wsdl_cache', '5.2', array(188, 189), '5.1.4', '5.1'),
+            array('soap.wsdl_cache_limit', '5.2', array(191, 192), '5.1.4', '5.1'),
 
-            array('allow_url_include', '5.2', array(7, 8, 9), '5.1', '5.3'),
-            array('pcre.backtrack_limit', '5.2', array(11, 12), '5.1', '5.3'),
-            array('pcre.recursion_limit', '5.2', array(14, 15), '5.1', '5.3'),
-            array('session.cookie_httponly', '5.2', array(17, 18), '5.1', '5.3'),
-            array('filter.default', '5.2', array(194, 195), '5.1', '5.3'),
-            array('filter.default_flags', '5.2', array(197, 198), '5.1', '5.3'),
+            array('allow_url_include', '5.2', array(7, 8), '5.1'),
+            array('pcre.backtrack_limit', '5.2', array(11, 12), '5.1'),
+            array('pcre.recursion_limit', '5.2', array(14, 15), '5.1'),
+            array('session.cookie_httponly', '5.2', array(17, 18), '5.1'),
+            array('filter.default', '5.2', array(194, 195), '5.1'),
+            array('filter.default_flags', '5.2', array(197, 198), '5.1'),
 
-            array('cgi.check_shebang_line', '5.2.1', array(200, 201), '5.2', '5.3'),
+            array('cgi.check_shebang_line', '5.3', array(200, 201), '5.2.0', '5.2'),
 
-            array('max_input_nesting_level', '5.2.3', array(20, 21), '5.2', '5.3'),
+            array('max_input_nesting_level', '5.3', array(20, 21), '5.2.2', '5.2'),
 
-            array('mysqli.allow_local_infile', '5.2.4', array(203, 204), '5.2', '5.3'),
+            array('mysqli.allow_local_infile', '5.3', array(203, 204), '5.2.3', '5.2'),
 
-            array('max_file_uploads', '5.2.12', array(206, 207), '5.2', '5.3'),
+            array('max_file_uploads', '5.3', array(206, 207), '5.2.11', '5.2'),
 
-            array('user_ini.filename', '5.3', array(23, 24), '5.2', '5.4'),
-            array('user_ini.cache_ttl', '5.3', array(26, 27), '5.2', '5.4'),
-            array('exit_on_timeout', '5.3', array(29, 30), '5.2', '5.4'),
-            array('mbstring.http_output_conv_mimetype', '5.3', array(32, 33), '5.2', '5.4'),
-            array('request_order', '5.3', array(35, 36), '5.2', '5.4'),
-            array('cgi.discard_path', '5.3', array(209, 210), '5.2', '5.4'),
-            array('intl.default_locale', '5.3', array(212, 213), '5.2', '5.4'),
-            array('intl.error_level', '5.3', array(215, 216), '5.2', '5.4'),
-            array('mail.add_x_header', '5.3', array(218, 219), '5.2', '5.4'),
-            array('mail.log', '5.3', array(221, 222), '5.2', '5.4'),
-            array('mysqli.allow_persistent', '5.3', array(224, 225), '5.2', '5.4'),
-            array('mysqli.max_persistent', '5.3', array(227, 228), '5.2', '5.4'),
-            array('mysqli.cache_size', '5.3', array(230, 231), '5.2', '5.4'),
-            array('mysqlnd.collect_memory_statistics', '5.3', array(233, 234), '5.2', '5.4'),
-            array('mysqlnd.collect_statistics', '5.3', array(236, 237), '5.2', '5.4'),
-            array('mysqlnd.debug', '5.3', array(239, 240), '5.2', '5.4'),
-            array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2', '5.4'),
-            array('odbc.default_cursortype', '5.3', array(245, 246), '5.2', '5.4'),
-            array('zend.enable_gc', '5.3', array(248, 249), '5.2', '5.4'),
+            array('user_ini.filename', '5.3', array(23, 24), '5.2'),
+            array('user_ini.cache_ttl', '5.3', array(26, 27), '5.2'),
+            array('exit_on_timeout', '5.3', array(29, 30), '5.2'),
+            array('mbstring.http_output_conv_mimetype', '5.3', array(32, 33), '5.2'),
+            array('request_order', '5.3', array(35, 36), '5.2'),
+            array('cgi.discard_path', '5.3', array(209, 210), '5.2'),
+            array('intl.default_locale', '5.3', array(212, 213), '5.2'),
+            array('intl.error_level', '5.3', array(215, 216), '5.2'),
+            array('mail.add_x_header', '5.3', array(218, 219), '5.2'),
+            array('mail.log', '5.3', array(221, 222), '5.2'),
+            array('mysqli.allow_persistent', '5.3', array(224, 225), '5.2'),
+            array('mysqli.max_persistent', '5.3', array(227, 228), '5.2'),
+            array('mysqli.cache_size', '5.3', array(230, 231), '5.2'),
+            array('mysqlnd.collect_memory_statistics', '5.3', array(233, 234), '5.2'),
+            array('mysqlnd.collect_statistics', '5.3', array(236, 237), '5.2'),
+            array('mysqlnd.debug', '5.3', array(239, 240), '5.2'),
+            array('mysqlnd.net_read_buffer_size', '5.3', array(242, 243), '5.2'),
+            array('odbc.default_cursortype', '5.3', array(245, 246), '5.2'),
+            array('zend.enable_gc', '5.3', array(248, 249), '5.2'),
 
-            array('curl.cainfo', '5.3.7', array(251, 252), '5.3', '5.4'),
+            array('curl.cainfo', '5.4', array(251, 252), '5.3.6', '5.3'),
 
-            array('max_input_vars', '5.3.9', array(47, 48), '5.3', '5.4'),
+            array('max_input_vars', '5.4', array(47, 48), '5.3.8', '5.3'),
 
-            array('sqlite3.extension_dir', '5.3.11', array(254, 255), '5.3', '5.4'),
+            array('sqlite3.extension_dir', '5.4', array(254, 255), '5.3.10', '5.3'),
 
-            array('cli.pager', '5.4', array(38, 39), '5.3', '5.5'),
-            array('cli.prompt', '5.4', array(41, 42), '5.3', '5.5'),
-            array('cli_server.color', '5.4', array(44, 45), '5.3', '5.5'),
-            array('zend.multibyte', '5.4', array(50, 51), '5.3', '5.5'),
-            array('zend.script_encoding', '5.4', array(53, 54), '5.3', '5.5'),
-            array('zend.signal_check', '5.4', array(56, 57), '5.3', '5.5'),
-            array('session.upload_progress.enabled', '5.4', array(59, 60), '5.3', '5.5'),
-            array('session.upload_progress.cleanup', '5.4', array(62, 63), '5.3', '5.5'),
-            array('session.upload_progress.name', '5.4', array(65, 66), '5.3', '5.5'),
-            array('session.upload_progress.freq', '5.4', array(68, 69), '5.3', '5.5'),
-            array('enable_post_data_reading', '5.4', array(71, 72), '5.3', '5.5'),
-            array('windows_show_crt_warning', '5.4', array(74, 75), '5.3', '5.5'),
-            array('session.upload_progress.prefix', '5.4', array(257, 258), '5.3', '5.5'),
-            array('mysqlnd.log_mask', '5.4', array(263, 264), '5.3', '5.5'),
-            array('mysqlnd.mempool_default_size', '5.4', array(266, 267), '5.3', '5.5'),
-            array('mysqlnd.net_cmd_buffer_size', '5.4', array(269, 270), '5.3', '5.5'),
-            array('mysqlnd.net_read_timeout', '5.4', array(272, 273), '5.3', '5.5'),
-            array('phar.cache_list', '5.4', array(275, 276), '5.3', '5.5'),
+            array('cli.pager', '5.4', array(38, 39), '5.3'),
+            array('cli.prompt', '5.4', array(41, 42), '5.3'),
+            array('cli_server.color', '5.4', array(44, 45), '5.3'),
+            array('zend.multibyte', '5.4', array(50, 51), '5.3'),
+            array('zend.script_encoding', '5.4', array(53, 54), '5.3'),
+            array('zend.signal_check', '5.4', array(56, 57), '5.3'),
+            array('session.upload_progress.enabled', '5.4', array(59, 60), '5.3'),
+            array('session.upload_progress.cleanup', '5.4', array(62, 63), '5.3'),
+            array('session.upload_progress.name', '5.4', array(65, 66), '5.3'),
+            array('session.upload_progress.freq', '5.4', array(68, 69), '5.3'),
+            array('enable_post_data_reading', '5.4', array(71, 72), '5.3'),
+            array('windows_show_crt_warning', '5.4', array(74, 75), '5.3'),
+            array('session.upload_progress.prefix', '5.4', array(257, 258), '5.3'),
+            array('mysqlnd.log_mask', '5.4', array(263, 264), '5.3'),
+            array('mysqlnd.mempool_default_size', '5.4', array(266, 267), '5.3'),
+            array('mysqlnd.net_cmd_buffer_size', '5.4', array(269, 270), '5.3'),
+            array('mysqlnd.net_read_timeout', '5.4', array(272, 273), '5.3'),
+            array('phar.cache_list', '5.4', array(275, 276), '5.3'),
 
-            array('intl.use_exceptions', '5.5', array(77, 78), '5.4', '5.6'),
-            array('mysqlnd.sha256_server_public_key', '5.5', array(80, 81), '5.4', '5.6'),
-            array('mysqlnd.trace_alloc', '5.5', array(278, 279), '5.4', '5.6'),
-            array('sys_temp_dir', '5.5', array(281, 282), '5.4', '5.6'),
-            array('xsl.security_prefs', '5.5', array(284, 285), '5.4', '5.6'),
+            array('intl.use_exceptions', '5.5', array(77, 78), '5.4'),
+            array('mysqlnd.sha256_server_public_key', '5.5', array(80, 81), '5.4'),
+            array('mysqlnd.trace_alloc', '5.5', array(278, 279), '5.4'),
+            array('sys_temp_dir', '5.5', array(281, 282), '5.4'),
+            array('xsl.security_prefs', '5.5', array(284, 285), '5.4'),
 
-            array('session.use_strict_mode', '5.5.2', array(287, 288), '5.5', '5.6'),
+            array('session.use_strict_mode', '5.6', array(287, 288), '5.5.1', '5.5'),
 
-            array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5', '7.0'),
+            array('mysqli.rollback_on_cached_plink', '5.6', array(290, 291), '5.5'),
 
-            array('assert.exception', '7.0', array(293, 294), '5.6', '7.1'),
-            array('pcre.jit', '7.0', array(296, 297), '5.6', '7.1'),
-            array('session.lazy_write', '7.0', array(299, 300), '5.6', '7.1'),
-            array('zend.assertions', '7.0', array(302, 303), '5.6', '7.1'),
+            array('assert.exception', '7.0', array(293, 294), '5.6'),
+            array('pcre.jit', '7.0', array(296, 297), '5.6'),
+            array('session.lazy_write', '7.0', array(299, 300), '5.6'),
+            array('zend.assertions', '7.0', array(302, 303), '5.6'),
 
         );
     }
@@ -201,21 +224,27 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
      *
      * @dataProvider dataNewIniDirectivesWithAlternative
      *
-     * @param string $iniName        Name of the ini directive.
-     * @param string $fromVersion    The PHP version in which the ini directive was introduced.
-     * @param string $alternative    An alternative ini directive.
-     * @param array  $lines          The line numbers in the test file which apply to this ini directive.
-     * @param string $warningVersion A PHP version in which the ini directive was not yet present.
-     * @param string $okVersion      A PHP version in which the ini directive was valid.
+     * @param string $iniName           Name of the ini directive.
+     * @param string $okVersion         A PHP version in which the ini directive was present.
+     * @param string $alternative       An alternative ini directive.
+     * @param array  $lines             The line numbers in the test file which apply to this ini directive.
+     * @param string $lastVersionBefore The last PHP version in which the ini directive was not present.
+     * @param string $testVersion       Optional PHP version to test error/warning message with -
+     *                                  if different from the $lastVersionBeforeversion.
+
      *
      * @return void
      */
-    public function testNewIniDirectivesWithAlternative($iniName, $fromVersion, $alternative, $lines, $warningVersion, $okVersion)
+    public function testNewIniDirectivesWithAlternative($iniName, $okVersion, $alternative, $lines, $lastVersionBefore, $testVersion = null)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $warningVersion);
-        foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is not available before version {$fromVersion}. This directive was previously called '{$alternative}'.");
+        if (isset($testVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $testVersion);
         }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        }
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier. This directive was previously called '{$alternative}'.");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier. This directive was previously called '{$alternative}'.");
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
@@ -233,8 +262,8 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     public function dataNewIniDirectivesWithAlternative()
     {
         return array(
-            array('fbsql.batchsize', '5.1', 'fbsql.batchSize', array(167, 168), '5.0', '5.2'),
-            array('zend.detect_unicode', '5.4', 'detect_unicode', array(260, 261), '5.3', '5.5'),
+            array('fbsql.batchsize', '5.1', 'fbsql.batchSize', array(167, 168), '5.0'),
+            array('zend.detect_unicode', '5.4', 'detect_unicode', array(260, 261), '5.3'),
         );
     }
 

--- a/Tests/sniff-examples/new_ini_directives.php
+++ b/Tests/sniff-examples/new_ini_directives.php
@@ -6,7 +6,7 @@ ini_set($iniName, 'filter.default'); // Verify sniff doesn't flag on second para
 
 ini_set('allow_url_include', 1);
 $test = ini_get('allow_url_include');
-ini_set("allow_url_include", 1); // Verify sniff works when using double quotes.
+
 
 ini_set('pcre.backtrack_limit', 1);
 $test = ini_get('pcre.backtrack_limit');


### PR DESCRIPTION
The error message was showing in one version too high.
I.e. `mail.log` ini directives was introduced in PHP 5.3. The error message *should* show for PHP 5.2 and lower, not for PHP 5.3, but in practice it was also showing for PHP 5.3.

Also:
* Adjusted the actual error message to be in line with this. Adjusted the message to mirror similar messages used in other sniffs.
* For ini directives introduced in patch versions of PHP, adjusted the _"last version before"_ in the data array to be in line with the adjusted version check.
* Changed the error message to use the native PHPCS variable replacement.
* Changed the error message **type** to `error` when the ini directive was used in an `ini_set()`, left it as `warning` for `ini_get()`. This is also how it is done in the `DeprecatedIniDirectives` sniff, so these two are now in line with each other.

The unit tests have also been adjusted to account for this change.