### PR TITLE
Refactor the error messages

### DIFF
--- a/AbstractComplexVersionSniff.php
+++ b/AbstractComplexVersionSniff.php
@@ -14,9 +14,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractComplexVersionSniff
-    extends PHPCompatibility_Sniff
-    implements PHPCompatibility_ComplexVersionInterface
+abstract class PHPCompatibility_AbstractComplexVersionSniff extends PHPCompatibility_Sniff implements PHPCompatibility_ComplexVersionInterface
 {
 
 

--- a/AbstractComplexVersionSniff.php
+++ b/AbstractComplexVersionSniff.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * PHPCompatibility_AbstractComplexVersionSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_AbstractComplexVersionSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+abstract class PHPCompatibility_AbstractComplexVersionSniff
+    extends PHPCompatibility_Sniff
+    implements PHPCompatibility_ComplexVersionInterface
+{
+
+
+    /**
+     * Handle the retrieval of relevant information and - if necessary - throwing of an
+     * error/warning for an item.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the relevant token in
+     *                                        the stack.
+     * @param array                $itemInfo  Base information about the item.
+     *
+     * @return void
+     */
+    public function handleFeature(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo)
+    {
+        $itemArray = $this->getItemArray($itemInfo);
+        $errorInfo = $this->getErrorInfo($itemArray, $itemInfo);
+
+        if ($this->shouldThrowError($errorInfo) === true) {
+            $this->addError($phpcsFile, $stackPtr, $itemInfo, $errorInfo);
+        }
+    }
+
+
+    /**
+     * Determine whether an error/warning should be thrown for an item based on collected information.
+     *
+     * @param array $errorInfo Detail information about an item.
+     *
+     * @return bool
+     */
+    abstract protected function shouldThrowError(array $errorInfo);
+
+
+    /**
+     * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * @return array
+     */
+    protected function getNonVersionArrayKeys()
+    {
+        return array();
+    }
+
+
+    /**
+     * Retrieve a subset of an item array containing only the array keys which
+     * contain PHP version information.
+     *
+     * @param array $itemArray Version and other information about an item.
+     *
+     * @return array Array with only the version information.
+     */
+    protected function getVersionArray(array $itemArray)
+    {
+        return array_diff_key($itemArray, array_flip($this->getNonVersionArrayKeys()));
+    }
+
+
+    /**
+     * Get the item name to be used for the creation of the error code and in the error message.
+     *
+     * @param array $itemInfo  Base information about the item.
+     * @param array $errorInfo Detail information about an item.
+     *
+     * @return string
+     */
+    protected function getItemName(array $itemInfo, array $errorInfo)
+    {
+        return $itemInfo['name'];
+    }
+
+
+    /**
+     * Get the error message template for a specific sniff.
+     *
+     * @return string
+     */
+    abstract protected function getErrorMsgTemplate();
+
+
+    /**
+     * Allow for concrete child classes to filter the error message before it's passed to PHPCS.
+     *
+     * @param string $error     The error message which was created.
+     * @param array  $itemInfo  Base information about the item this error message applied to.
+     * @param array  $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return string
+     */
+    protected function filterErrorMsg($error, array $itemInfo, array $errorInfo)
+    {
+        return $error;
+    }
+
+
+    /**
+     * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @param array $data      The error data array which was created.
+     * @param array $itemInfo  Base information about the item this error message applied to.
+     * @param array $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return array
+     */
+    protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
+    {
+        return $data;
+    }
+
+
+}//end class

--- a/AbstractNewFeatureSniff.php
+++ b/AbstractNewFeatureSniff.php
@@ -14,8 +14,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractNewFeatureSniff
-    extends PHPCompatibility_AbstractComplexVersionSniff
+abstract class PHPCompatibility_AbstractNewFeatureSniff extends PHPCompatibility_AbstractComplexVersionSniff
 {
 
 

--- a/AbstractNewFeatureSniff.php
+++ b/AbstractNewFeatureSniff.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * PHPCompatibility_AbstractNewFeatureSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PPHPCompatibility_AbstractNewFeatureSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+abstract class PHPCompatibility_AbstractNewFeatureSniff
+    extends PHPCompatibility_AbstractComplexVersionSniff
+{
+
+
+    /**
+     * Determine whether an error/warning should be thrown for an item based on collected information.
+     *
+     * @param array $errorInfo Detail information about an item.
+     *
+     * @return bool
+     */
+    protected function shouldThrowError(array $errorInfo)
+    {
+        return ($errorInfo['not_in_version'] !== '');
+    }
+
+
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo)
+    {
+        $errorInfo = array(
+            'not_in_version' => '',
+            'error'          => true,
+        );
+
+        $versionArray = $this->getVersionArray($itemArray);
+
+        if (empty($versionArray) === false) {
+            foreach ($versionArray as $version => $present) {
+                if ($errorInfo['not_in_version'] === '' && $present === false
+                    && $this->supportsBelow($version) === true
+                ) {
+                    $errorInfo['not_in_version'] = $version;
+                }
+            }
+        }
+
+        return $errorInfo;
+    }
+
+
+    /**
+     * Get the error message template for this sniff.
+     *
+     * @return string
+     */
+    protected function getErrorMsgTemplate()
+    {
+        return '%s is not present in PHP version %s or earlier';
+    }
+
+
+    /**
+     * Generates the error or warning for this item.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the relevant token in
+     *                                        the stack.
+     * @param array                $itemInfo  Base information about the item.
+     * @param array                $errorInfo Array with detail (version) information
+     *                                        relevant to the item.
+     *
+     * @return void
+     */
+    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    {
+        $itemName = $this->getItemName($itemInfo, $errorInfo);
+        $error    = $this->getErrorMsgTemplate();
+
+        $errorCode = $this->stringToErrorCode($itemName).'Found';
+        $data      = array(
+            $itemName,
+            $errorInfo['not_in_version'],
+        );
+
+        $error = $this->filterErrorMsg($error, $itemInfo, $errorInfo);
+        $data  = $this->filterErrorData($data, $itemInfo, $errorInfo);
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
+    }
+
+
+}//end class

--- a/AbstractRemovedFeatureSniff.php
+++ b/AbstractRemovedFeatureSniff.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * PHPCompatibility_AbstractRemovedFeatureSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_AbstractRemovedFeatureSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+abstract class PHPCompatibility_AbstractRemovedFeatureSniff
+    extends PHPCompatibility_AbstractComplexVersionSniff
+{
+
+
+    /**
+     * Determine whether an error/warning should be thrown for an item based on collected information.
+     *
+     * @param array $errorInfo Detail information about an item.
+     *
+     * @return bool
+     */
+    protected function shouldThrowError(array $errorInfo)
+    {
+        return ($errorInfo['deprecated'] !== '' || $errorInfo['removed'] !== '');
+    }
+
+
+    /**
+     * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * By default, removed feature version arrays, contain an additional 'alternative' array key.
+     *
+     * @return array
+     */
+    protected function getNonVersionArrayKeys()
+    {
+        return array('alternative');
+    }
+
+
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo)
+    {
+        $errorInfo = array(
+            'deprecated'  => '',
+            'removed'     => '',
+            'alternative' => '',
+            'error'       => false,
+        );
+
+        $versionArray = $this->getVersionArray($itemArray);
+
+        if (empty($versionArray) === false) {
+            foreach ($versionArray as $version => $removed) {
+                if ($this->supportsAbove($version) === true) {
+                    if ($removed === true && $errorInfo['removed'] === '') {
+                        $errorInfo['removed'] = $version;
+                        $errorInfo['error']   = true;
+                    } else if ($errorInfo['deprecated'] === '') {
+                        $errorInfo['deprecated'] = $version;
+                    }
+                }
+            }
+        }
+
+        if (isset($itemArray['alternative']) === true) {
+            $errorInfo['alternative'] = $itemArray['alternative'];
+        }
+
+        return $errorInfo;
+    }
+
+
+    /**
+     * Get the error message template for suggesting an alternative for a specific sniff.
+     *
+     * @return string
+     */
+    protected function getAlternativeOptionTemplate()
+    {
+        return '; Use %s instead';
+    }
+
+
+    /**
+     * Generates the error or warning for this item.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the relevant token in
+     *                                        the stack.
+     * @param array                $itemInfo  Base information about the item.
+     * @param array                $errorInfo Array with detail (version) information
+     *                                        relevant to the item.
+     *
+     * @return void
+     */
+    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    {
+        $itemName = $this->getItemName($itemInfo, $errorInfo);
+        $error    = $this->getErrorMsgTemplate();
+
+        $errorCode = $this->stringToErrorCode($itemName).'Found';
+        $data      = array($itemName);
+
+        if ($errorInfo['deprecated'] !== '') {
+            $error .= 'deprecated since PHP %s and ';
+            $data[] = $errorInfo['deprecated'];
+        }
+
+        if ($errorInfo['removed'] !== '') {
+            $error .= 'removed since PHP %s and ';
+            $data[] = $errorInfo['removed'];
+        }
+
+        // Remove the last 'and' from the message.
+        $error = substr($error, 0, (strlen($error) - 5));
+
+        if ($errorInfo['alternative'] !== '') {
+            $error .= $this->getAlternativeOptionTemplate();
+            $data[] = $errorInfo['alternative'];
+        }
+
+        $error = $this->filterErrorMsg($error, $itemInfo, $errorInfo);
+        $data  = $this->filterErrorData($data, $itemInfo, $errorInfo);
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
+
+    }//end addError()
+
+
+}//end class

--- a/AbstractRemovedFeatureSniff.php
+++ b/AbstractRemovedFeatureSniff.php
@@ -113,17 +113,19 @@ abstract class PHPCompatibility_AbstractRemovedFeatureSniff
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();
 
-        $errorCode = $this->stringToErrorCode($itemName).'Found';
+        $errorCode = $this->stringToErrorCode($itemName);
         $data      = array($itemName);
 
         if ($errorInfo['deprecated'] !== '') {
-            $error .= 'deprecated since PHP %s and ';
-            $data[] = $errorInfo['deprecated'];
+            $error     .= 'deprecated since PHP %s and ';
+            $errorCode .= 'Deprecated';
+            $data[]     = $errorInfo['deprecated'];
         }
 
         if ($errorInfo['removed'] !== '') {
-            $error .= 'removed since PHP %s and ';
-            $data[] = $errorInfo['removed'];
+            $error     .= 'removed since PHP %s and ';
+            $errorCode .= 'Removed';
+            $data[]     = $errorInfo['removed'];
         }
 
         // Remove the last 'and' from the message.

--- a/AbstractRemovedFeatureSniff.php
+++ b/AbstractRemovedFeatureSniff.php
@@ -14,8 +14,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractRemovedFeatureSniff
-    extends PHPCompatibility_AbstractComplexVersionSniff
+abstract class PHPCompatibility_AbstractRemovedFeatureSniff extends PHPCompatibility_AbstractComplexVersionSniff
 {
 
 

--- a/ComplexVersionInterface.php
+++ b/ComplexVersionInterface.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * PHPCompatibility_ComplexVersionInterface.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_ComplexVersionInterface.
+ *
+ * Interface to be implemented by sniffs using a multi-dimensional array of
+ * PHP features (functions, classes etc) being sniffed for with version
+ * information in sub-arrays.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+interface PHPCompatibility_ComplexVersionInterface
+{
+
+
+    /**
+     * Handle the retrieval of relevant information and - if necessary - throwing of an
+     * error/warning for an item.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the relevant token in
+     *                                        the stack.
+     * @param array                $itemInfo  Base information about the item.
+     *
+     * @return void
+     */
+    public function handleFeature(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo);
+
+
+    /**
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @param array $itemInfo Base information about the item.
+     *
+     * @return array Version and other information about the item.
+     */
+    public function getItemArray(array $itemInfo);
+
+
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo);
+
+
+    /**
+     * Generates the error or warning for this item.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the relevant token in
+     *                                        the stack.
+     * @param array                $itemInfo  Base information about the item.
+     * @param array                $errorInfo Array with detail (version) information
+     *                                        relevant to the item.
+     *
+     * @return void
+     */
+    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
+
+
+}//end interface

