### PR TITLE
Fix weird undefined index bug in `NewKeywords` sniff.

### DIFF
--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -191,6 +191,10 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
             $tokenType = $this->translateContentToToken[$content];
         }
 
+        if (isset($this->newKeywords[$tokenType]) === false) {
+            return;
+        }
+
         $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 


### PR DESCRIPTION
This bug seems to only manifest during unit testing, but would cause unit tests to fail on a `Undefined index "T_OPEN_PARENTHESIS"` in the `addError()` method of this sniff.

As the sniffing is quite token specific, it is weird that a `T_OPEN_PARENTHESIS` token would ever reach that method. All the same, the notice is interfering with other tests, so we might as well prevent it being thrown.

This fix takes care of that.