### PR TITLE
PHP 7.1: New sniff for nullable types.

### DIFF
--- a/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/Sniffs/PHP/NewNullableTypesSniff.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewNullableTypes.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewNullableTypes.
+ *
+ * Nullable type hints and return types are available since PHP 7.1.
+ *
+ * PHP version 7.1
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewNullableTypesSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $tokens = array(
+            T_FUNCTION,
+        );
+
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4') >= 0) {
+            $tokens[] = T_RETURN_TYPE;
+        }
+
+        return $tokens;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.0') === false) {
+            return;
+        }
+
+        $tokens    = $phpcsFile->getTokens();
+        $tokenCode = $tokens[$stackPtr]['code'];
+
+        if ($tokenCode === T_FUNCTION) {
+            $this->processFunctionDeclaration($phpcsFile, $stackPtr);
+        } else {
+            $this->processReturnType($phpcsFile, $stackPtr);
+        }
+    }//end process()
+
+
+    /**
+     * Process this test for function tokens.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processFunctionDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $params = $this->getMethodParameters($phpcsFile, $stackPtr);
+
+        if (empty($params) === false && is_array($params)) {
+            foreach ($params as $param) {
+                if ($param['nullable_type'] === true) {
+                    $phpcsFile->addError(
+                        'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
+                        $stackPtr,
+                        'typeDeclarationFound',
+                        array($param['type_hint'])
+                    );
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Process this test for return type tokens.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    protected function processReturnType(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        if ($tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN) {
+            $phpcsFile->addError(
+                'Nullable return types are not supported in PHP 7.0 or earlier.',
+                $stackPtr,
+                'returnTypeFound'
+            );
+        }
+    }
+
+}//end class

--- a/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * New nullable type hints / return types sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New nullable type hints / return types sniff test file
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewNullableTypesSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_nullable_types.php';
+
+    /**
+     * testNewNullableReturnTypes
+     *
+     * @group nullableTypes
+     *
+     * @dataProvider dataNewNullableReturnTypes
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewNullableReturnTypes($line)
+    {
+        // Skip this test for low PHPCS versions.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '<')) {
+            $this->markTestSkipped();
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Nullable return types are not supported in PHP 7.0 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewNullableReturnTypes()
+     *
+     * @return array
+     */
+    public function dataNewNullableReturnTypes()
+    {
+        return array(
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(26),
+            array(27),
+        );
+    }
+
+
+    /**
+     * testNewNullableTypeHints
+     *
+     * @group nullableTypes
+     *
+     * @dataProvider dataNewNullableTypeHints
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewNullableTypeHints($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Nullable type declarations are not supported in PHP 7.0 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewNullableTypeHints()
+     *
+     * @return array
+     */
+    public function dataNewNullableTypeHints()
+    {
+        return array(
+            array(45),
+            array(46),
+            array(47),
+            array(48),
+            array(49),
+            array(50),
+            array(51),
+            array(52),
+
+            array(55), // Three errors of the same.
+        );
+    }
+
+
+    /**
+     * testNoViolation
+     *
+     * @group nullableTypes
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0'); // Arbitrary pre-PHP 7.1 version.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation()
+    {
+        return array(
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+
+            array(33),
+            array(34),
+            array(35),
+            array(36),
+            array(37),
+            array(38),
+            array(39),
+            array(40),
+        );
+    }
+}

--- a/Tests/sniff-examples/new_nullable_types.php
+++ b/Tests/sniff-examples/new_nullable_types.php
@@ -1,0 +1,56 @@
+<?php
+
+class NullableTypes {
+
+    /**
+     * Pre PHP 7.1 return types.
+     */
+    function testReturnBool(): bool {}
+    function testReturnInt(): int {}
+    function testReturnFloat(): float {}
+    function testReturnString(): string {}
+    function testReturnArray(): array {}
+    function testReturnCallable(): callable {}
+    function testReturnSelf(): self {}
+    function testReturnObject(): Baz {}
+
+    /**
+     * PHP 7.1: New nullable return types.
+     */
+    function testReturnNullableBool(): ?bool {}
+    function testReturnNullableInt(): ?int {}
+    function testReturnNullableFloat(): ?float {}
+    function testReturnNullableString(): ?string {}
+    function testReturnNullableArray(): ?array {}
+    function testReturnNullableCallable(): ?callable {}
+    function testReturnNullableSelf(): ?self {}
+    function testReturnNullableObject(): ?Baz {}
+
+
+    /**
+     * Pre PHP 7.1 type hints.
+     */
+    function testTypeHintBool(bool $nullable) {}
+    function testTypeHintInt(int $nullable) {}
+    function testTypeHintFloat(float $nullable) {}
+    function testTypeHintString(string $nullable) {}
+    function testTypeHintArray(array $nullable) {}
+    function testTypeHintCallable(callable $nullable) {}
+    function testTypeHintSelf(self $nullable) {}
+    function testTypeHintObject(Baz $nullable) {}
+
+    /**
+     * PHP 7.1: Nullable type hints.
+     */
+    function testTypeHintNullableBool(?bool $nullable) {}
+    function testTypeHintNullableInt(?int $nullable) {}
+    function testTypeHintNullableFloat(?float $nullable) {}
+    function testTypeHintNullableString(?string $nullable) {}
+    function testTypeHintNullableArray(?array $nullable) {}
+    function testTypeHintNullableCallable(?callable $nullable) {}
+    function testTypeHintNullableSelf(?self $nullable) {}
+    function testTypeHintNullableObject(?Baz $nullable) {}
+
+	// Test with multiple variables and different spacing.
+    function testTypeHintNullableMultiParam( ?bool $nullableA, ?int $nullableB, ?Baz $nullableC ) {}
+}


### PR DESCRIPTION
PHP 7.1 introduces nullable type hints and nullable return types.

As return types are only recognized in PHPCS 2.3.4+, this return type part of this sniff is not available in earlier PHPCS versions.

For the type hints, the `getMethodParameters()` utility method has been adjusted and a PR for the same has been submitted upstream. https://github.com/squizlabs/PHP_CodeSniffer/pull/1193

Fixes #247 

Ref:
* http://php.net/manual/en/migration71.new-features.php#migration71.new-features.nullable-types
* https://wiki.php.net/rfc/nullable_types

#### Note:

This PR does **not** contain a warning about the backward compatibility break nullable types can cause as it is not possible to reliably test for it.
The backward compatibility break occurs when a parent class or interface defines a default value of `null` combined with a normal type hint and a child class or implementation defines a different default. In that case the child class or implementation needs to make the type hint nullable.
Ref: https://wiki.php.net/rfc/nullable_types#to_backward_compatibility