### PR TITLE
PHP 7.0.7: add new `socket_export_stream` function to `NewFunctions` sniff

### DIFF
--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1205,6 +1205,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
                                             '5.6' => false,
                                             '7.0' => true
                                         ),
+
+                                        'socket_export_stream' => array(
+                                            '7.0.6' => false,
+                                            '7.0.7' => true
+                                        ),
                                     );
 
 

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -382,6 +382,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('inflate_init', '5.6', array(309), '7.0'),
             array('deflate_init', '5.6', array(310), '7.0'),
 
+            array('socket_export_stream', '7.0.6', array(312), '7.1', '7.0'),
         );
     }
 

--- a/Tests/sniff-examples/new_functions.php
+++ b/Tests/sniff-examples/new_functions.php
@@ -309,3 +309,4 @@ deflate_add();
 inflate_init();
 deflate_init();
 
+socket_export_stream();


### PR DESCRIPTION
While this function appears to be missing from the manual, it is mentioned in the changelog and the associated PR was merged.

Ref:
* http://php.net/ChangeLog-7.php#7.0.7
* https://github.com/php/php-src/commit/e8abb70fc94247450e4016040272fc9459d18371