### PR TITLE
PHP 7.1: add new session ini directives to `DeprecatedIniDirectives` sniff

### DIFF
--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -448,6 +448,15 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             '5.6' => false,
             '7.0' => true,
         ),
+
+        'session.sid_length' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'session.sid_bits_per_character' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
     );
 
     /**

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -213,6 +213,8 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
             array('session.lazy_write', '7.0', array(299, 300), '5.6'),
             array('zend.assertions', '7.0', array(302, 303), '5.6'),
 
+            array('session.sid_length', '7.1', array(305, 306), '7.0'),
+            array('session.sid_bits_per_character', '7.1', array(308, 309), '7.0'),
         );
     }
 

--- a/Tests/sniff-examples/new_ini_directives.php
+++ b/Tests/sniff-examples/new_ini_directives.php
@@ -301,3 +301,9 @@ $test = ini_get('session.lazy_write');
 
 ini_set('zend.assertions', 1);
 $test = ini_get('zend.assertions');
+
+ini_set('session.sid_length', 1);
+$test = ini_get('session.sid_length');
+
+ini_set('session.sid_bits_per_character', 1);
+$test = ini_get('session.sid_bits_per_character');


### PR DESCRIPTION
Ref:
* http://php.net/manual/en/migration71.other-changes.php#migration71.other-changes.session-id-generation-without-hashing
* https://wiki.php.net/rfc/session-id-without-hashing

Includes unit tests.