### PR TITLE
Fix issue 268 long array vs class properties

### DIFF
--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -100,8 +100,17 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
         }
 
         // Still here, so throw an error/warning.
-        $error = "The use of long predefined variables has been deprecated in 5.3 and removed in 5.4; Found '%s'";
-        $data  = array($tokens[$stackPtr]['content']);
-        $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
+        $error   = "The use of long predefined variables has been deprecated in 5.3%s; Found '%s'";
+        $isError = $this->supportsAbove('5.4');
+        $data    = array(
+            ($isError ? ' and removed in 5.4' : ''),
+            $tokens[$stackPtr]['content']
+        );
+
+        if ($isError === true) {
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+        } else {
+            $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
+        }
     }
 }

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -65,10 +65,43 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
         }
 
         $tokens = $phpcsFile->getTokens();
-        if (in_array(substr($tokens[$stackPtr]['content'], 1), $this->deprecated, true)) {
-            $error = "The use of long predefined variables has been deprecated in 5.3 and removed in 5.4; Found '%s'";
-            $data  = array($tokens[$stackPtr]['content']);
-            $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
+
+        // Check if the variable name is in our blacklist.
+        if (in_array(substr($tokens[$stackPtr]['content'], 1), $this->deprecated, true) === false) {
+            return;
         }
+
+        if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
+            /*
+             * Check for class property definitions.
+             */
+            $properties = array();
+            try {
+                $properties = $phpcsFile->getMemberProperties($stackPtr);
+            } catch ( PHP_CodeSniffer_Exception $e) {
+                // If it's not an expected exception, throw it.
+                if ($e->getMessage() !== '$stackPtr is not a class member var') {
+                    throw $e;
+                }
+            }
+
+            if (isset($properties['scope'])) {
+                // Ok, so this was a class property declaration, not our concern.
+                return;
+            }
+
+            /*
+             * Check for static usage of class properties shadowing the long arrays.
+             */
+            $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+            if ($tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
+                return;
+            }
+        }
+
+        // Still here, so throw an error/warning.
+        $error = "The use of long predefined variables has been deprecated in 5.3 and removed in 5.4; Found '%s'";
+        $data  = array($tokens[$stackPtr]['content']);
+        $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
     }
 }

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -35,9 +35,14 @@ class LongArraysSniffTest extends BaseSniffTest
      */
     public function testLongVariable($longVariable, $lines, $deprecatedIn, $removedIn, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE);
+        $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The use of long predefined variables has been deprecated in {$deprecatedIn} and removed in {$removedIn}; Found '{$longVariable}'");
+            $this->assertWarning($file, $line, "The use of long predefined variables has been deprecated in {$deprecatedIn}; Found '{$longVariable}'");
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, "The use of long predefined variables has been deprecated in {$deprecatedIn} and removed in {$removedIn}; Found '{$longVariable}'");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -21,6 +21,8 @@ class LongArraysSniffTest extends BaseSniffTest
     /**
      * testLongVariable
      *
+     * @group longArrays
+     *
      * @dataProvider dataLongVariable
      *
      * @param string $longVariable Variable name.
@@ -54,14 +56,60 @@ class LongArraysSniffTest extends BaseSniffTest
     public function dataLongVariable()
     {
         return array(
-            array('$HTTP_POST_VARS', array(3), '5.3', '5.4', '5.2'),
-            array('$HTTP_GET_VARS', array(4), '5.3', '5.4', '5.2'),
-            array('$HTTP_ENV_VARS', array(5), '5.3', '5.4', '5.2'),
-            array('$HTTP_SERVER_VARS', array(6), '5.3', '5.4', '5.2'),
-            array('$HTTP_COOKIE_VARS', array(7), '5.3', '5.4', '5.2'),
-            array('$HTTP_SESSION_VARS', array(8), '5.3', '5.4', '5.2'),
-            array('$HTTP_POST_FILES', array(9), '5.3', '5.4', '5.2'),
+            array('$HTTP_POST_VARS', array(3, 24), '5.3', '5.4', '5.2'),
+            array('$HTTP_GET_VARS', array(4, 25, 42), '5.3', '5.4', '5.2'),
+            array('$HTTP_ENV_VARS', array(5, 26, 43), '5.3', '5.4', '5.2'),
+            array('$HTTP_SERVER_VARS', array(6, 27), '5.3', '5.4', '5.2'),
+            array('$HTTP_COOKIE_VARS', array(7, 28), '5.3', '5.4', '5.2'),
+            array('$HTTP_SESSION_VARS', array(8, 29), '5.3', '5.4', '5.2'),
+            array('$HTTP_POST_FILES', array(9, 30), '5.3', '5.4', '5.2'),
         );
     }
 
+
+    /**
+     * testNoViolation
+     *
+     * @group longArrays
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            // Issue #268 - class properties named after long array variables.
+            array(14),
+            array(15),
+            array(16),
+            array(17),
+            array(18),
+            array(19),
+            array(20),
+
+            array(33),
+            array(34),
+            array(35),
+            array(36),
+            array(37),
+            array(38),
+            array(39),
+        );
+    }
 }

--- a/Tests/sniff-examples/long_arrays.php
+++ b/Tests/sniff-examples/long_arrays.php
@@ -7,3 +7,39 @@ $HTTP_SERVER_VARS;
 $HTTP_COOKIE_VARS;
 $HTTP_SESSION_VARS;
 $HTTP_POST_FILES;
+
+// Issue #268
+class TestClass {
+	// OK.
+    private $HTTP_POST_VARS;
+    protected $HTTP_GET_VARS;
+    public $HTTP_ENV_VARS;
+    var $HTTP_SERVER_VARS;
+    private $HTTP_COOKIE_VARS;
+    protected $HTTP_SESSION_VARS;
+    public $HTTP_POST_FILES;
+
+    function testing() {
+		 // Bad.
+        $HTTP_POST_VARS;
+        $HTTP_GET_VARS;
+        $HTTP_ENV_VARS;
+        $HTTP_SERVER_VARS;
+        $HTTP_COOKIE_VARS;
+        $HTTP_SESSION_VARS;
+        $HTTP_POST_FILES;
+
+		// Ok.
+        self::$HTTP_POST_VARS;
+        self::$HTTP_GET_VARS;
+        static::$HTTP_ENV_VARS;
+        static::$HTTP_SERVER_VARS;
+        $this->HTTP_COOKIE_VARS;
+        $this->HTTP_SESSION_VARS;
+        $this->HTTP_POST_FILES;
+
+		// Bad.
+        self::{$HTTP_GET_VARS};
+        self::{$HTTP_ENV_VARS};
+    }
+}


### PR DESCRIPTION
### Fix class properties shadowing long array names.

Includes additional unit tests.

Fixes #268

---
### Make `LongArrays` error throwing follow deprecated/removed pattern.

In other sniffs, "deprecated" generally throws a warning, while "forbidden/removed" throws an error.
This sniff was always throwing a warning.

This has now been mitigated and will throw a warning for deprecated and error for removed.

Includes additional unit tests.