--- a/Sniff.php
+++ b/Sniff.php
@@ -40,6 +40,20 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     );
 
 
+    /**
+     * List of functions which take an ini directive as parameter (always the first parameter).
+     *
+     * Used by the new/removed ini directives sniffs.
+     * Key is the function name, value is the 1-based parameter position in the function call.
+     *
+     * @var array
+     */
+    protected $iniFunctions = array(
+        'ini_get' => 1,
+        'ini_set' => 1,
+    );
+
+
 /* The testVersion configuration variable may be in any of the following formats:
  * 1) Omitted/empty, in which case no version is specified.  This effectively
  *    disables all the checks provided by this standard.

--- a/Sniff.php
+++ b/Sniff.php
@@ -154,6 +154,21 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
 
     /**
+     * Convert an arbitrary string to an alphanumeric string with underscores.
+     *
+     * Pre-empt issues with arbitrary strings being used as error codes in XML and PHP.
+     *
+     * @param string $baseString Arbitrary string.
+     *
+     * @return string
+     */
+    public function stringToErrorCode($baseString)
+    {
+        return preg_replace('`[^a-z0-9_]`i', '_', strtolower($baseString));
+    }
+
+
+    /**
      * Strip quotes surrounding an arbitrary string.
      *
      * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING.

--- a/Sniff.php
+++ b/Sniff.php
@@ -197,6 +197,21 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
 
     /**
+     * Make all top level array keys in an array lowercase.
+     *
+     * @param array $array Initial array.
+     *
+     * @return array Same array, but with all lowercase top level keys.
+     */
+    public function arrayKeysToLowercase($array)
+    {
+        $keys = array_keys($array);
+        $keys = array_map('strtolower', $keys);
+        return array_combine($keys, $array);
+    }
+
+
+    /**
      * Returns the name(s) of the interface(s) that the specified class implements.
      *
      * Returns FALSE on error or if there are no implemented interface names.

--- a/Sniff.php
+++ b/Sniff.php
@@ -144,18 +144,18 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Add a PHPCS message to the output stack as either a warning or an error.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile  The file the message applies to.
-     * @param string               $message    The message.
-     * @param int                  $stackPtr   The position of the class token
-     *                                         the message relates to.
-     * @param bool                 $isError    Whether to report the message as an
-     *                                         'error' or 'warning'.
-     *                                         Defaults to true (error).
-     * @param string               $code       The error code for the message.
-     *                                         Defaults to 'Found'.
-     * @param array                $data       Optional input for the data replacements.
+     * @param PHP_CodeSniffer_File $phpcsFile The file the message applies to.
+     * @param string               $message   The message.
+     * @param int                  $stackPtr  The position of the token
+     *                                        the message relates to.
+     * @param bool                 $isError   Whether to report the message as an
+     *                                        'error' or 'warning'.
+     *                                        Defaults to true (error).
+     * @param string               $code      The error code for the message.
+     *                                        Defaults to 'Found'.
+     * @param array                $data      Optional input for the data replacements.
      *
-     * @return void.
+     * @return void
      */
     public function addMessage($phpcsFile, $message, $stackPtr, $isError, $code = 'Found', $data = array())
     {

--- a/Sniff.php
+++ b/Sniff.php
@@ -128,6 +128,32 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
 
     /**
+     * Add a PHPCS message to the output stack as either a warning or an error.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile  The file the message applies to.
+     * @param string               $message    The message.
+     * @param int                  $stackPtr   The position of the class token
+     *                                         the message relates to.
+     * @param bool                 $isError    Whether to report the message as an
+     *                                         'error' or 'warning'.
+     *                                         Defaults to true (error).
+     * @param string               $code       The error code for the message.
+     *                                         Defaults to 'Found'.
+     * @param array                $data       Optional input for the data replacements.
+     *
+     * @return void.
+     */
+    public function addMessage($phpcsFile, $message, $stackPtr, $isError, $code = 'Found', $data = array())
+    {
+        if ($isError === true) {
+            $phpcsFile->addError($message, $stackPtr, $code, $data);
+        } else {
+            $phpcsFile->addWarning($message, $stackPtr, $code, $data);
+        }
+    }
+
+
+    /**
      * Strip quotes surrounding an arbitrary string.
      *
      * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING.

--- a/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -63,8 +63,8 @@ class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPComp
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
-        if ($function !== 'define') {
+        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        if ($functionLc !== 'define') {
             return;
         }
 

--- a/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -75,7 +75,11 @@ class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPComp
 
         $array = $phpcsFile->findNext(array(T_ARRAY, T_OPEN_SHORT_ARRAY), $secondParam['start'], ($secondParam['end'] + 1));
         if ($array !== false) {
-            $phpcsFile->addError('Constant arrays using define are not allowed in PHP 5.6 or earlier', $array);
+            $phpcsFile->addError(
+                'Constant arrays using define are not allowed in PHP 5.6 or earlier',
+                $array,
+                'Found'
+            );
         }
     }
 }

--- a/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
+++ b/Sniffs/PHP/DefaultTimezoneRequiredSniff.php
@@ -48,8 +48,11 @@ class PHPCompatibility_Sniffs_PHP_DefaultTimeZoneRequiredSniff extends PHPCompat
         if ($this->supportsAbove('5.4')) {
             $ini_value = ini_get('date.timezone');
             if (is_string($ini_value) === false || $ini_value === '') {
-                $error = 'Default timezone is required since PHP 5.4';
-                $phpcsFile->addError($error, $stackPtr);
+                $phpcsFile->addError(
+                    'Default timezone is required since PHP 5.4',
+                    $stackPtr,
+                    'Missing'
+                );
             }
         }
 

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -16,7 +16,8 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff
+    extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
     /**
      * A list of deprecated and removed functions with their alternatives.
@@ -808,89 +809,37 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
             return;
         }
 
-        $errorInfo = $this->getErrorInfo($functionLc);
-
-        if ($errorInfo['deprecated'] !== '' || $errorInfo['removed'] !== '') {
-            $this->addError($phpcsFile, $stackPtr, $function, $errorInfo);
-        }
+        $itemInfo = array(
+            'name'   => $function,
+            'nameLc' => $functionLc,
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $functionLc The lowercase name of the function.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($functionLc)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'deprecated'  => '',
-            'removed'     => '',
-            'alternative' => '',
-            'error'       => false,
-        );
-
-        foreach ($this->removedFunctions[$functionLc] as $version => $removed) {
-            if ($version !== 'alternative' && $this->supportsAbove($version)) {
-                if ($removed === true && $errorInfo['removed'] === '') {
-                    $errorInfo['removed'] = $version;
-                    $errorInfo['error']   = true;
-                } elseif($errorInfo['deprecated'] === '') {
-                    $errorInfo['deprecated'] = $version;
-                }
-            }
-        }
-
-        if (isset($this->removedFunctions[$functionLc]['alternative'])) {
-            $errorInfo['alternative'] = $this->removedFunctions[$functionLc]['alternative'];
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->removedFunctions[$itemInfo['nameLc']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
-     * @param array                $errorInfo Array with details about the versions
-     *                                        in which the function was deprecated
-     *                                        and/or removed.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $function, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'Function %s() is ';
-        $errorCode = $this->stringToErrorCode($function) . 'Found';
-        $data      = array($function);
+        return 'Function %s() is ';
+    }
 
-        if($errorInfo['deprecated'] !== '') {
-            $error .= 'deprecated since PHP %s and ';
-            $data[] = $errorInfo['deprecated'];
-        }
-        if($errorInfo['removed'] !== '') {
-            $error .= 'removed since PHP %s and ';
-            $data[] = $errorInfo['removed'];
-        }
-
-        // Remove the last 'and' from the message.
-        $error = substr($error, 0, strlen($error) - 5);
-
-        if ($errorInfo['alternative'] !== '') {
-            $error .= '; use %s instead';
-            $data[] = $errorInfo['alternative'];
-        }
-
-        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -757,14 +757,6 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                                         ),
                                     );
 
-    /**
-     * List of just the function names.
-     *
-     * Will be set automatically in the register() method.
-     *
-     * @var array
-     */
-    protected $removedFunctionNames = array();
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -773,9 +765,8 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what removed functions
-        // they want to check for, so now we can cache out the list.
-        $this->removedFunctionNames = array_keys($this->removedFunctions);
+        // Handle case-insensitivity of function names.
+        $this->removedFunctions = $this->arrayKeysToLowercase($this->removedFunctions);
 
         return array(T_STRING);
 
@@ -810,13 +801,14 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
 
-        if (in_array($function, $this->removedFunctionNames) === false) {
+        if (isset($this->removedFunctions[$functionLc]) === false) {
             return;
         }
 
-        $this->addError($phpcsFile, $stackPtr, $function);
+        $this->addError($phpcsFile, $stackPtr, $functionLc);
 
     }//end process()
 

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -16,8 +16,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
     /**
      * A list of deprecated and removed functions with their alternatives.

--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -860,11 +860,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                 $error .= '; use ' . $this->removedFunctions[$function]['alternative'] . ' instead';
             }
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError);
         }
 
     }//end addError()

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -25,8 +25,8 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
     /**
      * A list of deprecated INI directives.
      *
-     * version => false means the directive was deprecated in that version.
-     * version => true means it was removed in that version.
+     * The array lists : version number with false (deprecated) and true (removed).
+     * If's sufficient to list the first version where the ini directive was deprecated/removed.
      *
      * @var array(string)
      */

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -240,12 +240,12 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
-        if (isset($this->iniFunctions[$function]) === false) {
+        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        if (isset($this->iniFunctions[$functionLc]) === false) {
             return;
         }
 
-        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$function]);
+        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$functionLc]);
         if ($iniToken === false) {
             return;
         }
@@ -262,7 +262,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
             if ($version !== 'alternative') {
                 if ($this->supportsAbove($version)) {
                     if ($removed === true) {
-                        $isError = ($function !== 'ini_get') ? true : false;
+                        $isError = ($functionLc !== 'ini_get') ? true : false;
                         $error .= " removed";
                     } else {
                         $isError = false;

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -280,11 +280,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
                 $error .= " Use '" . $this->deprecatedIniDirectives[$filteredToken]['alternative'] . "' instead.";
             }
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $iniToken['end']);
-            } else {
-                $phpcsFile->addWarning($error, $iniToken['end']);
-            }
+            $this->addMessage($phpcsFile, $error, $iniToken['end'], $isError);
         }
 
     }//end process()

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -20,8 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
     /**
      * A list of deprecated INI directives.

--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -241,11 +241,11 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         }
 
         $function = strtolower($tokens[$stackPtr]['content']);
-        if ($function !== 'ini_get' && $function !== 'ini_set') {
+        if (isset($this->iniFunctions[$function]) === false) {
             return;
         }
 
-        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, 1);
+        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$function]);
         if ($iniToken === false) {
             return;
         }

--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -50,13 +50,15 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompati
         if ($this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
             if ($tokens[$stackPtr - 1]['type'] == 'T_BITWISE_AND' || $tokens[$stackPtr - 2]['type'] == 'T_BITWISE_AND') {
+                $error   = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
+                $isError = false;
+
                 if ($this->supportsAbove('7.0')) {
-                    $error = 'Assigning the return value of new by reference is deprecated in PHP 5.3 and forbidden in PHP 7.0';
-                    $phpcsFile->addError($error, $stackPtr);
-                } else {
-                    $error = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
-                    $phpcsFile->addWarning($error, $stackPtr);
+                    $error  .= ' and forbidden in PHP 7.0';
+                    $isError = true;
                 }
+
+                $this->addMessage($phpcsFile, $error, $stackPtr, $isError);
             }
         }
 

--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -50,15 +50,17 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompati
         if ($this->supportsAbove('5.3')) {
             $tokens = $phpcsFile->getTokens();
             if ($tokens[$stackPtr - 1]['type'] == 'T_BITWISE_AND' || $tokens[$stackPtr - 2]['type'] == 'T_BITWISE_AND') {
-                $error   = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
-                $isError = false;
+                $error     = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
+                $isError   = false;
+                $errorCode = 'Deprecated';
 
                 if ($this->supportsAbove('7.0')) {
-                    $error  .= ' and forbidden in PHP 7.0';
-                    $isError = true;
+                    $error    .= ' and forbidden in PHP 7.0';
+                    $isError   = true;
+                    $errorCode = 'Forbidden';
                 }
 
-                $this->addMessage($phpcsFile, $error, $stackPtr, $isError);
+                $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
             }
         }
 

--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -54,7 +54,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompati
                 $isError   = false;
                 $errorCode = 'Deprecated';
 
-                if ($this->supportsAbove('7.0')) {
+                if ($this->supportsAbove('7.0') === true) {
                     $error    .= ' and forbidden in PHP 7.0';
                     $isError   = true;
                     $errorCode = 'Forbidden';

--- a/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -147,7 +147,10 @@ class PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff extends PHPCompatibility
      */
     protected function addError($phpcsFile, $stackPtr)
     {
-        $error = 'Only variables can be passed to empty() prior to PHP 5.5.';
-        $phpcsFile->addError($error, $stackPtr, 'Found');
+        $phpcsFile->addError(
+            'Only variables can be passed to empty() prior to PHP 5.5.',
+            $stackPtr,
+            'Found'
+        );
     }
 }

--- a/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -90,17 +90,18 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoopSniff extends
         }
 
         // If we're still here, no valid loop structure container has been found, so throw an error.
-        $error   = "Using '%s' outside of a loop or switch structure is invalid";
-        $isError = false;
-        $data    = array(
-            $token['content'],
-        );
+        $error     = "Using '%s' outside of a loop or switch structure is invalid";
+        $isError   = false;
+        $errorCode = 'Found';
+        $data      = array($token['content']);
+
         if ($this->supportsAbove('7.0')) {
-            $isError = true;
-            $error  .= ' and will throw a fatal error since PHP 7.0';
+            $error    .= ' and will throw a fatal error since PHP 7.0';
+            $isError   = true;
+            $errorCode = 'FatalError';
         }
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
 
     }//end process()
 

--- a/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -100,11 +100,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoopSniff extends
             $error  .= ' and will throw a fatal error since PHP 7.0';
         }
 
-        if ($isError === true) {
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-        } else {
-            $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
-        }
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
 
     }//end process()
 

--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -87,8 +87,9 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
 
         if ($errorType !== '') {
             $error     = 'Using %s on break or continue is forbidden since PHP 5.4';
-            $errorCode = $errorType . 'Found';
+            $errorCode = $errorType.'Found';
             $data      = array($this->errorTypes[$errorType]);
+
             $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
 

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -117,11 +117,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
                     $errorCode = 'NotAllowed';
                 }
 
-                if ($isError === true) {
-                    $phpcsFile->addError($error, $parameter['start'], $errorCode);
-                } else {
-                    $phpcsFile->addWarning($error, $parameter['start'], $errorCode);
-                }
+                $this->addMessage($phpcsFile, $error, $parameter['start'], $isError, $errorCode);
             }
         }
     }//end process()

--- a/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -81,8 +81,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPC
             }
 
             if ($error === true) {
-                $error = 'Empty list() assignments are not allowed since PHP 7.0';
-                $phpcsFile->addError($error, $stackPtr);
+                $phpcsFile->addError(
+                    'Empty list() assignments are not allowed since PHP 7.0',
+                    $stackPtr,
+                    'Found'
+                );
             }
         }
     }

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -69,7 +69,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
         }
 
         if (count($paramNames) != count(array_unique($paramNames))) {
-            $phpcsFile->addError('Functions can not have multiple parameters with the same name since PHP 7.0', $stackPtr);
+            $phpcsFile->addError(
+                'Functions can not have multiple parameters with the same name since PHP 7.0',
+                $stackPtr,
+                'Found'
+            );
         }
 
     }//end process()

--- a/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
+++ b/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
@@ -50,8 +50,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff extends P
             $variable = $phpcsFile->findNext(T_VARIABLE, $stackPtr, $stackPtr + 4, false);
 
             if (isset($tokens[$variable - 1]) && $tokens[$variable - 1]['type'] == 'T_DOLLAR') {
-                $error = 'Global with variable variables is not allowed since PHP 7.0';
-                $phpcsFile->addError($error, $stackPtr);
+                $phpcsFile->addError(
+                    'Global with variable variables is not allowed since PHP 7.0',
+                    $stackPtr,
+                    'Found'
+                );
             }
         }
     }

