### PR TITLE
Throw a warning not an error for PHP 4 style constructors. 

### DIFF
--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -81,7 +81,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
         }
 
         if ($newConstructorFound === false && $oldConstructorFound === true) {
-            $phpcsFile->addError('Use of deprecated PHP4 style class constructor is not supported since PHP 7', $oldConstructorPos);
+            $phpcsFile->addWarning('Use of PHP 4 style class constructor is deprecated since PHP 7', $oldConstructorPos);
         }
     }
 }

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -33,7 +33,7 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, 'Use of deprecated PHP4 style class constructor is not supported since PHP 7');
+        $this->assertWarning($file, $line, 'Use of PHP 4 style class constructor is deprecated since PHP 7');
     }
 
     /**


### PR DESCRIPTION
Currently this throws an error,  but I believe it should throw a warning. These constructors are only deprecated in PHP 7.0. 

http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors