### PR TITLE
PHP7.1: Add new reserved words to `ForbiddenNamesAsDeclared` sniff

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -53,6 +53,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
         'object'   => '7.0',
         'mixed'    => '7.0',
         'numeric'  => '7.0',
+        'iterable' => '7.1',
+        'void'     => '7.1',
     );
 
 

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -55,17 +55,19 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
     public function dataReservedKeyword()
     {
         return array(
-            array('null', array(22, 34, 46, 58, 71, 84), '7.0', '5.6'),
-            array('true', array(23, 35, 47, 59, 72, 85), '7.0', '5.6'),
-            array('false', array(24, 36, 48, 60, 73, 86), '7.0', '5.6'),
-            array('bool', array(25, 37, 49, 61, 74, 87), '7.0', '5.6'),
-            array('int', array(26, 38, 50, 62, 75, 88), '7.0', '5.6'),
-            array('float', array(27, 39, 51, 63, 76, 89), '7.0', '5.6'),
-            array('string', array(28, 40, 52, 64, 77, 90), '7.0', '5.6'),
-            array('resource', array(29, 41, 53, 65, 78, 91), '7.0', '5.6'),
-            array('object', array(30, 42, 54, 66, 79, 92), '7.0', '5.6'),
-            array('mixed', array(31, 43, 55, 67, 80, 93), '7.0', '5.6'),
-            array('numeric', array(32, 44, 56, 68, 81, 94), '7.0', '5.6'),
+            array('null', array(22, 36, 50, 64, 79, 94), '7.0', '5.6'),
+            array('true', array(23, 37, 51, 65, 80, 95), '7.0', '5.6'),
+            array('false', array(24, 38, 52, 66, 81, 96), '7.0', '5.6'),
+            array('bool', array(25, 39, 53, 67, 82, 97), '7.0', '5.6'),
+            array('int', array(26, 40, 54, 68, 83, 98), '7.0', '5.6'),
+            array('float', array(27, 41, 55, 69, 84, 99), '7.0', '5.6'),
+            array('string', array(28, 42, 56, 70, 85, 100), '7.0', '5.6'),
+            array('resource', array(29, 43, 57, 71, 86, 101), '7.0', '5.6'),
+            array('object', array(30, 44, 58, 72, 87, 102), '7.0', '5.6'),
+            array('mixed', array(31, 45, 59, 73, 88, 103), '7.0', '5.6'),
+            array('numeric', array(32, 46, 60, 74, 89, 104), '7.0', '5.6'),
+            array('iterable', array(33, 47, 61, 75, 90, 105), '7.1', '7.0'),
+            array('void', array(34, 48, 62, 76, 91, 106), '7.1', '7.0'),
         );
     }
 

--- a/Tests/sniff-examples/forbidden_names_as_declared.php
+++ b/Tests/sniff-examples/forbidden_names_as_declared.php
@@ -30,6 +30,8 @@ class resource {}
 class obJeCt {}  // Check case-insensitivity.
 class mixed {}
 class numeric {}
+class iterable {}
+class void {}
 
 interface null {}
 interface true {}
@@ -42,6 +44,8 @@ interface resource {}
 interface object {}
 interface mixed {}
 interface numeric {}
+interface iterable {}
+interface void {}
 
 namespace null;
 namespace true;
@@ -54,6 +58,8 @@ namespace resource;
 namespace object;
 namespace mixed;
 namespace numeric;
+namespace iterable;
+namespace void;
 
 namespace null {}
 namespace true {}
@@ -66,6 +72,8 @@ namespace resource {}
 namespace object {}
 namespace mixed {}
 namespace numeric {}
+namespace iterable {}
+namespace void {}
 
 // Multi-level namespaces.
 namespace MyProject\null\Level;
@@ -79,6 +87,8 @@ namespace MyProject\Sub\resource;
 namespace MyProject\object\Level;
 namespace MyProject\Sub\mixed;
 namespace MyProject\numeric\Level;
+namespace MyProject\Sub\iterable;
+namespace MyProject\void\Level;
 
 // These have to be at the end of the file for PHP 5.2 not to fail on them...
 trait null {}
@@ -92,3 +102,5 @@ trait resource {}
 trait object {}
 trait mixed {}
 trait numeric {}
+trait iterable {}
+trait void {}


### PR DESCRIPTION
See: http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.invalid-class-names