--- a/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -170,7 +170,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
         $version = $this->forbiddenNames[$nameLc];
         if ($this->supportsAbove($version) === true) {
             $error     = "'%s' is a reserved keyword as of PHP version %s and cannot be used to name a class, interface or trait or as part of a namespace (%s)";
-            $errorCode = $this->stringToErrorCode($nameLc) . 'Found';
+            $errorCode = $this->stringToErrorCode($nameLc).'Found';
             $data      = array(
                 $nameLc,
                 $version,

--- a/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -141,23 +141,23 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
 
             $nextNonEmptyCode = $tokens[$nextNonEmpty]['code'];
 
-			if ($nextNonEmptyCode !== T_STRING && isset($this->forbiddenTokens[$nextNonEmptyCode]) === true) {
+            if ($nextNonEmptyCode !== T_STRING && isset($this->forbiddenTokens[$nextNonEmptyCode]) === true) {
                 $name   = $tokens[$nextNonEmpty]['content'];
                 $nameLc = strtolower($tokens[$nextNonEmpty]['content']);
             } else if ($nextNonEmptyCode === T_STRING) {
-				$endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET), ($stackPtr + 1));
+                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET), ($stackPtr + 1));
 
-				do {
-					$nextNonEmptyLc = strtolower($tokens[$nextNonEmpty]['content']);
+                do {
+                    $nextNonEmptyLc = strtolower($tokens[$nextNonEmpty]['content']);
 
-	                if (isset($this->forbiddenNames[$nextNonEmptyLc]) === true) {
-	                    $name   = $tokens[$nextNonEmpty]['content'];
-	                    $nameLc = $nextNonEmptyLc;
-	                    break;
-	                }
-	                
-	                $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
-				} while ($nextNonEmpty !== false);
+                    if (isset($this->forbiddenNames[$nextNonEmptyLc]) === true) {
+                        $name   = $tokens[$nextNonEmpty]['content'];
+                        $nameLc = $nextNonEmptyLc;
+                        break;
+                    }
+
+                    $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
+                } while ($nextNonEmpty !== false);
             }
             unset($nextNonEmptyCode, $nextNonEmptyLc, $endOfStatement);
         }
@@ -169,14 +169,15 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
         // Still here, so this is one of the reserved words.
         $version = $this->forbiddenNames[$nameLc];
         if ($this->supportsAbove($version) === true) {
-            $error = "'%s' is a reserved keyword as of PHP version %s and cannot be used to name a class, interface or trait or as part of a namespace (%s)";
-            $data  = array(
+            $error     = "'%s' is a reserved keyword as of PHP version %s and cannot be used to name a class, interface or trait or as part of a namespace (%s)";
+            $errorCode = $this->stringToErrorCode($nameLc) . 'Found';
+            $data      = array(
                 $nameLc,
                 $version,
                 $tokens[$stackPtr]['type'],
             );
 
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
     }//end process()
 

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -139,7 +139,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends 
 
         if ($this->supportsAbove($version)) {
             $error     = "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)";
-            $errorCode = $this->stringToErrorCode($tokenContentLc) . 'Found';
+            $errorCode = $this->stringToErrorCode($tokenContentLc).'Found';
             $data      = array(
                 $tokenContentLc,
                 $version,

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -138,13 +138,15 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends 
         }
 
         if ($this->supportsAbove($version)) {
-            $error = "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)";
-            $data = array(
+            $error     = "'%s' is a reserved keyword introduced in PHP version %s and cannot be invoked as a function (%s)";
+            $errorCode = $this->stringToErrorCode($tokenContentLc) . 'Found';
+            $data      = array(
                 $tokenContentLc,
                 $version,
                 $tokens[$stackPtr]['type'],
             );
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
     }//end process()
 

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -234,12 +234,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
         }
 
         if ($this->supportsAbove($this->invalidNames[$nextContentLc])) {
-            $error = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
             $data  = array(
                 $tokens[$nextNonEmpty]['content'],
                 $this->invalidNames[$nextContentLc],
             );
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            $this->addError($phpcsFile, $stackPtr, $tokens[$nextNonEmpty]['content'], $data);
         }
 
     }//end processNonString()
@@ -281,14 +280,32 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
         $defineName = $this->stripQuotes($defineName);
 
         if (isset($this->invalidNames[$defineName]) && $this->supportsAbove($this->invalidNames[$defineName])) {
-            $error = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since PHP version %s)";
             $data  = array(
                 $defineName,
                 $this->invalidNames[$defineName],
             );
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+            $this->addError($phpcsFile, $stackPtr, $defineName, $data);
         }
     }//end processString()
+
+
+    /**
+     * Add the error message.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     * @param string               $content   The token content found.
+     * @param array                $data      The data to pass into the error message.
+     *
+     * @return void
+     */
+    protected function addError($phpcsFile, $stackPtr, $content, $data)
+    {
+        $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
+        $errorCode = $this->stringToErrorCode($content) . 'Found';
+        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+    }
 
 
     /**

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -276,15 +276,15 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
             return;
         }
 
-        $defineName = strtolower($firstParam['raw']);
-        $defineName = $this->stripQuotes($defineName);
+        $defineName   = $this->stripQuotes($firstParam['raw']);
+        $defineNameLc = strtolower($defineName);
 
-        if (isset($this->invalidNames[$defineName]) && $this->supportsAbove($this->invalidNames[$defineName])) {
+        if (isset($this->invalidNames[$defineNameLc]) && $this->supportsAbove($this->invalidNames[$defineNameLc])) {
             $data  = array(
                 $defineName,
-                $this->invalidNames[$defineName],
+                $this->invalidNames[$defineNameLc],
             );
-            $this->addError($phpcsFile, $stackPtr, $defineName, $data);
+            $this->addError($phpcsFile, $stackPtr, $defineNameLc, $data);
         }
     }//end processString()
 

--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -303,7 +303,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
     protected function addError($phpcsFile, $stackPtr, $content, $data)
     {
         $error     = "Function name, class name, namespace name or constant name can not be reserved keyword '%s' (since version %s)";
-        $errorCode = $this->stringToErrorCode($content) . 'Found';
+        $errorCode = $this->stringToErrorCode($content).'Found';
         $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
     }
 

--- a/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -57,8 +57,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff extends PHPComp
             return;
         }
 
-        $error = 'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0';
-        $phpcsFile->addError($error, $hasMinusSign);
+        $phpcsFile->addError(
+            'Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0',
+            $hasMinusSign,
+            'Found'
+        );
 
     }//end process()
 

--- a/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -65,7 +65,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff 
         }
 
         if ($defaultCount > 1) {
-            $phpcsFile->addError('Switch statements can not have multiple default blocks since PHP 7.0', $stackPtr);
+            $phpcsFile->addError(
+                'Switch statements can not have multiple default blocks since PHP 7.0',
+                $stackPtr,
+                'Found'
+            );
         }
     }//end process()
 

--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -40,10 +40,8 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
      */
     public function register()
     {
-        // Handle case-insensitivity of class names.
-        $keys = array_keys( $this->internalInterfaces );
-        $keys = array_map( 'strtolower', $keys );
-        $this->internalInterfaces = array_combine( $keys, $this->internalInterfaces );
+        // Handle case-insensitivity of interface names.
+        $this->internalInterfaces = $this->arrayKeysToLowercase($this->internalInterfaces);
 
         return array(T_CLASS);
 

--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -66,13 +66,13 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
         }
 
         foreach ($interfaces as $interface) {
-            $lcInterface = strtolower($interface);
-            if (isset($this->internalInterfaces[$lcInterface]) === true) {
+            $interfaceLc = strtolower($interface);
+            if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
-                $errorCode = $this->stringToErrorCode($lcInterface) . 'Found';
+                $errorCode = $this->stringToErrorCode($interfaceLc) . 'Found';
                 $data      = array(
                     $interface,
-                    $this->internalInterfaces[$lcInterface],
+                    $this->internalInterfaces[$interfaceLc],
                 );
 
                 $phpcsFile->addError($error, $stackPtr, $errorCode, $data);

--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -70,12 +70,14 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
         foreach ($interfaces as $interface) {
             $lcInterface = strtolower($interface);
             if (isset($this->internalInterfaces[$lcInterface]) === true) {
-                $error = 'The interface %s %s';
-                $data  = array(
+                $error     = 'The interface %s %s';
+                $errorCode = $this->stringToErrorCode($lcInterface) . 'Found';
+                $data      = array(
                     $interface,
                     $this->internalInterfaces[$lcInterface],
                 );
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
             }
         }
 

--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -69,7 +69,7 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
             $interfaceLc = strtolower($interface);
             if (isset($this->internalInterfaces[$interfaceLc]) === true) {
                 $error     = 'The interface %s %s';
-                $errorCode = $this->stringToErrorCode($interfaceLc) . 'Found';
+                $errorCode = $this->stringToErrorCode($interfaceLc).'Found';
                 $data      = array(
                     $interface,
                     $this->internalInterfaces[$interfaceLc],
@@ -80,5 +80,6 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
         }
 
     }//end process()
+
 
 }//end class

--- a/Sniffs/PHP/LateStaticBindingSniff.php
+++ b/Sniffs/PHP/LateStaticBindingSniff.php
@@ -52,13 +52,19 @@ class PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff extends PHPCompatibilit
         $inClass = $this->inClassScope($phpcsFile, $stackPtr, false);
 
         if ($inClass === true && $this->supportsBelow('5.2') === true) {
-            $error = 'Late static binding is not supported in PHP 5.2 or earlier.';
-            $phpcsFile->addError($error, $stackPtr, 'Found');
+            $phpcsFile->addError(
+                'Late static binding is not supported in PHP 5.2 or earlier.',
+                $stackPtr,
+                'Found'
+            );
         }
 
         if ($inClass === false) {
-            $error = 'Late static binding is not supported outside of class scope.';
-            $phpcsFile->addError($error, $stackPtr, 'OutsideClassScope');
+            $phpcsFile->addError(
+                'Late static binding is not supported outside of class scope.',
+                $stackPtr,
+                'OutsideClassScope'
+            );
         }
 
     }//end process()

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -107,10 +107,6 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
             $tokens[$stackPtr]['content']
         );
 
-        if ($isError === true) {
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-        } else {
-            $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
-        }
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
     }
 }

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -64,10 +64,11 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
             return;
         }
 
-        $tokens = $phpcsFile->getTokens();
+        $tokens  = $phpcsFile->getTokens();
+        $varName = substr($tokens[$stackPtr]['content'], 1);
 
         // Check if the variable name is in our blacklist.
-        if (in_array(substr($tokens[$stackPtr]['content'], 1), $this->deprecated, true) === false) {
+        if (in_array($varName, $this->deprecated, true) === false) {
             return;
         }
 
@@ -100,13 +101,14 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
         }
 
         // Still here, so throw an error/warning.
-        $error   = "The use of long predefined variables has been deprecated in 5.3%s; Found '%s'";
-        $isError = $this->supportsAbove('5.4');
-        $data    = array(
+        $error     = "The use of long predefined variables has been deprecated in 5.3%s; Found '%s'";
+        $isError   = $this->supportsAbove('5.4');
+        $errorCode = $this->stringToErrorCode($varName) . 'Found';
+        $data      = array(
             ($isError ? ' and removed in 5.4' : ''),
             $tokens[$stackPtr]['content']
         );
 
-        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
     }
 }

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -101,11 +101,11 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
         }
 
         // Still here, so throw an error/warning.
-        $error     = "The use of long predefined variables has been deprecated in 5.3%s; Found '%s'";
+        $error     = "The use of long predefined variables has been deprecated in PHP 5.3%s; Found '%s'";
         $isError   = $this->supportsAbove('5.4');
         $errorCode = $this->stringToErrorCode($varName) . 'Found';
         $data      = array(
-            ($isError ? ' and removed in 5.4' : ''),
+            ($isError ? ' and removed in PHP 5.4' : ''),
             $tokens[$stackPtr]['content']
         );
 

--- a/Sniffs/PHP/LongArraysSniff.php
+++ b/Sniffs/PHP/LongArraysSniff.php
@@ -103,10 +103,10 @@ class PHPCompatibility_Sniffs_PHP_LongArraysSniff extends PHPCompatibility_Sniff
         // Still here, so throw an error/warning.
         $error     = "The use of long predefined variables has been deprecated in PHP 5.3%s; Found '%s'";
         $isError   = $this->supportsAbove('5.4');
-        $errorCode = $this->stringToErrorCode($varName) . 'Found';
+        $errorCode = $this->stringToErrorCode($varName).'Found';
         $data      = array(
-            ($isError ? ' and removed in PHP 5.4' : ''),
-            $tokens[$stackPtr]['content']
+            (($isError === true) ? ' and removed in PHP 5.4' : ''),
+            $tokens[$stackPtr]['content'],
         );
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);

--- a/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -99,7 +99,7 @@ class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompa
                 $error .= ' Use mb_ereg_replace_callback() instead (PHP 5.4.1+).';
             }
 
-            $phpcsFile->addWarning($error, $stackPtr, 'Found');
+            $phpcsFile->addWarning($error, $stackPtr, 'Deprecated');
         }
 
     }//end process()

--- a/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -56,7 +56,11 @@ class PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff extends PHPCompatibil
             return;
         }
 
-        $phpcsFile->addError('Anonymous classes are not supported in PHP 5.6 or earlier', $stackPtr);
+        $phpcsFile->addError(
+            'Anonymous classes are not supported in PHP 5.6 or earlier',
+            $stackPtr,
+            'Found'
+        );
 
     }//end process()
 

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -19,7 +19,8 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewClassesSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -244,63 +245,37 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
             return;
         }
 
