### PR TITLE
PHP 7.1: add new functions to the `NewFunctions` sniff.

### DIFF
--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1210,6 +1210,35 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
                                             '7.0.6' => false,
                                             '7.0.7' => true
                                         ),
+
+                                        'curl_multi_errno' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'curl_share_errno' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'curl_share_strerror' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'is_iterable' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'pcntl_async_signals' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'session_create_id' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
+                                        'session_gc' => array(
+                                            '7.0' => false,
+                                            '7.1' => true
+                                        ),
                                     );
 
 

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -383,6 +383,15 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('deflate_init', '5.6', array(310), '7.0'),
 
             array('socket_export_stream', '7.0.6', array(312), '7.1', '7.0'),
+
+            array('curl_multi_errno', '7.0', array(314), '7.1'),
+            array('curl_share_errno', '7.0', array(315), '7.1'),
+            array('curl_share_strerror', '7.0', array(316), '7.1'),
+            array('is_iterable', '7.0', array(317), '7.1'),
+            array('pcntl_async_signals', '7.0', array(318), '7.1'),
+            array('session_create_id', '7.0', array(319), '7.1'),
+            array('session_gc', '7.0', array(320), '7.1'),
+
         );
     }
 

--- a/Tests/sniff-examples/new_functions.php
+++ b/Tests/sniff-examples/new_functions.php
@@ -310,3 +310,11 @@ inflate_init();
 deflate_init();
 
 socket_export_stream();
+
+curl_multi_errno();
+curl_share_errno();
+curl_share_strerror();
+is_iterable();
+pcntl_async_signals();
+session_create_id();
+session_gc();


### PR DESCRIPTION
Refs:
* http://php.net/manual/en/migration71.new-functions.php
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.asynchronous-signal-handling

Related RFCs:
* `curl_...()` - https://wiki.php.net/rfc/new-curl-error-functions
* `is_iterable()` - https://wiki.php.net/rfc/iterable
* `pcntl_async_signals()` https://wiki.php.net/rfc/async_signals
* `session_create_id()` - https://wiki.php.net/rfc/session-create-id
* `session_gc()` - https://wiki.php.net/rfc/session-gc

Includes unit tests.