### PR TITLE
Minor improvements to the `NewScalarReturnTypeDeclarations` sniff (incl PHP 7.1 addition)

### DIFF
--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -29,22 +29,18 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
                                         'int' => array(
                                             '5.6' => false,
                                             '7.0' => true,
-                                            'description' => 'int return type'
                                         ),
                                         'float' => array(
                                             '5.6' => false,
                                             '7.0' => true,
-                                            'description' => 'float return type'
                                         ),
                                         'bool' => array(
                                             '5.6' => false,
                                             '7.0' => true,
-                                            'description' => 'bool return type'
                                         ),
                                         'string' => array(
                                             '5.6' => false,
                                             '7.0' => true,
-                                            'description' => 'string return type'
                                         ),
                                     );
 
@@ -106,12 +102,15 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
             }
         }
         if (strlen($error) > 0) {
-            $error = $this->newTypes[$typeName]['description'] . ' is ' . $error;
+            $error = '%s return type is ' . $error;
+            $data  = array(
+                $typeName,
+            );
 
             if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
+                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
             } else {
-                $phpcsFile->addWarning($error, $stackPtr);
+                $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
             }
         }
 

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -42,6 +42,11 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
                                             '5.6' => false,
                                             '7.0' => true,
                                         ),
+
+                                        'void' => array(
+                                            '7.0' => false,
+                                            '7.1' => true,
+                                        ),
                                     );
 
 

--- a/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
@@ -67,6 +67,7 @@ class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
             array('int', '5.6', 5, '7.0'),
             array('float', '5.6', 7, '7.0'),
             array('string', '5.6', 9, '7.0'),
+            array('void', '7.0', 11, '7.1'),
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
@@ -15,7 +15,11 @@
  */
 class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/new_scalar_return_type_declarations.php';
 
+    /**
+     * Set up: skip these tests if the PHPCS version isn't high enough.
+     */
     protected function setUp()
     {
         if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '<')) {
@@ -29,15 +33,23 @@ class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
     /**
      * testScalarReturnType
      *
+     * @group scalarReturnType
+     *
      * @dataProvider dataScalarReturnType
      *
-     * @param int $line The line number.
+     * @param string $returnType        The return type.
+     * @param string $lastVersionBefore The PHP version just *before* the type was introduced.
+     * @param array  $line              The line number in the test file where the error should occur.
+     * @param string $okVersion         A PHP version in which the return type was ok to be used.
      *
      * @return void
      */
-    public function testScalarReturnType($line)
+    public function testScalarReturnType($returnType, $lastVersionBefore, $line, $okVersion)
     {
-        $file = $this->sniffFile('sniff-examples/new_scalar_return_type_declarations.php', '7.0');
+        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $this->assertError($file, $line, "{$returnType} return type is not present in PHP version {$lastVersionBefore} or earlier");
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         $this->assertNoViolation($file, $line);
     }
 
@@ -51,10 +63,10 @@ class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
     public function dataScalarReturnType()
     {
         return array(
-            array(3),
-            array(5),
-            array(7),
-            array(9),
+            array('bool', '5.6', 3, '7.0'),
+            array('int', '5.6', 5, '7.0'),
+            array('float', '5.6', 7, '7.0'),
+            array('string', '5.6', 9, '7.0'),
         );
     }
 }

--- a/Tests/sniff-examples/new_scalar_return_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_return_type_declarations.php
@@ -7,3 +7,5 @@ function foo($a): int {}
 function foo($a): float {}
 
 function foo($a): string {}
+
+function foo($a): void {}


### PR DESCRIPTION
#### Minor improvements to the sniff:

* The `description` key in the data array had no added value as the string could easily be concatenated, so removed it.
* The unit tests needed some refactoring as they were hard-coded to only test on version 7.0 and PHP 7.1 will introduce another new return type (`void`).
* Also - commit 65390fa removed the actual testing for the error message which was apparently breaking the unit tests.
This commit brings those tests back and so far I'm not seeing any breakage in the unit tests because of it.

----
#### PHP 7.1: add new return type `void` to `NewScalarReturnTypeDeclarations` sniff.

Ref:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
* https://wiki.php.net/rfc/void_return_type

Includes unit tests.

The sniff name might need adjusting to better cover what the sniff does.