-        $errorInfo = $this->getErrorInfo($classNameLc);
-
-        if ($errorInfo['not_in_version'] !== '') {
-            $this->addError($phpcsFile, $stackPtr, $className, $errorInfo);
-        }
-
+        $itemInfo = array(
+            'name'   => $className,
+            'nameLc' => $classNameLc,
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $classNameLc The lowercase name of the class.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($classNameLc)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newClasses[$classNameLc] as $version => $present) {
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newClasses[$itemInfo['nameLc']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the class token
-     *                                        in the token array.
-     * @param string               $className The name of the class.
-     * @param array                $errorInfo Array with details about when the
-     *                                        class was not (yet) available.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $className, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'The built-in class %s is not present in PHP version %s or earlier';
-        $errorCode = $this->stringToErrorCode($className) . 'Found';
-        $data      = array(
-            $className,
-            $errorInfo['not_in_version'],
-        );
+        return 'The built-in class ' . parent::getErrorMsgTemplate();
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -264,13 +264,11 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
     protected function addError($phpcsFile, $stackPtr, $className)
     {
         $error       = '';
-        $isError     = false;
         $classNameLc = strtolower($className);
 
         foreach ($this->newClasses[$classNameLc] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -278,11 +276,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
         if (strlen($error) > 0) {
             $error = 'The built-in class ' . $className . ' is ' . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -19,8 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewClassesSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -274,7 +273,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff
      */
     protected function getErrorMsgTemplate()
     {
-        return 'The built-in class ' . parent::getErrorMsgTemplate();
+        return 'The built-in class '.parent::getErrorMsgTemplate();
     }
 
 

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -194,9 +194,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Sniff
     public function register()
     {
         // Handle case-insensitivity of class names.
-        $keys = array_keys( $this->newClasses );
-        $keys = array_map( 'strtolower', $keys );
-        $this->newClasses = array_combine( $keys, $this->newClasses );
+        $this->newClasses = $this->arrayKeysToLowercase($this->newClasses);
 
         return array(
                 T_NEW,

--- a/Sniffs/PHP/NewClosureSniff.php
+++ b/Sniffs/PHP/NewClosureSniff.php
@@ -45,7 +45,11 @@ class PHPCompatibility_Sniffs_PHP_NewClosureSniff extends PHPCompatibility_Sniff
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2')) {
-            $phpcsFile->addError('Closures / anonymous functions are not available in PHP 5.2 or earlier', $stackPtr);
+            $phpcsFile->addError(
+                'Closures / anonymous functions are not available in PHP 5.2 or earlier',
+                $stackPtr,
+                'Found'
+            );
         }
     }//end process()
 

--- a/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -59,8 +59,8 @@ class PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff extends PHPCompatibili
         if ($this->tokenHasScope($phpcsFile, $stackPtr, array(T_CLASS, T_INTERFACE)) === true && $this->supportsBelow('7.0') === true) {
             $error = 'Visibility indicators for class constants are not supported in PHP 7.0 or earlier. Found "%s const"';
             $data  = array($tokens[$prevToken]['content']);
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
 
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
         }
 
     }//end process()

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -141,13 +141,11 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
      */
     protected function maybeAddError($phpcsFile, $stackPtr, $directive)
     {
-        $isError            = false;
         $notInVersion       = '';
         $conditionalVersion = '';
         foreach ($this->newDirectives[$directive] as $version => $present) {
             if (strpos($version, 'valid_') === false && $this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError      = true;
                     $notInVersion = $version;
                 }
                 else if (is_string($present)) {
@@ -156,8 +154,9 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
                 }
             }
         }
+
         if ($notInVersion !== '' || $conditionalVersion !== '') {
-            if ($isError === true && $notInVersion !== '') {
+            if ($notInVersion !== '') {
                 $error     = 'Directive %s is not present in PHP version %s or earlier';
                 $errorCode = $directive . 'Found';
                 $data      = array(

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -280,7 +279,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff
 
         if ($isError === true) {
             $error     = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
-            $errorCode = $this->stringToErrorCode($directive) . 'InvalidValueFound';
+            $errorCode = $this->stringToErrorCode($directive).'InvalidValueFound';
             $data      = array(
                 $directive,
                 $value,
@@ -334,5 +333,6 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff
             return false;
         }
     }
+
 
 }//end class

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -111,6 +111,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
                 implode(', ', array_keys($this->newDirectives)),
                 $directiveContent,
             );
+
             $phpcsFile->addError($error, $stackPtr, 'InvalidDirectiveFound', $data);
         }
         else {
@@ -158,7 +159,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
         if ($notInVersion !== '' || $conditionalVersion !== '') {
             if ($notInVersion !== '') {
                 $error     = 'Directive %s is not present in PHP version %s or earlier';
-                $errorCode = $directive . 'Found';
+                $errorCode = $this->stringToErrorCode($directive) . 'Found';
                 $data      = array(
                     $directive,
                     $notInVersion,
@@ -168,7 +169,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
             }
             else if($conditionalVersion !== '') {
                 $error     = 'Directive %s is present in PHP version %s but will be disregarded unless PHP is compiled with %s';
-                $errorCode = $directive . 'Found';
+                $errorCode = $this->stringToErrorCode($directive) . 'WithConditionFound';
                 $data      = array(
                     $directive,
                     $conditionalVersion,
@@ -215,12 +216,14 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
         }
 
         if ($isError === true) {
-            $error = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
-            $data  = array(
+            $error     = 'The execution directive %s does not seem to have a valid value. Please review. Found: %s';
+            $errorCode = $this->stringToErrorCode($directive) . 'InvalidValueFound';
+            $data      = array(
                 $directive,
                 $value,
             );
-            $phpcsFile->addWarning($error, $stackPtr, 'InvalidDirectiveValueFound', $data);
+
+            $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
         }
     }// addErrorOnInvalidValue()
 

--- a/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -75,7 +75,11 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
         $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
         $nextNonEmpty     = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET') {
-            $phpcsFile->addError('Function array dereferencing is not present in PHP version 5.3 or earlier', $nextNonEmpty);
+            $phpcsFile->addError(
+                'Function array dereferencing is not present in PHP version 5.3 or earlier',
+                $nextNonEmpty,
+                'Found'
+            );
         }
 
     }//end process()

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -731,22 +731,14 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
 
 
     /**
-     *
-     * @var array
-     */
-    private $newFunctionParametersNames;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what functions
-        // they want to check for, so now we can cache out the list.
-        $this->newFunctionParametersNames = array_keys($this->newFunctionParameters);
+        // Handle case-insensitivity of function names.
+        $this->newFunctionParameters = $this->arrayKeysToLowercase($this->newFunctionParameters);
 
         return array(T_STRING);
     }//end register()
@@ -779,7 +771,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
 
         $function = strtolower($tokens[$stackPtr]['content']);
 
-        if (in_array($function, $this->newFunctionParametersNames) === false) {
+        if (isset($this->newFunctionParameters[$function]) === false) {
             return;
         }
 

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -769,9 +769,10 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
 
-        if (isset($this->newFunctionParameters[$function]) === false) {
+        if (isset($this->newFunctionParameters[$functionLc]) === false) {
             return;
         }
 
@@ -784,7 +785,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
-        foreach($this->newFunctionParameters[$function] as $offset => $parameterDetails) {
+        foreach($this->newFunctionParameters[$functionLc] as $offset => $parameterDetails) {
             if ($offset <= $parameterOffsetFound) {
                 $this->addError($phpcsFile, $openParenthesis, $function, $offset);
             }
@@ -806,9 +807,10 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
      */
     protected function addError($phpcsFile, $stackPtr, $function, $parameterLocation)
     {
+        $functionLc = strtolower($function);
         $error = '';
 
-        foreach ($this->newFunctionParameters[$function][$parameterLocation] as $version => $present) {
+        foreach ($this->newFunctionParameters[$functionLc][$parameterLocation] as $version => $present) {
             if ($version != 'name' && $present === false && $this->supportsBelow($version)) {
                 $error .= 'in PHP version ' . $version . ' or earlier';
                 break;
@@ -816,7 +818,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         }
 
         if (strlen($error) > 0) {
-            $error = 'The function ' . $function . ' does not have a parameter "' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . '" ' . $error;
+            $error = 'The function ' . $function . ' does not have a parameter "' . $this->newFunctionParameters[$functionLc][$parameterLocation]['name'] . '" ' . $error;
 
             $phpcsFile->addError($error, $stackPtr);
         }

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new functions, not present in older versions.

--- a/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -816,10 +816,8 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
     {
         $error = '';
 
-        $isError = false;
         foreach ($this->newFunctionParameters[$function][$parameterLocation] as $version => $present) {
             if ($version != 'name' && $present === false && $this->supportsBelow($version)) {
-                $isError = true;
                 $error .= 'in PHP version ' . $version . ' or earlier';
                 break;
             }
@@ -828,11 +826,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatib
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' does not have a parameter "' . $this->newFunctionParameters[$function][$parameterLocation]['name'] . '" ' . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1243,24 +1243,14 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
 
 
     /**
-     *
-     * @var array
-     */
-    private $newFunctionNames;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what new functions
-        // they want to check for, so now we can cache out the list.
-        $this->newFunctionNames = array_keys($this->newFunctions);
-        $this->newFunctionNames = array_map('strtolower', $this->newFunctionNames);
-        $this->newFunctions     = array_combine($this->newFunctionNames, $this->newFunctions);
+        // Handle case-insensitivity of function names.
+        $this->newFunctions = $this->arrayKeysToLowercase($this->newFunctions);
 
         return array(T_STRING);
 
@@ -1296,13 +1286,14 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
 
-        if (in_array($function, $this->newFunctionNames) === false) {
+        if (isset($this->newFunctions[$functionLc]) === false) {
             return;
         }
 
-        $this->addError($phpcsFile, $stackPtr, $tokens[$stackPtr]['content']);
+        $this->addError($phpcsFile, $stackPtr, $function);
 
     }//end process()
 

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new functions, not present in older versions.

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -14,7 +14,8 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new functions, not present in older versions.
@@ -1293,63 +1294,37 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
             return;
         }
 
-        $errorInfo = $this->getErrorInfo($functionLc);
-
-        if ($errorInfo['not_in_version'] !== '') {
-            $this->addError($phpcsFile, $stackPtr, $function, $errorInfo);
-        }
-
+        $itemInfo = array(
+            'name'   => $function,
+            'nameLc' => $functionLc,
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $functionLc The lowercase name of the function.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($functionLc)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newFunctions[$functionLc] as $version => $present) {
-            if ($errorInfo['not_in_version'] === '' && $present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newFunctions[$itemInfo['nameLc']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function token
-     *                                        in the token array.
-     * @param string               $function  The name of the function.
-     * @param array                $errorInfo Array with details about when the
-     *                                        function was not (yet) available.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $function, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'The function %s is not present in PHP version %s or earlier';
-        $errorCode = $this->stringToErrorCode($function) . 'Found';
-        $data      = array(
-            $function,
-            $errorInfo['not_in_version'],
-        );
+        return 'The function %s() is not present in PHP version %s or earlier';
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1322,11 +1322,9 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
         $functionLc = strtolower($function);
         $error      = '';
 
-        $isError = false;
         foreach ($this->newFunctions[$functionLc] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -1334,11 +1332,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Sni
         if (strlen($error) > 0) {
             $error = 'The function ' . $function . ' is ' . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
+++ b/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
@@ -45,7 +45,11 @@ class PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff extends PHPCompat
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6')) {
-            $phpcsFile->addError('Group use declarations are not allowed in PHP 5.6 or earlier', $stackPtr);
+            $phpcsFile->addError(
+                'Group use declarations are not allowed in PHP 5.6 or earlier',
+                $stackPtr,
+                'Found'
+            );
         }
     }//end process()
 }//end class

--- a/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -14,7 +14,8 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new hash algorithms, not present in older versions.
@@ -106,63 +107,36 @@ class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff extends PHPCompatibilit
         }
 
         // Check if the algorithm used is new.
-        $errorInfo = $this->getErrorInfo($algo);
-
-        if ($errorInfo['not_in_version'] !== '') {
-            $this->addError($phpcsFile, $stackPtr, $algo, $errorInfo);
-        }
+        $itemInfo = array(
+            'name'   => $algo,
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $algorithm The name of the algorithm.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($algorithm)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newAlgorithms[$algorithm] as $version => $present) {
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newAlgorithms[$itemInfo['name']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $algorithm The name of the algorithm.
-     * @param array                $errorInfo Array with details about the versions
-     *                                        in which the algorithm was deprecated
-     *                                        and/or removed.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $algorithm, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'The %s hash algorithm is not present in PHP version %s or earlier ';
-        $errorCode = $this->stringToErrorCode($algorithm) . 'Found';
-        $data      = array(
-            $algorithm,
-            $errorInfo['not_in_version'],
-        );
+        return 'The %s hash algorithm is not present in PHP version %s or earlier';
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -155,7 +155,7 @@ class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff extends PHPCompatibilit
     protected function addError($phpcsFile, $stackPtr, $algorithm, $errorInfo)
     {
         $error     = 'The %s hash algorithm is not present in PHP version %s or earlier ';
-        $errorCode = $algorithm . 'Found';
+        $errorCode = $this->stringToErrorCode($algorithm) . 'Found';
         $data      = array(
             $algorithm,
             $errorInfo['not_in_version'],

--- a/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new hash algorithms, not present in older versions.

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -25,6 +25,9 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
     /**
      * A list of new INI directives
      *
+     * The array lists : version number with false (not present) or true (present).
+     * If's sufficient to list the first version where the ini directive appears.
+     *
      * @var array(string)
      */
     protected $newIniDirectives = array(

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -20,8 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
     /**
      * A list of new INI directives

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -530,11 +530,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
                 $data[] = $this->newIniDirectives[$filteredToken]['alternative'];
             }
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $iniToken['end'], 'Found', $data);
-            } else {
-                $phpcsFile->addWarning($error, $iniToken['end'], 'Found', $data);
-            }
+            $this->addMessage($phpcsFile, $error, $iniToken['end'], $isError, 'Found', $data);
         }
 
     }//end process()

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -500,11 +500,11 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
         }
 
         $function = strtolower($tokens[$stackPtr]['content']);
-        if ($function != 'ini_get' && $function != 'ini_set') {
+        if (isset($this->iniFunctions[$function]) === false) {
             return;
         }
 
-        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, 1);
+        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$function]);
         if ($iniToken === false) {
             return;
         }

--- a/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -499,12 +499,12 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
-        if (isset($this->iniFunctions[$function]) === false) {
+        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        if (isset($this->iniFunctions[$functionLc]) === false) {
             return;
         }
 
-        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$function]);
+        $iniToken = $this->getFunctionCallParameter($phpcsFile, $stackPtr, $this->iniFunctions[$functionLc]);
         if ($iniToken === false) {
             return;
         }
@@ -523,7 +523,7 @@ class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility
 
         if ($notInVersion !== '') {
             $error   = "INI directive '%s' is not present in PHP version %s or earlier";
-            $isError = ($function !== 'ini_get') ? true : false;
+            $isError = ($functionLc !== 'ini_get') ? true : false;
             $data    = array(
                 $filteredToken,
                 $notInVersion

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -171,11 +171,9 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
         $interfaceLc = strtolower($interface);
         $error       = '';
 
-        $isError = false;
         foreach ($this->newInterfaces[$interfaceLc] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -184,11 +182,7 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
         if (strlen($error) > 0) {
             $error = 'The built-in interface ' . $interface . ' is ' . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -141,13 +141,15 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
                     }
 
                     if (isset($this->unsupportedMethods[$lcInterface][$funcName]) === true) {
-                        $error = 'Classes that implement interface %s do not support the method %s(). See %s';
-                        $data  = array(
+                        $error     = 'Classes that implement interface %s do not support the method %s(). See %s';
+                        $errorCode = $this->stringToErrorCode($interface) . 'UnsupportedMethod';
+                        $data      = array(
                             $interface,
                             $funcName,
                             $this->unsupportedMethods[$lcInterface][$funcName],
                         );
-                        $phpcsFile->addError($error, $nextFunc, 'UnsupportedMethod', $data);
+
+                        $phpcsFile->addError($error, $nextFunc, $errorCode, $data);
                     }
                 }
             }

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -16,7 +16,8 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -123,13 +124,13 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
 
         foreach ($interfaces as $interface) {
             $interfaceLc = strtolower($interface);
+
             if (isset($this->newInterfaces[$interfaceLc]) === true) {
-
-                $errorInfo = $this->getErrorInfo($interfaceLc);
-
-                if ($errorInfo['not_in_version'] !== '') {
-                    $this->addError($phpcsFile, $stackPtr, $interface, $errorInfo);
-                }
+                $itemInfo = array(
+                    'name'   => $interface,
+                    'nameLc' => $interfaceLc,
+                );
+                $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
             }
 
             if ($checkMethods === true && isset($this->unsupportedMethods[$interfaceLc]) === true) {
@@ -160,52 +161,27 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $interfaceLc The lowercase name of the interface.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($interfaceLc)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newInterfaces[$interfaceLc] as $version => $present) {
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newInterfaces[$itemInfo['nameLc']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the class token
-     *                                        in the token array.
-     * @param string               $interface The name of the interface.
-     * @param array                $errorInfo Array with details about when the
-     *                                        interface was not (yet) available.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $interface, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'The built-in interface %s is not present in PHP version %s or earlier';
-        $errorCode = $this->stringToErrorCode($interface) . 'Found';
-        $data      = array(
-            $interface,
-            $errorInfo['not_in_version'],
-        );
+        return 'The built-in interface '.parent::getErrorMsgTemplate();
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -16,8 +16,7 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -144,7 +143,7 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff
 
                     if (isset($this->unsupportedMethods[$interfaceLc][$funcNameLc]) === true) {
                         $error     = 'Classes that implement interface %s do not support the method %s(). See %s';
-                        $errorCode = $this->stringToErrorCode($interface) . 'UnsupportedMethod';
+                        $errorCode = $this->stringToErrorCode($interface).'UnsupportedMethod';
                         $data      = array(
                             $interface,
                             $funcName,

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -122,26 +122,27 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
         }
 
         foreach ($interfaces as $interface) {
-            $lcInterface = strtolower($interface);
-            if (isset($this->newInterfaces[$lcInterface]) === true) {
+            $interfaceLc = strtolower($interface);
+            if (isset($this->newInterfaces[$interfaceLc]) === true) {
                 $this->addError($phpcsFile, $stackPtr, $interface);
             }
 
-            if ($checkMethods === true && isset($this->unsupportedMethods[$lcInterface]) === true) {
+            if ($checkMethods === true && isset($this->unsupportedMethods[$interfaceLc]) === true) {
                 $nextFunc = $stackPtr;
                 while (($nextFunc = $phpcsFile->findNext(T_FUNCTION, ($nextFunc + 1), $scopeCloser)) !== false) {
-                    $funcName = strtolower($phpcsFile->getDeclarationName($nextFunc));
-                    if ($funcName === '') {
+                    $funcName   = $phpcsFile->getDeclarationName($nextFunc);
+                    $funcNameLc = strtolower($funcName);
+                    if ($funcNameLc === '') {
                         continue;
                     }
 
-                    if (isset($this->unsupportedMethods[$lcInterface][$funcName]) === true) {
+                    if (isset($this->unsupportedMethods[$interfaceLc][$funcNameLc]) === true) {
                         $error     = 'Classes that implement interface %s do not support the method %s(). See %s';
                         $errorCode = $this->stringToErrorCode($interface) . 'UnsupportedMethod';
                         $data      = array(
                             $interface,
                             $funcName,
-                            $this->unsupportedMethods[$lcInterface][$funcName],
+                            $this->unsupportedMethods[$interfaceLc][$funcNameLc],
                         );
 
                         $phpcsFile->addError($error, $nextFunc, $errorCode, $data);

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -87,14 +87,9 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Sn
      */
     public function register()
     {
-        // Handle case-insensitivity of class names.
-        $keys = array_keys( $this->newInterfaces );
-        $keys = array_map( 'strtolower', $keys );
-        $this->newInterfaces = array_combine( $keys, $this->newInterfaces );
-
-        $keys = array_keys( $this->unsupportedMethods );
-        $keys = array_map( 'strtolower', $keys );
-        $this->unsupportedMethods = array_combine( $keys, $this->unsupportedMethods );
+        // Handle case-insensitivity of interface names.
+        $this->newInterfaces      = $this->arrayKeysToLowercase($this->newInterfaces);
+        $this->unsupportedMethods = $this->arrayKeysToLowercase($this->unsupportedMethods);
 
         return array(T_CLASS);
 

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -19,8 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -247,12 +247,14 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
         }
 
         if ($notInVersion !== '') {
-            $error = '%s is not present in PHP version %s or earlier';
-            $data  = array(
+            $error     = '%s is not present in PHP version %s or earlier';
+            $errorCode = $this->stringToErrorCode($keywordName) . 'Found';
+            $data      = array(
                 $this->newKeywords[$keywordName]['description'],
                 $notInVersion,
             );
-            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -19,7 +19,8 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -218,70 +219,75 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Snif
                 }
             }
 
-            $errorInfo = $this->getErrorInfo($tokenType);
-
-            if ($errorInfo['not_in_version'] !== '') {
-                $this->addError($phpcsFile, $stackPtr, $tokenType, $errorInfo);
-            }
+            $itemInfo = array(
+                'name'   => $tokenType,
+            );
+            $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
         }
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $tokenType The token type representing the keyword.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($tokenType)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'description'    => '',
-            'not_in_version' => '',
-        );
-
-        $errorInfo['description'] = $this->newKeywords[$tokenType]['description'];
-
-        foreach ($this->newKeywords[$tokenType] as $version => $present) {
-            if (in_array($version, array('condition', 'description', 'content'), true)) {
-                continue;
-            }
-
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newKeywords[$itemInfo['name']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get an array of the non-PHP-version array keys used in a sub-array.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the keyword token
-     *                                        in the token array.
-     * @param string               $tokenType The token type representing the keyword.
-     * @param array                $errorInfo Array with details about when the
-     *                                        keyword was not (yet) available.
-     *
-     * @return void
+     * @return array
      */
-    protected function addError($phpcsFile, $stackPtr, $tokenType, $errorInfo)
+    protected function getNonVersionArrayKeys()
     {
-        $error     = '%s is not present in PHP version %s or earlier';
-        $errorCode = $this->stringToErrorCode($tokenType) . 'Found';
-        $data      = array(
-            $errorInfo['description'],
-            $errorInfo['not_in_version'],
+        return array(
+            'description',
+            'condition',
+            'content',
         );
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
 
-    }//end addError()
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo)
+    {
+        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo['description'] = $itemArray['description'];
+
+        return $errorInfo;
+
+    }
+
+
+    /**
+     * Allow for concrete child classes to filter the error data before it's passed to PHPCS.
+     *
+     * @param array $data      The error data array which was created.
+     * @param array $itemInfo  Base information about the item this error message applied to.
+     * @param array $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return array
+     */
+    protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
+    {
+        $data[0] = $errorInfo['description'];
+        return $data;
+    }
+
 
 }//end class

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -178,11 +178,9 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
     {
         $error = '';
 
-        $isError = false;
         foreach ($this->newConstructs[$keywordName] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -190,11 +188,7 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
         if (strlen($error) > 0) {
             $error = $this->newConstructs[$keywordName]['description'] . ' is ' . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -19,8 +19,7 @@
  * @version   1.0.0
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/NewMagicMethodsSniff.php
+++ b/Sniffs/PHP/NewMagicMethodsSniff.php
@@ -16,8 +16,7 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -97,11 +97,9 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
     {
         $error = '';
 
-        $isError = false;
         foreach ($this->newTypes[$typeName] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -112,11 +110,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
                 $typeName,
             );
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
-            }
+            $phpcsFile->addError($error, $stackPtr, 'Found', $data);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -14,7 +14,8 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -77,63 +78,38 @@ class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends P
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
-        if (in_array($tokens[$stackPtr]['content'], array_keys($this->newTypes))) {
-            $errorInfo = $this->getErrorInfo($tokens[$stackPtr]['content']);
 
-            if ($errorInfo['not_in_version'] !== '') {
-                $this->addError($phpcsFile, $stackPtr, $tokens[$stackPtr]['content'], $errorInfo);
-            }
+        if (isset($this->newTypes[$tokens[$stackPtr]['content']]) === true) {
+            $itemInfo = array(
+                'name'   => $tokens[$stackPtr]['content'],
+            );
+            $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
         }
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $typeName The return type.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($typeName)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newTypes[$typeName] as $version => $present) {
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newTypes[$itemInfo['name']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the return type token
-     *                                        in the token array.
-     * @param string               $typeName  The return type.
-     * @param array                $errorInfo Array with details about when the
-     *                                        return type was not (yet) available.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $typeName, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = '%s return type is not present in PHP version %s or earlier';
-        $errorCode = $this->stringToErrorCode($typeName) . 'Found';
-        $data      = array(
-            $typeName,
-            $errorInfo['not_in_version'],
-        );
+        return '%s return type is not present in PHP version %s or earlier';
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -108,24 +108,31 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
             }
 
             if ($supportsPHP4 === true) {
-                $error = 'Type hints were not present in PHP 4.4 or earlier.';
-                $phpcsFile->addError($error, $stackPtr, 'TypeHintFound');
+                $phpcsFile->addError(
+                    'Type hints were not present in PHP 4.4 or earlier.',
+                    $stackPtr,
+                    'TypeHintFound'
+                );
             }
             else if (isset($this->newTypes[$param['type_hint']])) {
                 $this->addError($phpcsFile, $stackPtr, $param['type_hint']);
             }
             else if (isset($this->invalidTypes[$param['type_hint']])) {
                 $error = "'%s' is not a valid type declaration. Did you mean %s ?";
-                $data = array(
+                $data  = array(
                     $param['type_hint'],
                     $this->invalidTypes[$param['type_hint']],
                 );
+
                 $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHintFound', $data);
             }
             else if ($param['type_hint'] === 'self') {
                 if ($this->inClassScope($phpcsFile, $stackPtr) === false) {
-                    $error = "'self' type cannot be used outside of class scope";
-                    $phpcsFile->addError($error, $stackPtr, 'SelfOutsideClassScopeFound');
+                    $phpcsFile->addError(
+                        "'self' type cannot be used outside of class scope",
+                        $stackPtr,
+                        'SelfOutsideClassScopeFound'
+                    );
                 }
             }
         }

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff
-    extends PHPCompatibility_AbstractNewFeatureSniff
+class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -146,11 +146,9 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
     {
         $error = '';
 
-        $isError = false;
         foreach ($this->newTypes[$typeName] as $version => $present) {
             if ($this->supportsBelow($version)) {
                 if ($present === false) {
-                    $isError = true;
                     $error .= 'not present in PHP version ' . $version . ' or earlier';
                 }
             }
@@ -158,11 +156,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
         if (strlen($error) > 0) {
             $error = "'{$typeName}' type declaration is " . $error;
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr);
-            }
+            $phpcsFile->addError($error, $stackPtr);
         }
 
     }//end addError()

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -14,7 +14,8 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff
+    extends PHPCompatibility_AbstractNewFeatureSniff
 {
 
     /**
@@ -115,11 +116,10 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                 );
             }
             else if (isset($this->newTypes[$param['type_hint']])) {
-                $errorInfo = $this->getErrorInfo($param['type_hint']);
-
-                if ($errorInfo['not_in_version'] !== '') {
-                    $this->addError($phpcsFile, $stackPtr, $param['type_hint'], $errorInfo);
-                }
+                $itemInfo = array(
+                    'name'   => $param['type_hint'],
+                );
+                $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
             }
             else if (isset($this->invalidTypes[$param['type_hint']])) {
                 $error = "'%s' is not a valid type declaration. Did you mean %s ?";
@@ -144,52 +144,27 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $typeName The type.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($typeName)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'not_in_version' => '',
-        );
-
-        foreach ($this->newTypes[$typeName] as $version => $present) {
-            if ($present === false && $this->supportsBelow($version)) {
-                $errorInfo['not_in_version'] = $version;
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->newTypes[$itemInfo['name']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the class token
-     *                                        in the token array.
-     * @param string               $typeName  The type.
-     * @param array                $errorInfo Array with details about when the
-     *                                        class was not (yet) available.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $typeName, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = "'%s' type declaration is not present in PHP version %s or earlier";
-        $errorCode = $this->stringToErrorCode($typeName) . 'Found';
-        $data      = array(
-            $typeName,
-            $errorInfo['not_in_version'],
-        );
+        return "'%s' type declaration is not present in PHP version %s or earlier";
+    }
 
-        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -129,28 +129,29 @@ class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatib
             }
 
             $methodProperties = $phpcsFile->getMethodProperties($functionToken);
+            $errorCodeBase    = $this->stringToErrorCode($methodNameLc);
 
             if (isset($this->magicMethods[$methodNameLc]['visibility']) && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']) {
-                $error = 'Visibility for magic method %s must be %s. Found: %s';
-                $data  = array(
+                $error     = 'Visibility for magic method %s must be %s. Found: %s';
+                $errorCode = $errorCodeBase . 'MethodVisibility';
+                $data      = array(
                     $methodName,
                     $this->magicMethods[$methodNameLc]['visibility'],
                     $methodProperties['scope'],
                 );
 
-                $phpcsFile->addError($error, $functionToken, 'MethodVisibility', $data);
+                $phpcsFile->addError($error, $functionToken, $errorCode, $data);
             }
 
             if (isset($this->magicMethods[$methodNameLc]['static']) && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']) {
                 $error     = 'Magic method %s cannot be defined as static.';
-                $errorCode = 'MethodStatic';
+                $errorCode = $errorCodeBase . 'MethodStatic';
+                $data      = array($methodName);
+
                 if ( $this->magicMethods[$methodNameLc]['static'] === true ) {
                     $error     = 'Magic method %s must be defined as static.';
-                    $errorCode = 'MethodNonStatic';
+                    $errorCode = $errorCodeBase . 'MethodNonStatic';
                 }
-                $data = array(
-                    $methodName,
-                );
 
                 $phpcsFile->addError($error, $functionToken, $errorCode, $data);
             }

--- a/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -133,7 +133,7 @@ class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatib
 
             if (isset($this->magicMethods[$methodNameLc]['visibility']) && $this->magicMethods[$methodNameLc]['visibility'] !== $methodProperties['scope']) {
                 $error     = 'Visibility for magic method %s must be %s. Found: %s';
-                $errorCode = $errorCodeBase . 'MethodVisibility';
+                $errorCode = $errorCodeBase.'MethodVisibility';
                 $data      = array(
                     $methodName,
                     $this->magicMethods[$methodNameLc]['visibility'],
@@ -145,12 +145,12 @@ class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatib
 
             if (isset($this->magicMethods[$methodNameLc]['static']) && $this->magicMethods[$methodNameLc]['static'] !== $methodProperties['is_static']) {
                 $error     = 'Magic method %s cannot be defined as static.';
-                $errorCode = $errorCodeBase . 'MethodStatic';
+                $errorCode = $errorCodeBase.'MethodStatic';
                 $data      = array($methodName);
 
                 if ( $this->magicMethods[$methodNameLc]['static'] === true ) {
                     $error     = 'Magic method %s must be defined as static.';
-                    $errorCode = $errorCodeBase . 'MethodNonStatic';
+                    $errorCode = $errorCodeBase.'MethodNonStatic';
                 }
 
                 $phpcsFile->addError($error, $functionToken, $errorCode, $data);

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -60,9 +60,11 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
 
         foreach ($parameters as $param) {
             if (in_array($param['name'], $this->superglobals, true)) {
-                $error = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
-                $data  = array($param['name']);
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
+                $error     = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
+                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
+                $data      = array($param['name']);
+
+                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
             }
         }
     }

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -61,7 +61,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
         foreach ($parameters as $param) {
             if (in_array($param['name'], $this->superglobals, true)) {
                 $error     = 'Parameter shadowing super global (%s) causes fatal error since PHP 5.4';
-                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)) . 'Found';
+                $errorCode = $this->stringToErrorCode(substr($param['name'], 1)).'Found';
                 $data      = array($param['name']);
 
                 $phpcsFile->addError($error, $stackPtr, $errorCode, $data);

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -125,11 +125,7 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
                     $errorCode = 'Removed';
                 }
 
-                if ($isError === true) {
-                    $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-                } else {
-                    $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
-                }
+                $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
             }
         }
 

--- a/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -111,8 +111,12 @@ class PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff extends PHPComp
         }
 
         if (isset($errorCode, $data)) {
-            $error = '%s style opening tags have been removed in PHP 7.0. Found "%s"';
-            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+            $phpcsFile->addError(
+                '%s style opening tags have been removed in PHP 7.0. Found "%s"',
+                $stackPtr,
+                $errorCode,
+                $data
+            );
             return;
         }
 

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -175,6 +175,9 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
      */
     public function register()
     {
+        // Handle case-insensitivity of function names.
+        $this->removedExtensions = $this->arrayKeysToLowercase($this->removedExtensions);
+
         return array(T_STRING);
 
     }//end register()
@@ -224,13 +227,16 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
             return;
         }
 
-        if($this->isWhiteListed(strtolower($tokens[$stackPtr]['content'])) === true){
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
+
+        if($this->isWhiteListed($functionLc) === true){
             // Function is whitelisted.
             return;
         }
 
         foreach ($this->removedExtensions as $extension => $versionList) {
-            if (strpos(strtolower($tokens[$stackPtr]['content']), strtolower($extension)) === 0) {
+            if (strpos($functionLc, $extension) === 0) {
                 $error = '';
                 $isError = false;
                 $previousStatus = null;

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -20,8 +20,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
     /**
      * A list of functions to whitelist, if any.

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -151,13 +151,14 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff
                 '5.4' => true,
                 'alternative' => null
         ),
-        'sybase' => array(
-                '5.3' => true,
-                'alternative' => 'sybase_ct'
-        ),
+        // Has to be before `sybase` as otherwise it will never match.
         'sybase_ct' => array(
                 '7.0' => true,
                 'alternative' => null
+        ),
+        'sybase' => array(
+                '5.3' => true,
+                'alternative' => 'sybase_ct'
         ),
         'w32api' => array(
                 '5.1' => true,

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -41,308 +41,129 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
 
     /**
      * A list of removed extensions with their alternative, if any
-     * Array codes : 0 = removed/unavailable, -1 = deprecated, 1 = active
+     *
+     * The array lists : version number with false (deprecated) and true (removed).
+     * If's sufficient to list the first version where the extension was deprecated/removed.
      *
      * @var array(string|null)
      */
     protected $removedExtensions = array(
         'activescript' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/activescript'
         ),
         'cpdf' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/pdflib'
         ),
         'dbase' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => null
         ),
         'dbx' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/dbx'
         ),
         'dio' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/dio'
         ),
         'ereg' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => -1,
-                '5.4' => -1,
-                '5.5' => -1,
-                '5.6' => -1,
-                '7.0' => 0,
+                '5.3' => false,
+                '7.0' => true,
                 'alternative' => 'pcre'
         ),
         'fam' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => null
         ),
         'fbsql' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => null
         ),
         'fdf' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => 'pecl/fdf'
         ),
         'filepro' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.2' => true,
                 'alternative' => null
         ),
         'hw_api' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.2' => true,
                 'alternative' => null
         ),
         'ingres' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/ingres'
         ),
         'ircg' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => null
         ),
         'mcrypt' => array(
-                '7.0' => 1,
-                '7.1' => -1,
+                '7.1' => false,
                 'alternative' => 'openssl (preferred) or pecl/mcrypt once available'
         ),
         'mcve' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/mvce'
         ),
         'ming' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => 'pecl/ming'
         ),
         'mnogosearch' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => null
         ),
         'msql' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => null
         ),
         'mssql' => array(
-                '7.0' => 0,
+                '7.0' => true,
                 'alternative' => null
         ),
         'mysql_' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 1,
-                '5.4' => 1,
-                '5.5' => -1,
-                '5.6' => -1,
-                '7.0' => 0,
+                '5.5' => false,
+                '7.0' => true,
                 'alternative' => 'mysqli',
         ),
         'ncurses' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => 'pecl/ncurses'
         ),
         'oracle' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'oci8 or pdo_oci'
         ),
         'ovrimos' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => null
         ),
         'pfpro' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => null
         ),
         'sqlite' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 1,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.4' => true,
                 'alternative' => null
         ),
         'sybase' => array(
-                '5.0' => 1,
-                '5.1' => 1,
-                '5.2' => 1,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.3' => true,
                 'alternative' => 'sybase_ct'
         ),
         'sybase_ct' => array(
-                '7.0' => 0,
+                '7.0' => true,
                 'alternative' => null
         ),
         'w32api' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => 'pecl/ffi'
         ),
         'yp' => array(
-                '5.0' => 1,
-                '5.1' => 0,
-                '5.2' => 0,
-                '5.3' => 0,
-                '5.4' => 0,
-                '5.5' => 0,
-                '5.6' => 0,
-                '7.0' => 0,
+                '5.1' => true,
                 'alternative' => null
         ),
     );
@@ -411,28 +232,23 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
         foreach ($this->removedExtensions as $extension => $versionList) {
             if (strpos(strtolower($tokens[$stackPtr]['content']), strtolower($extension)) === 0) {
                 $error = '';
-                $isErrored = false;
-                $isDeprecated = false;
-                foreach ($versionList as $version => $status) {
-                    if ($version != 'alternative') {
-                        if ($status == -1 || $status == 0) {
-                            if ($this->supportsAbove($version)) {
-                                switch ($status) {
-                                    case -1:
-                                        if($isDeprecated === false ) {
-                                            $error .= 'deprecated since PHP ' . $version . ' and ';
-                                            $isDeprecated = true;
-                                        }
-                                        break;
-                                    case 0:
-                                        $isErrored = true;
-                                        $error .= 'removed since PHP ' . $version . ' and ';
-                                        break 2;
-                                }
+                $isError = false;
+                $previousStatus = null;
+                foreach ($versionList as $version => $removed) {
+                    if ($version !== 'alternative' && $this->supportsAbove($version)) {
+                        if ($previousStatus !== $removed) {
+                            $previousStatus = $removed;
+                            if ($removed === true) {
+                                $isError = true;
+                                $error .= 'removed';
+                            } else {
+                                $error .= 'deprecated';
                             }
+                            $error .=  ' since PHP ' . $version . ' and ';
                         }
                     }
                 }
+
                 if (strlen($error) > 0) {
                     $error = "Extension '" . $extension . "' is " . $error;
                     $error = substr($error, 0, strlen($error) - 5);
@@ -440,7 +256,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
                         $error .= ' - use ' . $versionList['alternative'] . ' instead.';
                     }
 
-                    $this->addMessage($phpcsFile, $error, $stackPtr, $isErrored);
+                    $this->addMessage($phpcsFile, $error, $stackPtr, $isError);
                 }
             }
         }

--- a/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -439,11 +439,8 @@ class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibilit
                     if (!is_null($versionList['alternative'])) {
                         $error .= ' - use ' . $versionList['alternative'] . ' instead.';
                     }
-                    if ($isErrored === true) {
-                        $phpcsFile->addError($error, $stackPtr);
-                    } else {
-                        $phpcsFile->addWarning($error, $stackPtr);
-                    }
+
+                    $this->addMessage($phpcsFile, $error, $stackPtr, $isErrored);
                 }
             }
         }

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -168,11 +168,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
                 $function,
             );
 
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
-            }
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
 
     }//end addError()

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -19,9 +19,9 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
     /**
      * A list of removed function parameters, which were present in older versions.
      *
-     * The array lists : version number with true (deprecated) and false (removed).
+     * The array lists : version number with false (deprecated) and true (removed).
      * The index is the location of the parameter in the parameter list, starting at 0 !
-     * If's sufficient to list the first version where the function was deprecated/removed.
+     * If's sufficient to list the first version where the function parameter was deprecated/removed.
      *
      * @var array
      */
