### PR TITLE
PHP 7.1: New sniff for catch statements catching multiple exceptions.

### DIFF
--- a/Sniffs/PHP/NewMultiCatchSniff.php
+++ b/Sniffs/PHP/NewMultiCatchSniff.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMultiCatch.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMultiCatch.
+ *
+ * Catching multiple exception types in one statement is available since PHP 7.1.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewMultiCatchSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_CATCH);
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.0') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $token  = $tokens[$stackPtr];
+
+        // Bow out during live coding.
+        if (isset($token['parenthesis_opener'], $token['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $hasBitwiseOr = $phpcsFile->findNext(T_BITWISE_OR, $token['parenthesis_opener'], $token['parenthesis_closer']);
+
+        if ($hasBitwiseOr === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Catching multiple exceptions within one statement is not supported in PHP 7.0 or earlier.',
+            $hasBitwiseOr,
+            'Found'
+        );
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * New catching multiple exception types sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New catching multiple exception types sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewMultiCatchSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_multi_catch.php';
+
+    /**
+     * testNewMultiCatch
+     *
+     * @group multiCatch
+     *
+     * @dataProvider dataNewMultiCatch
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewMultiCatch($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Catching multiple exceptions within one statement is not supported in PHP 7.0 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewMultiCatch()
+     *
+     * @return array
+     */
+    public function dataNewMultiCatch()
+    {
+        return array(
+            array(21),
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group multiCatch
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0'); // Arbitrary pre-PHP 7.1 version.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(8),
+            array(10),
+            array(12),
+            array(23),
+        );
+    }
+}

--- a/Tests/sniff-examples/new_multi_catch.php
+++ b/Tests/sniff-examples/new_multi_catch.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Valid pre-PHP 7.1.
+ */
+try {
+   // Some code...
+} catch (ExceptionType1 $e) {
+   // Code to handle the exception.
+} catch (ExceptionType2 $e) {
+   // Same code to handle the exception.
+} catch (Exception $e) {
+   // ...
+}
+
+/**
+ * Multi-catch - only valid in PHP 7.1+.
+ */
+try {
+   // Some code...
+} catch (ExceptionType1 | ExceptionType2 $e) {
+   // Code to handle the exception.
+} catch (\Exception $e) {
+   // ...
+}


### PR DESCRIPTION
Includes unit tests.

Fixes #251 

Ref:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
* https://wiki.php.net/rfc/multiple-catch