### PR TITLE
PHP 7.1: New sniff for class constant visibility indicators.

### DIFF
--- a/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewConstVisibility.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewConstVisibility.
+ *
+ * Visibility for class constants is available since PHP 7.1.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_CONST);
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+
+        if ($prevToken === false) {
+            return;
+        }
+
+        // Is the previous token a visibility indicator ?
+        if (in_array($tokens[$prevToken]['code'], PHP_CodeSniffer_Tokens::$scopeModifiers, true) === false) {
+            return;
+        }
+
+        if ($this->tokenHasScope($phpcsFile, $stackPtr, array(T_CLASS, T_INTERFACE)) === true && $this->supportsBelow('7.0') === true) {
+            $error = 'Visibility indicators for class constants are not supported in PHP 7.0 or earlier. Found "%s const"';
+            $data  = array($tokens[$prevToken]['content']);
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+        }
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * New const visibility sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New const visibility sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewConstVisibilitySniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_const_visibility.php';
+
+    /**
+     * testConstVisibility
+     *
+     * @group constVisibility
+     *
+     * @dataProvider dataConstVisibility
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testConstVisibility($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Visibility indicators for class constants are not supported in PHP 7.0 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testConstVisibility()
+     *
+     * @return array
+     */
+    public function dataConstVisibility()
+    {
+        return array(
+            array(10),
+            array(11),
+            array(12),
+
+            array(20),
+            array(23),
+            array(24),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group constVisibility
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3'); // Arbitrary pre-PHP 7.1 version.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(3),
+            array(7),
+            array(17),
+        );
+    }
+}

--- a/Tests/sniff-examples/new_const_visibility.php
+++ b/Tests/sniff-examples/new_const_visibility.php
@@ -1,0 +1,25 @@
+<?php
+
+const NONCLASSCONST = 'foo';
+
+class ConstDemo
+{
+    const PUBLIC_CONST_A = 1;
+
+    // PHP 7.1+
+    public const PUBLIC_CONST_B = 2;
+    protected const PROTECTED_CONST = 3;
+    private const PRIVATE_CONST = 4;
+}
+
+interface InterfaceDemo
+{
+    const PUBLIC_CONST_A = 1;
+
+    // PHP 7.1+
+    public const PUBLIC_CONST_B = 2;
+
+    // Invalid, but the check for which visibility indicator is used is outside the scope of this library.
+    protected const PROTECTED_CONST = 3;
+    private const PRIVATE_CONST = 4;
+}


### PR DESCRIPTION
Introduces a new sniff to detect the use of visibility indicators for `class` & `interface` constants in pre-PHP 7.1 code.

Includes unit tests.

Fixes #249

#### Notes:
* AFAIK _class constants_ can not be defined in traits, so traits are disregarded for the purposes of this sniff. Please correct me if I'm wrong in this regard.
* The only valid visibility indicator for constants in `interface`s is `public`. However validating the visibility indicator used is outside the scope of this sniff/sniff library. See: https://github.com/wimg/PHPCompatibility/issues/249#issuecomment-254678830
* Visibility indicators for constants outside class scope are not supported in any PHP version. However, this again is outside the scope of this sniff/sniff library. See: https://github.com/wimg/PHPCompatibility/issues/249#issuecomment-254678830

Ref:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility
* https://wiki.php.net/rfc/class_const_visibility