@@ -29,27 +29,27 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
                                         'gmmktime' => array(
                                             6 => array(
                                                 'name' => 'is_dst',
-                                                '5.1' => true, // deprecated
-                                                '7.0' => false,
+                                                '5.1' => false, // deprecated
+                                                '7.0' => true,
                                             ),
                                         ),
                                         'ldap_first_attribute' => array(
                                             2 => array(
                                                 'name' => 'ber_identifier',
-                                                '5.2.4' => false,
+                                                '5.2.4' => true,
                                             ),
                                         ),
                                         'ldap_next_attribute' => array(
                                             2 => array(
                                                 'name' => 'ber_identifier',
-                                                '5.2.4' => false,
+                                                '5.2.4' => true,
                                             ),
                                         ),
                                         'mktime' => array(
                                             6 => array(
                                                 'name' => 'is_dst',
-                                                '5.1' => true, // deprecated
-                                                '7.0' => false,
+                                                '5.1' => false, // deprecated
+                                                '7.0' => true,
                                             ),
                                         ),
                                     );
@@ -143,12 +143,12 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
 
         $isError        = false;
         $previousStatus = null;
-        foreach ($this->removedFunctionParameters[$function][$parameterLocation] as $version => $present) {
+        foreach ($this->removedFunctionParameters[$function][$parameterLocation] as $version => $removed) {
             if ($version != 'name' && $this->supportsAbove($version)) {
 
-                if ($previousStatus !== $present) {
-                    $previousStatus = $present;
-                    if ($present === false) {
+                if ($previousStatus !== $removed) {
+                    $previousStatus = $removed;
+                    if ($removed === true) {
                         $isError = true;
                         $error .= 'removed';
                     } else {

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
     /**
      * A list of removed function parameters, which were present in older versions.

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -56,22 +56,14 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
 
 
     /**
-     *
-     * @var array
-     */
-    private $removedFunctionParametersNames;
-
-
-    /**
      * Returns an array of tokens this test wants to listen for.
      *
      * @return array
      */
     public function register()
     {
-        // Everyone has had a chance to figure out what removed function parameters
-        // they want to check for, so now we can cache out the list.
-        $this->removedFunctionParametersNames = array_keys($this->removedFunctionParameters);
+        // Handle case-insensitivity of function names.
+        $this->removedFunctionParameters = $this->arrayKeysToLowercase($this->removedFunctionParameters);
 
         return array(T_STRING);
     }//end register()
@@ -104,7 +96,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
 
         $function = strtolower($tokens[$stackPtr]['content']);
 
-        if (in_array($function, $this->removedFunctionParametersNames) === false) {
+        if (isset($this->removedFunctionParameters[$function]) === false) {
             return;
         }
 

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -94,9 +94,10 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
 
-        if (isset($this->removedFunctionParameters[$function]) === false) {
+        if (isset($this->removedFunctionParameters[$functionLc]) === false) {
             return;
         }
 
@@ -109,7 +110,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
         $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
-        foreach($this->removedFunctionParameters[$function] as $offset => $parameterDetails) {
+        foreach($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {
             if ($offset <= $parameterOffsetFound) {
                 $this->addError($phpcsFile, $openParenthesis, $function, $offset);
             }
@@ -131,11 +132,12 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
      */
     protected function addError($phpcsFile, $stackPtr, $function, $parameterLocation)
     {
+        $functionLc = strtolower($function);
         $error = '';
 
         $isError        = false;
         $previousStatus = null;
-        foreach ($this->removedFunctionParameters[$function][$parameterLocation] as $version => $removed) {
+        foreach ($this->removedFunctionParameters[$functionLc][$parameterLocation] as $version => $removed) {
             if ($version != 'name' && $this->supportsAbove($version)) {
 
                 if ($previousStatus !== $removed) {
@@ -156,7 +158,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
             $error     = substr($error, 0, strlen($error) - 5);
             $errorCode = 'RemovedParameter';
             $data      = array(
-                $this->removedFunctionParameters[$function][$parameterLocation]['name'],
+                $this->removedFunctionParameters[$functionLc][$parameterLocation]['name'],
                 $function,
             );
 

--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -92,11 +92,8 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
                 $error .= ' - use %s instead.';
                 $data[] = $versionList['alternative'];
             }
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr, 'Found', $data);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr, 'Found', $data);
-            }
+
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
         }
 
     }//end process()

--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -83,17 +83,17 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
             }
         }
         if (strlen($error) > 0) {
-            $error = "Global variable '%s' is " . $error;
-            $error = substr($error, 0, strlen($error) - 5);
-            $data  = array(
-                $tokens[$stackPtr]['content']
-            );
+            $error     = "Global variable '%s' is " . $error;
+            $error     = substr($error, 0, strlen($error) - 5);
+            $errorCode = $this->stringToErrorCode($varName) . 'Found';
+            $data      = array($tokens[$stackPtr]['content']);
+
             if (isset($versionList['alternative'])) {
                 $error .= ' - use %s instead.';
                 $data[] = $versionList['alternative'];
             }
 
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'Found', $data);
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
         }
 
     }//end process()

--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -16,8 +16,7 @@
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -132,7 +132,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
     protected function addError($phpcsFile, $stackPtr, $algorithm, $errorInfo)
     {
         $error     = 'The %s hash algorithm is ';
-        $errorCode = $algorithm . 'Found';
+        $errorCode = $this->stringToErrorCode($algorithm) . 'Found';
         $data      = array($algorithm);
 
         if ($errorInfo['deprecated'] !== '') {

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -22,7 +22,8 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatibility_Sniff
+class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff
+    extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
 
     /**
@@ -75,80 +76,36 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
             return;
         }
 
-        // Check if the algorithm used is deprecated or removed.
-        $errorInfo = $this->getErrorInfo($algo);
-
-        if ($errorInfo['deprecated'] !== '' || $errorInfo['removed'] !== '') {
-            $this->addError($phpcsFile, $stackPtr, $algo, $errorInfo);
-        }
+        $itemInfo = array(
+            'name' => $algo,
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
 
     }//end process()
 
 
     /**
-     * Retrieve the relevant (version) information for the error message.
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
      *
-     * @param string $algorithm The name of the algorithm.
+     * @param array $itemInfo Base information about the item.
      *
-     * @return array
+     * @return array Version and other information about the item.
      */
-    protected function getErrorInfo($algorithm)
+    public function getItemArray(array $itemInfo)
     {
-        $errorInfo  = array(
-            'deprecated'  => '',
-            'removed'     => '',
-            'error'       => false,
-        );
-
-        foreach ($this->removedAlgorithms[$algorithm] as $version => $removed) {
-            if ($this->supportsAbove($version)) {
-                if ($removed === true && $errorInfo['removed'] === '') {
-                    $errorInfo['removed'] = $version;
-                    $errorInfo['error']   = true;
-                } elseif ($errorInfo['deprecated'] === '') {
-                    $errorInfo['deprecated'] = $version;
-                }
-            }
-        }
-
-        return $errorInfo;
-
-    }//end getErrorInfo()
+        return $this->removedAlgorithms[$itemInfo['name']];
+    }
 
 
     /**
-     * Generates the error or warning for this sniff.
+     * Get the error message template for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function
-     *                                        in the token array.
-     * @param string               $algorithm The name of the algorithm.
-     * @param array                $errorInfo Array with details about the versions
-     *                                        in which the algorithm was deprecated
-     *                                        and/or removed.
-     *
-     * @return void
+     * @return string
      */
-    protected function addError($phpcsFile, $stackPtr, $algorithm, $errorInfo)
+    protected function getErrorMsgTemplate()
     {
-        $error     = 'The %s hash algorithm is ';
-        $errorCode = $this->stringToErrorCode($algorithm) . 'Found';
-        $data      = array($algorithm);
+        return 'The %s hash algorithm is ';
+    }
 
-        if ($errorInfo['deprecated'] !== '') {
-            $error .= 'deprecated since PHP version %s and ';
-            $data[] = $errorInfo['deprecated'];
-        }
-        if ($errorInfo['removed'] !== '') {
-            $error .= 'removed since PHP version %s and ';
-            $data[] = $errorInfo['removed'];
-        }
-
-        // Remove the last 'and' from the message.
-        $error = substr($error, 0, strlen($error) - 5);
-
-        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
-
-    }//end addError()
 
 }//end class

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -147,11 +147,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatib
         // Remove the last 'and' from the message.
         $error = substr($error, 0, strlen($error) - 5);
 
-        if ($errorInfo['error'] === true) {
-            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
-        } else {
-            $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
-        }
+        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
 
     }//end addError()
 

--- a/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -22,8 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff
-    extends PHPCompatibility_AbstractRemovedFeatureSniff
+class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
 {
 
     /**

--- a/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -52,6 +52,9 @@ class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff extend
      */
     public function register()
     {
+        // Handle case-insensitivity of function names.
+        $this->functionParameters = $this->arrayKeysToLowercase($this->functionParameters);
+
         return array(T_STRING);
     }//end register()
 
@@ -81,9 +84,10 @@ class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff extend
             return;
         }
 
-        $function = strtolower($tokens[$stackPtr]['content']);
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
 
-        if (isset($this->functionParameters[$function]) === false) {
+        if (isset($this->functionParameters[$functionLc]) === false) {
             return;
         }
 
@@ -98,7 +102,7 @@ class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff extend
         $requiredVersion      = null;
         $parameterName        = null;
 
-        foreach($this->functionParameters[$function] as $offset => $parameterDetails) {
+        foreach($this->functionParameters[$functionLc] as $offset => $parameterDetails) {
             if ($offset > $parameterOffsetFound) {
                 foreach ($parameterDetails as $version => $present) {
                     if ($version !== 'name' && $present === true && $this->supportsBelow($version)) {

--- a/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -14,8 +14,7 @@
  * @package   PHPCompatibility
  * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff
-    extends PHPCompatibility_AbstractComplexVersionSniff
+class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff extends PHPCompatibility_AbstractComplexVersionSniff
 {
 
     /**
@@ -100,8 +99,6 @@ class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
         $openParenthesis      = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
-        $requiredVersion      = null;
-        $parameterName        = null;
 
         foreach($this->functionParameters[$functionLc] as $offset => $parameterDetails) {
             if ($offset > $parameterOffsetFound) {

--- a/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -59,8 +59,11 @@ class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility
                                      ($stackPtr + 1), null, true);
 
         if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
-            $error = 'Middle may not be omitted from ternary operators in PHP < 5.3';
-            $phpcsFile->addError($error, $stackPtr);
+            $phpcsFile->addError(
+                'Middle may not be omitted from ternary operators in PHP < 5.3',
+                $stackPtr,
+                'MiddleMissing'
+            );
         }
     }
 }

--- a/Sniffs/PHP/ValidIntegersSniff.php
+++ b/Sniffs/PHP/ValidIntegersSniff.php
@@ -69,18 +69,30 @@ class PHPCompatibility_Sniffs_PHP_ValidIntegersSniff extends PHPCompatibility_Sn
             return;
         }
 
-        $data = array( $token['content'] );
+        $isError = $this->supportsAbove('7.0');
+        $data    = array( $token['content'] );
+
         if ($this->isInvalidOctalInteger($tokens, $stackPtr) === true) {
-            $error   = 'Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: %s';
-            $isError = $this->supportsAbove('7.0');
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'InvalidOctalIntegerFound', $data);
+            $this->addMessage(
+                $phpcsFile,
+                'Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: %s',
+                $stackPtr,
+                $isError,
+                'InvalidOctalIntegerFound',
+                $data
+            );
             return;
         }
 
         if ($this->isHexidecimalNumericString($tokens, $stackPtr) === true) {
-            $error   = 'The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: %s';
-            $isError = $this->supportsAbove('7.0');
-            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'HexNumericStringFound', $data);
+            $this->addMessage(
+                $phpcsFile,
+                'The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: %s',
+                $stackPtr,
+                $isError,
+                'HexNumericStringFound',
+                $data
+            );
             return;
         }
 

--- a/Sniffs/PHP/ValidIntegersSniff.php
+++ b/Sniffs/PHP/ValidIntegersSniff.php
@@ -73,25 +73,14 @@ class PHPCompatibility_Sniffs_PHP_ValidIntegersSniff extends PHPCompatibility_Sn
         if ($this->isInvalidOctalInteger($tokens, $stackPtr) === true) {
             $error   = 'Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: %s';
             $isError = $this->supportsAbove('7.0');
-
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr, 'InvalidOctalIntegerFound', $data);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr, 'InvalidOctalIntegerFound', $data);
-            }
-
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'InvalidOctalIntegerFound', $data);
             return;
         }
 
         if ($this->isHexidecimalNumericString($tokens, $stackPtr) === true) {
             $error   = 'The behaviour of hexadecimal numeric strings was inconsistent prior to PHP 7 and support has been removed in PHP 7. Found: %s';
             $isError = $this->supportsAbove('7.0');
-
-            if ($isError === true) {
-                $phpcsFile->addError($error, $stackPtr, 'HexNumericStringFound', $data);
-            } else {
-                $phpcsFile->addWarning($error, $stackPtr, 'HexNumericStringFound', $data);
-            }
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, 'HexNumericStringFound', $data);
             return;
         }
 

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -38,11 +38,48 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
 
 
    /**
+     * testStringToErrorCode
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataStringToErrorCode
+     *
+     * @covers PHPCompatibility_Sniff::stringToErrorCode
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected error code.
+     */
+    public function testStringToErrorCode($input, $expected)
+    {
+        $this->assertSame($expected, $this->helperClass->stringToErrorCode($input));
+    }
+
+    /**
+     * dataStringToErrorCode
+     *
+     * @see testStringToErrorCode()
+     *
+     * @return array
+     */
+    public function dataStringToErrorCode()
+    {
+        return array(
+            array('dir_name', 'dir_name'), // No change.
+            array('soap.wsdl_cache', 'soap_wsdl_cache'), // No dot.
+            array('arbitrary-string with space', 'arbitrary_string_with_space'), // No dashes, no spaces.
+            array('^%*&%*€יבר', '__________'), // No non alpha-numeric characters.
+        );
+    }
+
+
+   /**
      * testStripQuotes
      *
      * @group utilityFunctions
      *
      * @dataProvider dataStripQuotes
+     *
+     * @covers PHPCompatibility_Sniff::stripQuotes
      *
      * @param string $input    The input string.
      * @param string $expected The expected function output.

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -107,4 +107,47 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
         );
     }
 
+
+    /**
+     * testArrayKeysToLowercase
+     *
+     * @group utilityFunctions
+     *
+     * @dataProvider dataArrayKeysToLowercase
+     *
+     * @covers PHPCompatibility_Sniff::arrayKeysToLowercase
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected function output.
+     */
+    public function testArrayKeysToLowercase($input, $expected)
+    {
+        $this->assertSame($expected, $this->helperClass->arrayKeysToLowercase($input));
+    }
+
+    /**
+     * dataArrayKeysToLowercase
+     *
+     * @see testArrayKeysToLowercase()
+     *
+     * @return array
+     */
+    public function dataArrayKeysToLowercase()
+    {
+        return array(
+            array(
+                array(
+                    'UPPERCASE' => true,
+                    'MIXEDcase' => false,
+                    'lowercase' => '123',
+                ),
+                array(
+                    'uppercase' => true,
+                    'mixedcase' => false,
+                    'lowercase' => '123',
+                ),
+            ),
+        );
+    }
+
 }

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -97,7 +97,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; use {$alternative} instead");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
         }
     }
 
@@ -359,7 +359,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; use {$alternative} instead");
+            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
         }
 
         if (isset($removedVersion)){
@@ -369,7 +369,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; use {$alternative} instead");
+            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead");
         }
     }
 

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -66,7 +66,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}.");
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}");
         }
 
         if (isset($removedVersion)){
@@ -142,7 +142,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}.");
+            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}");
         }
     }
 
@@ -202,8 +202,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}. Use '{$alternative}' instead.");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}. Use '{$alternative}' instead.");
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}; Use '{$alternative}' instead");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}; Use '{$alternative}' instead");
     }
 
     /**
@@ -251,8 +251,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}.");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}.");
+        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}");
+        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}");
     }
 
     /**

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -37,12 +37,12 @@ class LongArraysSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The use of long predefined variables has been deprecated in {$deprecatedIn}; Found '{$longVariable}'");
+            $this->assertWarning($file, $line, "The use of long predefined variables has been deprecated in PHP {$deprecatedIn}; Found '{$longVariable}'");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The use of long predefined variables has been deprecated in {$deprecatedIn} and removed in {$removedIn}; Found '{$longVariable}'");
+            $this->assertError($file, $line, "The use of long predefined variables has been deprecated in PHP {$deprecatedIn} and removed in PHP {$removedIn}; Found '{$longVariable}'");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -41,7 +41,7 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName} does not have a parameter \"{$parameterName}\" in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, "The function {$functionName}() does not have a parameter \"{$parameterName}\" in PHP version {$lastVersionBefore} or earlier");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -65,7 +65,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName} is not present in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, "The function {$functionName}() is not present in PHP version {$lastVersionBefore} or earlier");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -82,69 +82,45 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     public function dataRemovedExtension()
     {
         return array(
-            array('activescript', '5.1', array(3, 4), '5.0'),
-            array('cpdf', '5.1', array(6, 7, 8), '5.0'),
             array('dbase', '5.3', array(10), '5.2'),
-            array('dbx', '5.1', array(12), '5.0'),
-            array('dio', '5.1', array(14), '5.0'),
             array('fam', '5.1', array(16), '5.0'),
             array('fbsql', '5.3', array(18), '5.2'),
-            array('fdf', '5.3', array(20), '5.2'),
             array('filepro', '5.2', array(22), '5.1'),
             array('hw_api', '5.2', array(24), '5.1'),
-            array('ingres', '5.1', array(26), '5.0'),
             array('ircg', '5.1', array(28), '5.0'),
-            array('mcve', '5.1', array(30), '5.0'),
-            array('ming', '5.3', array(32), '5.2'),
             array('mnogosearch', '5.1', array(34), '5.0'),
             array('msql', '5.3', array(36), '5.2'),
-            array('ncurses', '5.3', array(40), '5.2'),
-            array('oracle', '5.1', array(42), '5.0'),
+            array('mssql', '7.0', array(63), '5.6'),
             array('ovrimos', '5.1', array(44), '5.0'),
             array('pfpro', '5.3', array(46), '5.2'),
             array('sqlite', '5.4', array(48), '5.3'),
-            array('sybase', '5.3', array(50), '5.2'),
-            array('w32api', '5.1', array(52), '5.0'),
+//            array('sybase', '7.0', array(xx), '5.6'), sybase_ct ???
             array('yp', '5.1', array(54), '5.0'),
-            array('mssql', '7.0', array(63), '5.6'),
         );
     }
 
-
     /**
-     * testDeprecatedRemovedExtension
+     * testRemovedExtensionWithAlternative
      *
      * @group removedExtensions
      *
-     * @dataProvider dataDeprecatedRemovedExtension
+     * @dataProvider dataRemovedExtensionWithAlternative
      *
-     * @param string $extensionName     Name of the PHP extension.
-     * @param string $deprecatedIn      The PHP version in which the extension was deprecated.
-     * @param string $removedIn         The PHP version in which the extension was removed.
-     * @param array  $lines             The line numbers in the test file which apply to this extension.
-     * @param string $okVersion         A PHP version in which the extension was still present.
-     * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
-     *                                  if different from the $deprecatedIn version.
-     * @param string $removedVersion    Optional PHP version to test removal message with -
-     *                                  if different from the $removedIn version.
+     * @param string $extensionName  Name of the PHP extension.
+     * @param string $removedIn      The PHP version in which the extension was removed.
+     * @param string $alternative       An alternative extension.
+     * @param array  $lines          The line numbers in the test file which apply to this extension.
+     * @param string $okVersion      A PHP version in which the extension was still present.
+     * @param string $removedVersion Optional PHP version to test removal message with -
+     *                               if different from the $removedIn version.
      *
      * @return void
      */
