### PR TITLE
Improve message text and variable names for deprecated/removed sniffs.

### DIFF
--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -19,14 +19,14 @@
 class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibility_Sniff
 {
     /**
-     * A list of forbidden functions with their alternatives.
+     * A list of deprecated and removed functions with their alternatives.
      *
-     * The array lists : version number with false (deprecated) or true (forbidden) and an alternative function.
+     * The array lists : version number with false (deprecated) or true (removed) and an alternative function.
      * If no alternative exists, it is NULL, i.e, the function should just not be used.
      *
      * @var array(string => array(string => bool|string|null))
      */
-    protected $forbiddenFunctions = array(
+    protected $removedFunctions = array(
                                         'php_check_syntax' => array(
                                             '5.0.5' => true,
                                             'alternative' => null
@@ -764,7 +764,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      *
      * @var array
      */
-    protected $forbiddenFunctionNames = array();
+    protected $removedFunctionNames = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -773,9 +773,9 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what forbidden functions
+        // Everyone has had a chance to figure out what removed functions
         // they want to check for, so now we can cache out the list.
-        $this->forbiddenFunctionNames = array_keys($this->forbiddenFunctions);
+        $this->removedFunctionNames = array_keys($this->removedFunctions);
 
         return array(T_STRING);
 
@@ -812,7 +812,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
 
         $function = strtolower($tokens[$stackPtr]['content']);
 
-        if (in_array($function, $this->forbiddenFunctionNames) === false) {
+        if (in_array($function, $this->removedFunctionNames) === false) {
             return;
         }
 
@@ -824,9 +824,9 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      * Generates the error or warning for this sniff.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the forbidden function
+     * @param int                  $stackPtr  The position of the function
      *                                        in the token array.
-     * @param string               $function  The name of the forbidden function.
+     * @param string               $function  The name of the function.
      *
      * @return void
      */
@@ -836,28 +836,28 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
 
         $isError = false;
         $previousVersionStatus = null;
-        foreach ($this->forbiddenFunctions[$function] as $version => $forbidden) {
+        foreach ($this->removedFunctions[$function] as $version => $removed) {
             if ($this->supportsAbove($version)) {
                 if ($version != 'alternative') {
-                    if ($previousVersionStatus !== $forbidden) {
-                        $previousVersionStatus = $forbidden;
-                        if ($forbidden === true) {
+                    if ($previousVersionStatus !== $removed) {
+                        $previousVersionStatus = $removed;
+                        if ($removed === true) {
                             $isError = true;
-                            $error .= 'forbidden';
+                            $error .= 'removed';
                         } else {
-                            $error .= 'discouraged';
+                            $error .= 'deprecated';
                         }
-                        $error .=  ' from PHP version ' . $version . ' and ';
+                        $error .=  ' since PHP ' . $version . ' and ';
                     }
                 }
             }
         }
         if (strlen($error) > 0) {
-            $error = 'The use of function ' . $function . ' is ' . $error;
+            $error = 'Function ' . $function . '() is ' . $error;
             $error = substr($error, 0, strlen($error) - 5);
 
-            if ($this->forbiddenFunctions[$function]['alternative'] !== null) {
-                $error .= '; use ' . $this->forbiddenFunctions[$function]['alternative'] . ' instead';
+            if ($this->removedFunctions[$function]['alternative'] !== null) {
+                $error .= '; use ' . $this->removedFunctions[$function]['alternative'] . ' instead';
             }
 
             if ($isError === true) {

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -257,18 +257,18 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
 
         $error = '';
 
-        foreach ($this->deprecatedIniDirectives[$filteredToken] as $version => $forbidden)
+        foreach ($this->deprecatedIniDirectives[$filteredToken] as $version => $removed)
         {
             if ($version !== 'alternative') {
                 if ($this->supportsAbove($version)) {
-                    if ($forbidden === true) {
+                    if ($removed === true) {
                         $isError = ($function !== 'ini_get') ? true : false;
-                        $error .= " forbidden";
+                        $error .= " removed";
                     } else {
                         $isError = false;
                         $error .= " deprecated";
                     }
-                    $error .= " from PHP " . $version . " and";
+                    $error .= " since PHP " . $version . " and";
                 }
             }
         }

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -744,7 +744,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what forbidden functions
+        // Everyone has had a chance to figure out what functions
         // they want to check for, so now we can cache out the list.
         $this->newFunctionParametersNames = array_keys($this->newFunctionParameters);
 

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -24,7 +24,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      *
      * @var array(string => array(string => int|string|null))
      */
-    protected $forbiddenFunctions = array(
+    protected $newFunctions = array(
                                         'array_fill_keys' => array(
                                             '5.1' => false,
                                             '5.2' => true
@@ -1246,7 +1246,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      *
      * @var array
      */
-    private $forbiddenFunctionNames;
+    private $newFunctionNames;
 
 
     /**
@@ -1256,11 +1256,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what forbidden functions
+        // Everyone has had a chance to figure out what new functions
         // they want to check for, so now we can cache out the list.
-        $this->forbiddenFunctionNames = array_keys($this->forbiddenFunctions);
-        $this->forbiddenFunctionNames = array_map('strtolower', $this->forbiddenFunctionNames);
-        $this->forbiddenFunctions     = array_combine($this->forbiddenFunctionNames, $this->forbiddenFunctions);
+        $this->newFunctionNames = array_keys($this->newFunctions);
+        $this->newFunctionNames = array_map('strtolower', $this->newFunctionNames);
+        $this->newFunctions     = array_combine($this->newFunctionNames, $this->newFunctions);
 
         return array(T_STRING);
 
@@ -1298,7 +1298,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
         $function = strtolower($tokens[$stackPtr]['content']);
 
-        if (in_array($function, $this->forbiddenFunctionNames) === false) {
+        if (in_array($function, $this->newFunctionNames) === false) {
             return;
         }
 
@@ -1323,7 +1323,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
         $error      = '';
 
         $isError = false;
-        foreach ($this->forbiddenFunctions[$functionLc] as $version => $present) {
+        foreach ($this->newFunctions[$functionLc] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
                     $isError = true;

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -69,7 +69,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what forbidden functions
+        // Everyone has had a chance to figure out what removed function parameters
         // they want to check for, so now we can cache out the list.
         $this->removedFunctionParametersNames = array_keys($this->removedFunctionParameters);
 

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -47,7 +47,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn}");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}");
         }
     }
 
@@ -97,7 +97,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn}; use {$alternative} instead");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; use {$alternative} instead");
         }
     }
 
@@ -198,45 +198,45 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
 
 
     /**
-     * testForbiddenFunction
+     * testRemovedFunction
      *
-     * @dataProvider dataForbiddenFunction
+     * @dataProvider dataRemovedFunction
      *
-     * @param string $functionName      Name of the function.
-     * @param string $forbiddenIn       The PHP version in which the function was forbidden.
-     * @param array  $lines             The line numbers in the test file which apply to this function.
-     * @param string $okVersion         A PHP version in which the function was still valid.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $functionName   Name of the function.
+     * @param string $removedIn      The PHP version in which the function was removed.
+     * @param array  $lines          The line numbers in the test file which apply to this function.
+     * @param string $okVersion      A PHP version in which the function was still valid.
+     * @param string $removedVersion Optional PHP version to test removed message with -
+     *                               if different from the $removedIn version.
      *
      * return void
      */
-    public function testForbiddenFunction($functionName, $forbiddenIn, $lines, $okVersion, $forbiddenVersion = null)
+    public function testRemovedFunction($functionName, $removedIn, $lines, $okVersion, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "The use of function {$functionName} is forbidden from PHP version {$forbiddenIn}");
+            $this->assertError($file, $line, "Function {$functionName}() is removed since PHP {$removedIn}");
         }
     }
 
     /**
      * Data provider.
      *
-     * @see testForbiddenFunction()
+     * @see testRemovedFunction()
      *
      * @return array
      */
-    public function dataForbiddenFunction()
+    public function dataRemovedFunction()
     {
         return array(
             array('php_logo_guid', '5.5', array(32), '5.4'),
@@ -258,23 +258,23 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
 
 
     /**
-     * testDeprecatedForbiddenFunction
+     * testDeprecatedRemovedFunction
      *
-     * @dataProvider dataDeprecatedForbiddenFunction
+     * @dataProvider dataDeprecatedRemovedFunction
      *
      * @param string $functionName      Name of the function.
      * @param string $deprecatedIn      The PHP version in which the function was deprecated.
-     * @param string $forbiddenIn       The PHP version in which the function was forbidden.
+     * @param string $removedIn         The PHP version in which the function was removed.
      * @param array  $lines             The line numbers in the test file which apply to this function.
      * @param string $okVersion         A PHP version in which the function was still valid.
      * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
      *                                  if different from the $deprecatedIn version.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $removedVersion    Optional PHP version to test removed message with -
+     *                                  if different from the $removedIn version.
      *
      * return void
      */
-    public function testDeprecatedForbiddenFunction($functionName, $deprecatedIn, $forbiddenIn, $lines, $okVersion, $deprecatedVersion = null, $forbiddenVersion = null)
+    public function testDeprecatedRemovedFunction($functionName, $deprecatedIn, $removedIn, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
@@ -288,28 +288,28 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn}");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}");
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn} and forbidden from PHP version {$forbiddenIn}");
+            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
         }
     }
 
     /**
      * Data provider.
      *
-     * @see testDeprecatedForbiddenFunction()
+     * @see testDeprecatedRemovedFunction()
      *
      * @return array
      */
-    public function dataDeprecatedForbiddenFunction()
+    public function dataDeprecatedRemovedFunction()
     {
         return array(
             array('define_syslog_variables', '5.3', '5.4', array(5), '5.2'),
@@ -328,24 +328,24 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
 
 
     /**
-     * testDeprecatedForbiddenFunctionWithAlternative
+     * testDeprecatedRemovedFunctionWithAlternative
      *
-     * @dataProvider dataDeprecatedForbiddenFunctionWithAlternative
+     * @dataProvider dataDeprecatedRemovedFunctionWithAlternative
      *
      * @param string $functionName      Name of the function.
      * @param string $deprecatedIn      The PHP version in which the function was deprecated.
-     * @param string $forbiddenIn       The PHP version in which the function was forbidden.
+     * @param string $removedIn         The PHP version in which the function was removed.
      * @param string $alternative       An alternative function.
      * @param array  $lines             The line numbers in the test file which apply to this function.
      * @param string $okVersion         A PHP version in which the function was still valid.
      * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
      *                                  if different from the $deprecatedIn version.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $removedVersion    Optional PHP version to test removed message with -
+     *                                  if different from the $removedIn version.
      *
      * return void
      */
-    public function testDeprecatedForbiddenFunctionWithAlternative($functionName, $deprecatedIn, $forbiddenIn, $alternative, $lines, $okVersion, $deprecatedVersion = null, $forbiddenVersion = null)
+    public function testDeprecatedRemovedFunctionWithAlternative($functionName, $deprecatedIn, $removedIn, $alternative, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
@@ -359,28 +359,28 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn}; use {$alternative} instead");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; use {$alternative} instead");
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "The use of function {$functionName} is discouraged from PHP version {$deprecatedIn} and forbidden from PHP version {$forbiddenIn}; use {$alternative} instead");
+            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; use {$alternative} instead");
         }
     }
 
     /**
      * Data provider.
      *
-     * @see testDeprecatedForbiddenFunctionWithAlternative()
+     * @see testDeprecatedRemovedFunctionWithAlternative()
      *
      * @return array
      */
-    public function dataDeprecatedForbiddenFunctionWithAlternative()
+    public function dataDeprecatedRemovedFunctionWithAlternative()
     {
         return array(
             array('call_user_method', '5.3', '7.0', 'call_user_func', array(3), '5.2'),

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -34,25 +34,25 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     }
 
     /**
-     * testDeprecatedForbiddenDirectives
+     * testDeprecatedRemovedDirectives
      *
      * @group IniDirectives
      *
-     * @dataProvider dataDeprecatedForbiddenDirectives
+     * @dataProvider dataDeprecatedRemovedDirectives
      *
      * @param string $iniName           Name of the ini directive.
      * @param string $deprecatedIn      The PHP version in which the ini directive was deprecated.
-     * @param string $forbiddenIn       The PHP version in which the ini directive was forbidden.
+     * @param string $removedIn         The PHP version in which the ini directive was removed.
      * @param array  $lines             The line numbers in the test file which apply to this ini directive.
      * @param string $okVersion         A PHP version in which the ini directive was still valid.
      * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
      *                                  if different from the $deprecatedIn version.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $removedVersion    Optional PHP version to test removed message with -
+     *                                  if different from the $removedIn version.
      *
      * @return void
      */
-    public function testDeprecatedForbiddenDirectives($iniName, $deprecatedIn, $forbiddenIn, $lines, $okVersion, $deprecatedVersion = null, $forbiddenVersion = null)
+    public function testDeprecatedRemovedDirectives($iniName, $deprecatedIn, $removedIn, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
@@ -66,27 +66,27 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated from PHP {$deprecatedIn}.");
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}.");
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is deprecated from PHP {$deprecatedIn} and forbidden from PHP {$forbiddenIn}");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is deprecated from PHP {$deprecatedIn} and forbidden from PHP {$forbiddenIn}");
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
     }
 
     /**
      * Data provider.
      *
-     * @see testDeprecatedForbiddenDirectives()
+     * @see testDeprecatedRemovedDirectives()
      *
      * @return array
      */
-    public function dataDeprecatedForbiddenDirectives()
+    public function dataDeprecatedRemovedDirectives()
     {
         return array(
             array('define_syslog_variables', '5.3', '5.4', array(3, 4), '5.2'),
@@ -142,7 +142,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated from PHP {$deprecatedIn}.");
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}.");
         }
     }
 
@@ -173,47 +173,47 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
 
     /**
-     * testForbiddenWithAlternative
+     * testRemovedWithAlternative
      *
      * @group IniDirectives
      *
-     * @dataProvider dataForbiddenWithAlternative
+     * @dataProvider dataRemovedWithAlternative
      *
-     * @param string $iniName           Name of the ini directive.
-     * @param string $forbiddenIn       The PHP version in which the ini directive was forbidden.
-     * @param string $alternative       An alternative ini directive for the forbidden directive.
-     * @param array  $lines             The line numbers in the test file which apply to this ini directive.
-     * @param string $okVersion         A PHP version in which the ini directive was still valid.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $iniName        Name of the ini directive.
+     * @param string $removedIn      The PHP version in which the ini directive was removed.
+     * @param string $alternative    An alternative ini directive for the removed directive.
+     * @param array  $lines          The line numbers in the test file which apply to this ini directive.
+     * @param string $okVersion      A PHP version in which the ini directive was still valid.
+     * @param string $removedVersion Optional PHP version to test removed message with -
+     *                               if different from the $removedIn version.
      *
      * @return void
      */
-    public function testForbiddenWithAlternative($iniName, $forbiddenIn, $alternative, $lines, $okVersion, $forbiddenVersion = null)
+    public function testRemovedWithAlternative($iniName, $removedIn, $alternative, $lines, $okVersion, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$forbiddenIn}. Use '{$alternative}' instead.");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$forbiddenIn}. Use '{$alternative}' instead.");
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}. Use '{$alternative}' instead.");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}. Use '{$alternative}' instead.");
     }
 
     /**
      * Data provider.
      *
-     * @see testForbiddenWithAlternative()
+     * @see testRemovedWithAlternative()
      *
      * @return array
      */
-    public function dataForbiddenWithAlternative()
+    public function dataRemovedWithAlternative()
     {
         return array(
             array('fbsql.batchSize', '5.1', 'fbsql.batchsize', array(89, 90), '5.0'),
@@ -223,46 +223,46 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     }
 
     /**
-     * testForbiddenDirectives
+     * testRemovedDirectives
      *
      * @group IniDirectives
      *
-     * @dataProvider dataForbiddenDirectives
+     * @dataProvider dataRemovedDirectives
      *
-     * @param string $iniName           Name of the ini directive.
-     * @param string $forbiddenIn       The PHP version in which the ini directive was forbidden.
-     * @param array  $lines             The line numbers in the test file which apply to this ini directive.
-     * @param string $okVersion         A PHP version in which the ini directive was still valid.
-     * @param string $forbiddenVersion  Optional PHP version to test forbidden message with -
-     *                                  if different from the $forbiddenIn version.
+     * @param string $iniName        Name of the ini directive.
+     * @param string $removedIn      The PHP version in which the ini directive was removed.
+     * @param array  $lines          The line numbers in the test file which apply to this ini directive.
+     * @param string $okVersion      A PHP version in which the ini directive was still valid.
+     * @param string $removedVersion Optional PHP version to test removed message with -
+     *                               if different from the $removedIn version.
      *
      * @return void
      */
-    public function testForbiddenDirectives($iniName, $forbiddenIn, $lines, $okVersion, $forbiddenVersion = null)
+    public function testRemovedDirectives($iniName, $removedIn, $lines, $okVersion, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
         }
 
-        if (isset($forbiddenVersion)){
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenVersion);
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
         }
         else {
-            $file = $this->sniffFile(self::TEST_FILE, $forbiddenIn);
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is forbidden from PHP {$forbiddenIn}.");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is forbidden from PHP {$forbiddenIn}.");
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}.");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}.");
     }
 
     /**
      * Data provider.
      *
-     * @see testForbiddenDirectives()
+     * @see testRemovedDirectives()
      *
      * @return array
      */
-    public function dataForbiddenDirectives()
+    public function dataRemovedDirectives()
     {
         return array(
             array('ifx.allow_persistent', '5.2.1', array(92, 93), '5.1', '5.3'),


### PR DESCRIPTION
The message text for removed functions and ini directives used "forbidden" was IMHO could be misleading.
The message text has been adjusted to use "removed" instead.

For clarity relevant variable names containing "forbidden" have been adjusted to use "removed" as well.

P.S.: _I kind of have feeling this is a left-over from the first version of these sniffs being based on the PHPCS native `Generic.PHP.ForbiddenFunctions` sniff_.