### PR TITLE
Improve consistency of warning/error logic.

### DIFF
--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -81,7 +81,11 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
         }
 
         if ($newConstructorFound === false && $oldConstructorFound === true) {
-            $phpcsFile->addError('Use of deprecated PHP4 style class constructor is not supported since PHP 7', $oldConstructorPos);
+            $phpcsFile->addWarning(
+                'Use of deprecated PHP4 style class constructor is not supported since PHP 7.',
+                $oldConstructorPos,
+                'Found'
+            );
         }
     }
 }

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -107,11 +107,21 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
         foreach ($parameters as $parameter) {
             if ($this->isCallTimePassByReferenceParam($phpcsFile, $parameter, $nestedParenthesisCount) === true) {
                 // T_BITWISE_AND represents a pass-by-reference.
-                $error = 'Using a call-time pass-by-reference is deprecated since PHP 5.3';
+                $error     = 'Using a call-time pass-by-reference is deprecated since PHP 5.3';
+                $isError   = false;
+                $errorCode = 'Deprecated';
+
                 if($this->supportsAbove('5.4')) {
-                    $error .= ' and prohibited since PHP 5.4';
+                    $error    .= ' and prohibited since PHP 5.4';
+                    $isError   = true;
+                    $errorCode = 'NotAllowed';
                 }
-                $phpcsFile->addError($error, $parameter['start'], 'NotAllowed');
+
+                if ($isError === true) {
+                    $phpcsFile->addError($error, $parameter['start'], $errorCode);
+                } else {
+                    $phpcsFile->addWarning($error, $parameter['start'], $errorCode);
+                }
             }
         }
     }//end process()

--- a/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -99,7 +99,7 @@ class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompa
                 $error .= ' Use mb_ereg_replace_callback() instead (PHP 5.4.1+).';
             }
 
-            $phpcsFile->addError($error, $stackPtr, 'Found');
+            $phpcsFile->addWarning($error, $stackPtr, 'Found');
         }
 
     }//end process()

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -114,13 +114,22 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
             $modifiers = substr($regex, $regexEndPos + 1);
 
             if (strpos($modifiers, 'e') !== false) {
+                $error     = '%s() - /e modifier is deprecated since PHP 5.5';
+                $isError   = false;
+                $errorCode = 'Deprecated';
+                $data      = array($functionName);
+
                 if ($this->supportsAbove('7.0')) {
-                    $error = '%s() - /e modifier is forbidden since PHP 7.0';
-                } else {
-                    $error = '%s() - /e modifier is deprecated since PHP 5.5';
+                    $error    .= ' and removed since PHP 7.0';
+                    $isError   = true;
+                    $errorCode = 'Removed';
                 }
-                $data = array($functionName);
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+                if ($isError === true) {
+                    $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+                } else {
+                    $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
+                }
             }
         }
 

--- a/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -60,7 +60,7 @@ class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility
 
         if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
             $error = 'Middle may not be omitted from ternary operators in PHP < 5.3';
-            $phpcsFile->addWarning($error, $stackPtr);
+            $phpcsFile->addError($error, $stackPtr);
         }
     }
 }

--- a/Sniffs/PHP/ValidIntegersSniff.php
+++ b/Sniffs/PHP/ValidIntegersSniff.php
@@ -64,7 +64,7 @@ class PHPCompatibility_Sniffs_PHP_ValidIntegersSniff extends PHPCompatibility_Sn
             if ($this->isInvalidBinaryInteger($tokens, $stackPtr) === true) {
                 $error = 'Invalid binary integer detected. Found: %s';
                 $data  = array($this->getBinaryInteger($phpcsFile, $tokens, $stackPtr));
-                $phpcsFile->addError($error, $stackPtr, 'InvalidBinaryIntegerFound', $data);
+                $phpcsFile->addWarning($error, $stackPtr, 'InvalidBinaryIntegerFound', $data);
             }
             return;
         }

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -33,7 +33,7 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, 'Use of deprecated PHP4 style class constructor is not supported since PHP 7');
+        $this->assertWarning($file, $line, 'Use of deprecated PHP4 style class constructor is not supported since PHP 7');
     }
 
     /**

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -54,7 +54,7 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, $line, 'Using a call-time pass-by-reference is deprecated since PHP 5.3');
+        $this->assertWarning($file, $line, 'Using a call-time pass-by-reference is deprecated since PHP 5.3');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertError($file, $line, 'Using a call-time pass-by-reference is deprecated since PHP 5.3 and prohibited since PHP 5.4');

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -34,10 +34,10 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3-7.1');
-        $this->assertError($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1.');
+        $this->assertWarning($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1.');
 
         $file = $this->sniffFile(self::TEST_FILE, '7.1');
-        $this->assertError($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1. Use mb_ereg_replace_callback() instead (PHP 5.4.1+).');
+        $this->assertWarning($file, $line, 'The Mbstring regex "e" modifier is deprecated since PHP 7.1. Use mb_ereg_replace_callback() instead (PHP 5.4.1+).');
     }
 
     /**

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -36,10 +36,10 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, $line, "{$functionName}() - /e modifier is deprecated since PHP 5.5");
+        $this->assertWarning($file, $line, "{$functionName}() - /e modifier is deprecated since PHP 5.5");
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, "{$functionName}() - /e modifier is forbidden since PHP 7.0");
+        $this->assertError($file, $line, "{$functionName}() - /e modifier is deprecated since PHP 5.5 and removed since PHP 7.0");
     }
 
     /**

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -45,9 +45,9 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     public function testMissingMiddleExpression5dot2()
     {
         $this->_sniffFile = $this->sniffFile('sniff-examples/ternary_operator.php', '5.2-5.4');
-        $this->assertWarning($this->_sniffFile, 8,
+        $this->assertError($this->_sniffFile, 8,
                 "Middle may not be omitted from ternary operators in PHP < 5.3");
-        $this->assertWarning($this->_sniffFile, 10,
+        $this->assertError($this->_sniffFile, 10,
                 "Middle may not be omitted from ternary operators in PHP < 5.3");
     }
 

--- a/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -90,7 +90,7 @@ class ValidIntegersSniffTest extends BaseSniffTest
      */
     public function testInvalidBinaryInteger()
     {
-        $this->assertError($this->_sniffFile, 4, 'Invalid binary integer detected. Found: 0b0123456');
+        $this->assertWarning($this->_sniffFile, 4, 'Invalid binary integer detected. Found: 0b0123456');
     }
 
 


### PR DESCRIPTION
Looking at all the other sniffs:
* **_Deprecated_** functionality should throw a warning.
* **_Removed_** or otherwise unavailable functionality should throw an error.

This distinction was not consistently applied everywhere.

In part inspired by https://github.com/wpengine/phpcompat/issues/73 (which this solves).