-    public function testDeprecatedRemovedExtension($extensionName, $deprecatedIn, $removedIn, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
+    public function testRemovedExtensionWithAlternative($extensionName, $removedIn, $alternative, $lines, $okVersion, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
             $this->assertNoViolation($file, $line);
-        }
-
-        if (isset($deprecatedVersion)){
-            $file = $this->sniffFile(self::TEST_FILEE, $deprecatedVersion);
-        }
-        else {
-            $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
-        }
-        foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}");
         }
 
         if (isset($removedVersion)){
@@ -154,43 +130,57 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
+            $this->assertError($file, $line, "Extension '{$extensionName}' is removed since PHP {$removedIn}; Use {$alternative} instead");
         }
     }
 
     /**
      * Data provider.
      *
-     * @see testDeprecatedRemovedExtension()
+     * @see testRemovedExtensionWithAlternative()
      *
      * @return array
      */
-    public function dataDeprecatedRemovedExtension()
+    public function dataRemovedExtensionWithAlternative()
     {
         return array(
-            array('ereg', '5.3', '7.0', array(65), '5.2'),
-            array('mysql_', '5.5', '7.0', array(38), '5.4'),
+            array('activescript', '5.1', 'pecl/activescript', array(3, 4), '5.0'),
+            array('cpdf', '5.1', 'pecl/pdflib', array(6, 7, 8), '5.0'),
+            array('dbx', '5.1', 'pecl/dbx', array(12), '5.0'),
+            array('dio', '5.1', 'pecl/dio', array(14), '5.0'),
+            array('fdf', '5.3', 'pecl/fdf', array(20), '5.2'),
+            array('ingres', '5.1', 'pecl/ingres', array(26), '5.0'),
+            array('mcve', '5.1', 'pecl/mvce', array(30), '5.0'),
+            array('ming', '5.3', 'pecl/ming', array(32), '5.2'),
+            array('ncurses', '5.3', 'pecl/ncurses', array(40), '5.2'),
+            array('oracle', '5.1', 'oci8 or pdo_oci', array(42), '5.0'),
+            array('sybase', '5.3', 'sybase_ct', array(50), '5.2'),
+            array('w32api', '5.1', 'pecl/ffi', array(52), '5.0'),
         );
     }
 
 
     /**
-     * testDeprecatedExtension
+     * testDeprecatedRemovedExtensionWithAlternative
      *
      * @group removedExtensions
      *
-     * @dataProvider dataDeprecatedExtension
+     * @dataProvider dataDeprecatedRemovedExtensionWithAlternative
      *
      * @param string $extensionName     Name of the PHP extension.
      * @param string $deprecatedIn      The PHP version in which the extension was deprecated.
+     * @param string $removedIn         The PHP version in which the extension was removed.
+     * @param string $alternative       An alternative extension.
      * @param array  $lines             The line numbers in the test file which apply to this extension.
      * @param string $okVersion         A PHP version in which the extension was still present.
-     * @param string $deprecatedVersion Optional PHP version to test removal message with -
+     * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
      *                                  if different from the $deprecatedIn version.
+     * @param string $removedVersion    Optional PHP version to test removal message with -
+     *                                  if different from the $removedIn version.
      *
      * @return void
      */
