### PR TITLE
Fix PCRE /e modifier sniff for compound parameter with different quotes.

### DIFF
--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -142,6 +142,8 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(107),
             array(109),
 
+			// Issue 265 - mixed string quotes.
+            array(157),
         );
     }
 

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -152,3 +152,6 @@ preg_filter('/\/e/e', $Replace, $Source);
 // Regex build up of strings combined with variables/function calls.
 preg_replace('/something' . $variable . 'something else/e', $Replace, $Source);
 preg_replace('/something' . preg_quote($variable) . 'something else/e', $Replace, $Source);
+
+// Issue 265 - build up string with varying quotes - this should be ok.
+preg_replace('~'.testme()."~s", '', "foo bar was here");


### PR DESCRIPTION
Using the `raw` first parameter value worked fine when the string quotes of the first string token and the last string token in the parameter were the same, but was breaking on mixed quotes.

```php
// Compound parameter with same string quotes at the start and end - this was working fine:
'/something' . $variable . 'something else/e'
"/something" . preg_quote($variable) . "something else/e"
"/something" . ' and something more and ' . "something else/e"

// Compound parameter with mixed string quotes at the start and end - this was breaking:
'~'.testme()."~s"
```

This PR fixes this.

Includes additional unit test.

Closes #265