### PR TITLE
PHP 7.1: add removed session ini directives to `DeprecatedIniDirectives` sniff.

### DIFF
--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -179,7 +179,20 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         ),
         'xsl.security_prefs' => array(
             '7.0' => true
-        )
+        ),
+
+        'session.entropy_file' => array(
+            '7.1' => true
+        ),
+        'session.entropy_length' => array(
+            '7.1' => true
+        ),
+        'session.hash_function' => array(
+            '7.1' => true
+        ),
+        'session.hash_bits_per_character' => array(
+            '7.1' => true
+        ),
     );
 
     /**

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -278,6 +278,11 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
             array('asp_tags', '7.0', array(83, 84), '5.6'),
             array('xsl.security_prefs', '7.0', array(86, 87), '5.6'),
+
+            array('session.entropy_file', '7.1', array(135, 136), '7.0'),
+            array('session.entropy_length', '7.1', array(138, 139), '7.0'),
+            array('session.hash_function', '7.1', array(141, 142), '7.0'),
+            array('session.hash_bits_per_character', '7.1', array(144, 145), '7.0'),
         );
     }
 

--- a/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/Tests/sniff-examples/deprecated_ini_directives.php
@@ -131,3 +131,15 @@ $a = ini_get('mbstring.script_encoding');
 // Ini directive with variable for ini name.
 $iniName = 'ifx.default_user'
 ini_set($iniName, 'ifx.default_password'); // Ok, as we're interested in the variable name, not the value.
+
+ini_set('session.entropy_file', 1);
+$a = ini_get('session.entropy_file');
+
+ini_set('session.entropy_length', 1);
+$a = ini_get('session.entropy_length');
+
+ini_set('session.hash_function', 1);
+$a = ini_get('session.hash_function');
+
+ini_set('session.hash_bits_per_character', 1);
+$a = ini_get('session.hash_bits_per_character');


### PR DESCRIPTION
Ref:
* http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.removed-ini-directives
* https://wiki.php.net/rfc/session-id-without-hashing

Includes unit tests.