-    public function testDeprecatedExtension($extensionName, $deprecatedIn, $lines, $okVersion, $deprecatedVersion = null)
+    public function testDeprecatedRemovedExtensionWithAlternative($extensionName, $deprecatedIn, $removedIn, $alternative, $lines, $okVersion, $deprecatedVersion = null, $removedVersion = null)
     {
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {
@@ -204,21 +194,82 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+        }
+
+        if (isset($removedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $removedVersion);
+        }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        }
+        foreach($lines as $line) {
+            $this->assertError($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead");
         }
     }
 
     /**
      * Data provider.
      *
-     * @see testDeprecatedExtension()
+     * @see testDeprecatedRemovedExtensionWithAlternative()
      *
      * @return array
      */
-    public function dataDeprecatedExtension()
+    public function dataDeprecatedRemovedExtensionWithAlternative()
     {
         return array(
-            array('mcrypt', '7.1', array(71), '7.0'),
+            array('ereg', '5.3', '7.0', 'pcre', array(65), '5.2'),
+            array('mysql_', '5.5', '7.0', 'mysqli', array(38), '5.4'),
+        );
+    }
+
+
+    /**
+     * testDeprecatedExtensionWithAlternative
+     *
+     * @group removedExtensions
+     *
+     * @dataProvider dataDeprecatedExtensionWithAlternative
+     *
+     * @param string $extensionName     Name of the PHP extension.
+     * @param string $deprecatedIn      The PHP version in which the extension was deprecated.
+     * @param string $alternative       An alternative extension.
+     * @param array  $lines             The line numbers in the test file which apply to this extension.
+     * @param string $okVersion         A PHP version in which the extension was still present.
+     * @param string $deprecatedVersion Optional PHP version to test removal message with -
+     *                                  if different from the $deprecatedIn version.
+     *
+     * @return void
+     */
+    public function testDeprecatedExtensionWithAlternative($extensionName, $deprecatedIn, $alternative, $lines, $okVersion, $deprecatedVersion = null)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        if (isset($deprecatedVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $deprecatedVersion);
+        }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
+        }
+        foreach($lines as $line) {
+            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedExtensionWithAlternative()
+     *
+     * @return array
+     */
+    public function dataDeprecatedExtensionWithAlternative()
+    {
+        return array(
+            array('mcrypt', '7.1', 'openssl (preferred) or pecl/mcrypt once available', array(71), '7.0'),
         );
     }
 

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -46,7 +46,7 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was removed in PHP version {$removedIn}");
+            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is removed since PHP {$removedIn}");
         }
     }
 
