### PR TITLE
Add new PHP 7.1 `iterable` type hint

### DIFF
--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -50,6 +50,10 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                                '5.6' => false,
                                '7.0' => true,
                            ),
+                           'iterable' => array(
+                               '7.0' => false,
+                               '7.1' => true,
+                           ),
                           );
 
 

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -50,11 +50,12 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
         return array(
             array('array', '5.0', 4, '5.1'),
             array('array', '5.0', 5, '5.1'),
-            array('callable', '5.3', 9, '5.4'),
-            array('bool', '5.6', 13, '7.0'),
-            array('int', '5.6', 14, '7.0'),
-            array('float', '5.6', 15, '7.0'),
-            array('string', '5.6', 16, '7.0'),
+            array('callable', '5.3', 8, '5.4'),
+            array('bool', '5.6', 11, '7.0'),
+            array('int', '5.6', 12, '7.0'),
+            array('float', '5.6', 13, '7.0'),
+            array('string', '5.6', 14, '7.0'),
+            array('iterable', '7.0', 17, '7.1'),
         );
     }
 
@@ -165,11 +166,12 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
         return array(
             array(4),
             array(5),
-            array(9),
+            array(8),
+            array(11),
+            array(12),
             array(13),
             array(14),
-            array(15),
-            array(16),
+            array(17),
             array(20),
             array(21),
             array(24),
@@ -181,5 +183,5 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
             array(44),
         );
     }
-}
 
+}

--- a/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -4,10 +4,8 @@
 function foo(array $a) {}
 function foo( array   $a ) {} // Test extra spacing.
 
-
 // Callable type declaration - PHP 5.4+
 function foo(callable $a) {}
-
 
 // Scalar type declarations - PHP 7.0+
 function foo(bool $a) {}
@@ -15,6 +13,8 @@ function foo(int $a) {}
 function foo(float $a) {}
 function foo(string $a) {}
 
+// Iterable type declaration - PHP 7.1+
+function foo(iterable $a) {}
 
 // (Very likely) Invalid type declarations - will be treated as class/interface names.
 function foo(boolean $a) {}


### PR DESCRIPTION
Ref:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.iterable-pseudo-type
* https://wiki.php.net/rfc/iterable

Includes unit tests.

The sniff name might need adjusting to better cover what the sniff does.