@@ -89,12 +89,12 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
 
         $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was deprecated in PHP version {$deprecatedIn}");
+            $this->assertWarning($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}");
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} was deprecated in PHP version {$deprecatedIn} and removed in PHP version {$removedIn}");
+            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
         }
     }
 

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -35,10 +35,10 @@ class RemovedGlobalVariablesSniffTest  extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertWarning($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6 - use php://input instead");
+        $this->assertWarning($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6; Use php://input instead");
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6 and removed since PHP 7.0 - use php://input instead");
+        $this->assertError($file, $line, "Global variable '$" . $varName . "' is deprecated since PHP 5.6 and removed since PHP 7.0; Use php://input instead");
     }
 
     /**

--- a/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -37,7 +37,7 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, $removedIn);
-        $this->assertError($file, $line, "The {$algorithm} hash algorithm is removed since PHP version {$removedIn}");
+        $this->assertError($file, $line, "The {$algorithm} hash algorithm is removed since PHP {$removedIn}");
     }
 
     /**
@@ -76,7 +76,7 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
     public function testRemovedHashAlgorithmsPbkdf2()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, 25, "The salsa20 hash algorithm is removed since PHP version 5.4");
+        $this->assertError($file, 25, "The salsa20 hash algorithm is removed since PHP 5.4");
     }
 
 


### PR DESCRIPTION
**_Note: As this is a massive PR touching all sniffs, reviewing will be easiest to do per commit rather than everything in one go.
To this end, I've tried to create isolated commits which should make reviewing a lot easier._**

This PR addresses three basic principles:
1. All error messages should have modular error codes so individual checks can be selectively disabled without disabling the complete sniff.
2. Defer to the build-in PHPCS native sprintf replacement functionality for the building up of the error message when it is composed of a combination of text and variables.
3. Isolate the determination of whether or not an error/warning should be shown from the creation of the actual message.

Additionally, there was quite some (near) duplicate code in relation to the error messages creation. That has been addressed as well.

To this end, I've:
- Abstracted out the toggling of `addError()`/`addWarning()` to a separate function.
- Rewritten a number of error messages to use the PHPCS native sprint replacement functionality.
- Added a helper method `stringToErrorCode()` to create compound error code strings which will be ok for use in the XML file.
- Added modular error codes to all messages.
  The error code defaults to _'Found'_. For errors being generated based on arrays of input data, the error code is generally build up of the array key + 'Found'.
  If a message already had an error code and did not need further modularization, the error code was left as-is for backward-compatibility.
- For the multi-dimensional array based sniffs a 3-step refactor has taken place to ensure consistency in handling and error messages and to massively reduce code duplication and method complexity.
  - I have introduced an interface to set up the basic pattern these sniffs should follow.
  - Additionally I've introduced three abstract classes and turned all relevant multi-dimensional array sniffs into child classes of these abstract classes.
    - There is a basic `AbstractComplexVersionSniff` class which sets up the minimal defaults and some abstract methods which should be implemented.
    - Then there are two abstract child classes which build onto this parent class, one for removed features, one for new features which further implement default behaviours for each.

As the creation of a large part of the error message text for new/removed features using the abstract classes has been abstracted to parent methods, there are some small textual changes in some of the error messages, which only serve to make the messages being thrown more consistent.

_Note: Even though the lines removed is significantly lower to lines added, I _have_ in fact removed quite a lot of code.
The abstraction introduces a lot of tiny functions with very low complexity and as, of course, all the functions are documented, the added documentation makes the line number diff misleading._

Also:
- improved consistency of variable naming around lowercase token content

Includes additional unit tests for two of the three new utility functions.
### Commit summary:
- Add new `addMessage()` utility method.
  The `addMessage()` method allows for toggling between the `addError()` and the `addWarning()` PHPCS methods.
- Implement the new `addMessage()` method to reduce code duplication.
- Remove the `if/else` and related $isError variable for error/warning when it effectively isn't used anyway.
- Minor other changes to the `ValidIntegers` error handling code.
  - Only call `supportsAbove('7.0')` once.
  - Put the error messages straight into the function as they aren't variable.
  - Break the function calls into several lines as the lines were getting very long.
- Add simple error codes to one-dimensional sniffs.
  Also - including for sniffs which already had a simple error code - :
  - If the error message was non-variable, but assigned to a variable, put it straight into the function.
  - If the line - including the error message - would get quite long, break the function call into several lines.
- Add new `stringToErrorCode()` utility method.
  The `stringToErrorCode()` method is used for converting an arbitrary string to a string usable as an error code for PHPCS messages.
  Includes unit tests for the new method.
- Add variable error codes to array based sniffs.
  These error codes all use the newly introduced `stringToErrorCode()` method.
- Refactor some (near) duplicate error related code to a separate method for the ForbiddenNames sniff
- Minor refactor of error message creation for `ForbiddenBreakContinueVariableArguments` sniff.
  - Change the constants to an array class property, so we can store the error code as the key and the message as the value.
  - Slight code simplification - `$isError` variable is not needed.
  - And, of course, add an $errorCode to the message and use the PHPCS native sprintf functionality.
- Minor message text adjustment for the `LongArrays` sniff.
- Make large version arrays consistent in set up and values.
  Most sniffs for deprecated/removed features use an array with `false` for deprecated and `true` for removed.
  There were three exceptions to this "rule".
  - The array in the `RemovedFunctionParameters` sniff used reversed logic for deprecated/removed compared to all the other deprecated/removed sniffs with version arrays. I.e. `true` was used for deprecated and false for removed.
  - The arrays in the `RemovedExtensions` and the `RemovedGlobalVariables` sniffs used arrays with `-1` for deprecated and `0` for removed (and `1` for present).
    The version arrays for these sniffs have now been made consistent with the other sniffs.
    Also made sure that all such arrays have proper documentation about the values used and their meaning.
- Abstract out the list of ini directive related functions.
- Add new utility function to lowercase top level array keys.
  Includes unit test.
- Implement use of new `arrayKeysToLowercase()` function.
- Improve consistency in variable names relating to lowercase T_STRING content
- Refactor the large version arrays sniffs - step 1
  - Move the retrieving of the relevant information from the array to a separate method.
  - Move the building of the error message to a separate method.
- Refactor the large version array sniffs - step 2
  Introduce an interface and three abstract classes to lay the ground-work for removing a lot of duplicate code.
- Refactor the large version array sniffs - step 3
  Remove the duplicate code and implement the methods introduced via the interface and abstract classes.
  Includes some small textual changes in some of the error messages, which only serves to make the messages being thrown more consistent.
- Add testing for correct alternative to `RemovedExtensions` sniff.
  Also: change the array order with respect to the `sybase` extension as in the old order the check for `sybase_ct` would never run.
- Minor further improvement in modularisation of deprecated/removed errorcodes.
- Minor tidying up (code style and such)
