### PR TITLE
Allow for an array of regex patterns in the PregReplaceEModifierSniff

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -281,6 +281,9 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      * Expects to be passed the T_STRING stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
      *
+     * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer, it
+     * will detect whether the array has values or is empty.
+     *
      * @link https://github.com/wimg/PHPCompatibility/issues/120
      * @link https://github.com/wimg/PHPCompatibility/issues/152
      *
@@ -298,24 +301,42 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_STRING) {
+        // Is this one of the tokens this function handles ?
+        if (in_array($tokens[$stackPtr]['code'], array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY), true) === false) {
             return false;
         }
 
+        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+
+        // Deal with short array syntax.
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+                return false;
+            }
+
+            if ($nextNonEmpty === $tokens[$stackPtr]['bracket_closer']) {
+                // No parameters.
+                return false;
+            }
+            else {
+                return true;
+            }
+        }
+
+        // Deal with function calls & long arrays.
         // Next non-empty token should be the open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-        if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
+        if ($nextNonEmpty === false && $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
             return false;
         }
 
-        if (isset($tokens[$openParenthesis]['parenthesis_closer']) === false) {
+        if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
             return false;
         }
 
-        $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
-        $nextNonEmpty     = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $openParenthesis + 1, $closeParenthesis + 1, true);
+        $closeParenthesis = $tokens[$nextNonEmpty]['parenthesis_closer'];
+        $nextNextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextNonEmpty + 1, $closeParenthesis + 1, true);
 
-        if ($nextNonEmpty === $closeParenthesis) {
+        if ($nextNextNonEmpty === $closeParenthesis) {
             // No parameters.
             return false;
         }
@@ -329,6 +350,9 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      *
      * Expects to be passed the T_STRING stack pointer for the function call.
      * If passed a T_STRING which is *not* a function call, the behaviour is unreliable.
+     *
+     * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
+     * it will return the number of values in the array.
      *
      * @link https://github.com/wimg/PHPCompatibility/issues/111
      * @link https://github.com/wimg/PHPCompatibility/issues/114
@@ -359,6 +383,9 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      * pointer and raw parameter value for all parameters. Index will be 1-based.
      * If no parameters are found, will return an empty array.
      *
+     * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
+     * it will tokenize the values / key/value pairs contained in the array call.
+     *
      * @param PHP_CodeSniffer_File $phpcsFile     The file being scanned.
      * @param int                  $stackPtr      The position of the function call token.
      *
@@ -370,23 +397,34 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return array();
         }
 
-        // Ok, we know we have a T_STRING with parameters and valid open & close parenthesis.
+        // Ok, we know we have a T_STRING, T_ARRAY or T_OPEN_SHORT_ARRAY with parameters
+        // and valid open & close brackets/parenthesis.
         $tokens = $phpcsFile->getTokens();
 
-        $openParenthesis  = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-        $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
+        // Mark the beginning and end tokens.
+        if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
+            $opener = $stackPtr;
+            $closer = $tokens[$stackPtr]['bracket_closer'];
+
+            $nestedParenthesisCount = 0;
+        }
+        else {
+            $opener = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+            $closer = $tokens[$opener]['parenthesis_closer'];
+
+            $nestedParenthesisCount = 1;
+        }
 
         // Which nesting level is the one we are interested in ?
-        $nestedParenthesisCount = 1;
-        if (isset($tokens[$openParenthesis]['nested_parenthesis'])) {
-            $nestedParenthesisCount = count($tokens[$openParenthesis]['nested_parenthesis']) + 1;
+        if (isset($tokens[$opener]['nested_parenthesis'])) {
+            $nestedParenthesisCount += count($tokens[$opener]['nested_parenthesis']);
         }
 
         $parameters = array();
-        $nextComma  = $openParenthesis;
-        $paramStart = $openParenthesis + 1;
+        $nextComma  = $opener;
+        $paramStart = $opener + 1;
         $cnt        = 1;
-        while ($nextComma = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS, T_OPEN_SHORT_ARRAY), $nextComma + 1, $closeParenthesis + 1)) {
+        while ($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY), $nextComma + 1, $closer + 1)) {
             // Ignore anything within short array definition brackets.
             if (
                 $tokens[$nextComma]['type'] === 'T_OPEN_SHORT_ARRAY'
@@ -411,8 +449,8 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 continue;
             }
 
-            // Ignore closing parenthesis if not 'ours'.
-            if ($tokens[$nextComma]['type'] === 'T_CLOSE_PARENTHESIS' && $nextComma !== $closeParenthesis) {
+            // Ignore closing parenthesis/bracket if not 'ours'.
+            if ($tokens[$nextComma]['type'] === $tokens[$closer]['type'] && $nextComma !== $closer) {
                 continue;
             }
 
@@ -424,7 +462,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             // Check if there are more tokens before the closing parenthesis.
             // Prevents code like the following from setting a third parameter:
             // functionCall( $param1, $param2, );
-            $hasNextParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextComma + 1, $closeParenthesis, true, null, true);
+            $hasNextParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextComma + 1, $closer, true, null, true);
             if ($hasNextParam === false) {
                 break;
             }

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -141,6 +141,13 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
         }
 
         $regexFirstChar = substr($regex, 0, 1);
+
+        // Make sure that the character identified as the delimiter is valid.
+        // Otherwise, it is a false positive caused by the string concatenation.
+        if (preg_match('`[a-z0-9\\\\ ]`i', $regexFirstChar) === 1) {
+            return;
+        }
+
         if (isset($this->doublesSeparators[$regexFirstChar])) {
             $regexEndPos = strrpos($regex, $this->doublesSeparators[$regexFirstChar]);
         }

--- a/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -34,7 +34,8 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
      *
      * @covers PHPCompatibility_Sniff::doesFunctionCallHaveParameters
      *
-     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
+     * @param int    $stackPtr Stack pointer for a function call T_STRING token
+     *                         or a T_ARRAY token in the test file.
      * @param string $expected The expected fully qualified class name.
      */
     public function testDoesFunctionCallHaveParameters($stackPtr, $expected) {
@@ -52,6 +53,7 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
     public function dataDoesFunctionCallHaveParameters()
     {
         return array(
+            // Function calls.
             array(12, false),
             array(17, false),
             array(23, false),
@@ -59,6 +61,22 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
             array(42, true),
             array(50, true),
             array(60, true),
+
+            // Arrays.
+            array(80, false),
+            array(89, false),
+            array(99, false),
+            array(111, false),
+            array(121, false),
+            array(129, false),
+            array(138, false),
+            array(149, false),
+            array(163, true),
+            array(175, true),
+            array(189, true),
+            array(199, true),
+            array(210, true),
+            array(223, true),
         );
     }
 

--- a/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/Tests/BaseClass/GetFunctionParametersTest.php
@@ -34,8 +34,9 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameters
      *
-     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param int    $stackPtr Stack pointer for a function call T_STRING,
+     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
+     * @param string $expected The expected parameter array.
      */
     public function testGetFunctionCallParameters($stackPtr, $expected)
     {
@@ -152,6 +153,76 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
                        ),
 
             ),
+
+            // Long array.
+            array(1422, array(
+                        1 => array(
+                              'start' => 1424,
+                              'end'   => 1430,
+                              'raw'   => 'some_call(5, 1)',
+                             ),
+                        2 => array(
+                              'start' => 1432,
+                              'end'   => 1436,
+                              'raw'   => 'another(1)',
+                             ),
+                        3 => array(
+                              'start' => 1438,
+                              'end'   => 1448,
+                              'raw'   => 'why(5, 1, 2)',
+                             ),
+                        4 => array(
+                              'start' => 1450,
+                              'end'   => 1451,
+                              'raw'   => '4',
+                             ),
+                        5 => array(
+                              'start' => 1453,
+                              'end'   => 1454,
+                              'raw'   => '5',
+                             ),
+                        6 => array(
+                              'start' => 1456,
+                              'end'   => 1457,
+                              'raw'   => '6',
+                             ),
+                       ),
+            ),
+
+            // Short array.
+            array(1667, array(
+                        1 => array(
+                              'start' => 1668,
+                              'end'   => 1668,
+                              'raw'   => '0',
+                             ),
+                        2 => array(
+                              'start' => 1670,
+                              'end'   => 1671,
+                              'raw'   => '0',
+                             ),
+                        3 => array(
+                              'start' => 1673,
+                              'end'   => 1677,
+                              'raw'   => 'date(\'s\')',
+                             ),
+                        4 => array(
+                              'start' => 1679,
+                              'end'   => 1683,
+                              'raw'   => 'date(\'m\')',
+                             ),
+                        5 => array(
+                              'start' => 1685,
+                              'end'   => 1689,
+                              'raw'   => 'date(\'d\')',
+                             ),
+                        6 => array(
+                              'start' => 1691,
+                              'end'   => 1695,
+                              'raw'   => 'date(\'Y\')',
+                             ),
+                       ),
+            ),
         );
     }
 
@@ -163,8 +234,9 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameter
      *
-     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param int    $stackPtr Stack pointer for a function call T_STRING,
+     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
+     * @param string $expected The expected array for the specific parameter.
      */
     public function testGetFunctionCallParameter($stackPtr, $paramPosition, $expected)
     {
@@ -206,6 +278,42 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
                            'raw'   => '$arrStDt[2]',
                           ),
             ),
+            array(1296, 1, array(
+                           'start' => 1298,
+                           'end'   => 1299,
+                           'raw'   => '1',
+                          ),
+            ),
+            array(1296, 7, array(
+                           'start' => 1316,
+                           'end'   => 1318,
+                           'raw'   => 'true',
+                          ),
+            ),
+            array(1422, 3, array(
+                           'start' => 1438,
+                           'end'   => 1448,
+                           'raw'   => 'why(5, 1, 2)',
+                          ),
+            ),
+            array(1466, 2, array(
+                           'start' => 1474,
+                           'end'   => 1479,
+                           'raw'   => '\'b\' => $b',
+                          ),
+            ),
+            array(1611, 1, array(
+                           'start' => 1612,
+                           'end'   => 1624,
+                           'raw'   => 'str_replace("../", "/", trim($value))',
+                          ),
+            ),
+            array(1814, 3, array(
+                           'start' => 1828,
+                           'end'   => 1850,
+                           'raw'   => '(isset($c) ? 6 => $c : 6 => null)',
+                          ),
+            ),
         );
     }
 
@@ -217,8 +325,9 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameterCount
      *
-     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param int    $stackPtr Stack pointer for a function call T_STRING,
+     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
+     * @param string $expected The expected parameter count.
      */
     public function testGetFunctionCallParameterCount($stackPtr, $expected)
     {
@@ -285,6 +394,26 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
             array(1184, 1),
             array(1215, 1),
             array(1241, 1),
+
+            // Long arrays.
+            array(1296, 7),
+            array(1326, 1),
+            array(1349, 6),
+            array(1384, 6),
+            array(1422, 6),
+            array(1466, 3),
+            array(1494, 3),
+            array(1535, 3),
+
+            // Short arrays.
+            array(1582, 7),
+            array(1611, 1),
+            array(1633, 6),
+            array(1667, 6),
+            array(1704, 6),
+            array(1747, 3),
+            array(1774, 3),
+            array(1814, 3),
         );
     }
 

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -165,6 +165,7 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(167),
             array(178),
             array(187),
+            array(201),
         );
     }
 

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -84,6 +84,21 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(127, 'preg_filter'),
             array(142, 'preg_filter'),
             array(148, 'preg_filter'),
+
+            // Array of patterns.
+            array(162),
+            array(163),
+            array(164),
+            array(165),
+            array(166),
+
+            array(173),
+            array(174),
+            array(175),
+            array(176),
+            array(177),
+
+            array(182), // Three errors.
         );
     }
 
@@ -143,8 +158,13 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(107),
             array(109),
 
-			// Issue 265 - mixed string quotes.
+            // Issue 265 - mixed string quotes.
             array(157),
+
+            // Issues https://wordpress.org/support/topic/wrong-error-preg_replace-e-modifier-is-forbidden-since-php-7-0/
+            array(167),
+            array(178),
+            array(187),
         );
     }
 

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -195,3 +195,7 @@ $cleaned = preg_replace(
   ),
   $data
 );
+
+// Another false positive.
+// https://wordpress.org/support/topic/wrong-error-preg_replace-e-modifier-is-forbidden-since-php-7-0/
+$this->value = preg_replace( $this->field['preg']['pattern'], $this->field['preg']['replacement'], $this->value );

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -155,3 +155,43 @@ preg_replace('/something' . preg_quote($variable) . 'something else/e', $Replace
 
 // Issue 265 - build up string with varying quotes - this should be ok.
 preg_replace('~'.testme()."~s", '', "foo bar was here");
+
+// Passing an array of patterns:
+preg_replace(
+    array(
+        "/double-quoted/e",
+        '/single-quoted/e',
+        '#hash-chars (common)#e',
+        '!exclamations (why not?!e',
+        '/some text/emS',
+        '/some text/i', // Ok
+    ), $Replace, $Source
+);
+// Array of patterns with array keys:
+preg_replace(
+    [
+        'ae' => "/double-quoted/e",
+        'be' => '/single-quoted/e',
+        'ce' => '#hash-chars (common)#e',
+        'de' => '!exclamations (why not?!e',
+        'ee' => '/some text/emS',
+        'ef' => '/some text/i', // Ok
+    ], $Replace, $Source
+);
+// Single line array.
+preg_replace(array("/double-quoted/e", '/something'.preg_quote($variable, '/').'something else/e', '/single-quoted/e',), $Replace, $Source);
+
+
+// Array of patterns, check against false positive - this should be ok.
+// https://wordpress.org/support/topic/wrong-error-preg_replace-e-modifier-is-forbidden-since-php-7-0/
+$cleaned = preg_replace(
+  array(
+    '/<!--[^\[><](.*?)-->/s',
+    '#(?ix)(?>[^\S ]\s*|\s{2,})(?=(?:(?:[^<]++|<(?!/?(?:textarea|pre)\b))*+)(?:<(?>textarea|pre)\b|\z))#'
+  ),
+  array(
+    '',
+    ' '
+  ),
+  $data
+);

--- a/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
+++ b/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
@@ -19,3 +19,29 @@ some_function(/*nothing here*/);
 some_function( 1 );
 some_function(1,2,3);
 some_function(true);
+
+/*
+ * Even though a language construct and not a function call, the function should work just as well for arrays.
+ */
+
+/*
+ * No parameters.
+ */
+$foo = array();
+$foo = array(     );
+$foo = array( /*nothing here*/ );
+$foo = array(/*nothing here*/);
+$bar = [];
+$bar = [     ];
+$bar = [ /*nothing here*/ ];
+$bar = [/*nothing here*/];
+
+/*
+ * Has parameters.
+ */
+$foo = array( 1 );
+$foo = array(1,2,3);
+$foo = array(true);
+$bar = [ 1 ];
+$bar = [1,2,3];
+$bar = [true];

--- a/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -49,7 +49,7 @@ gettimeofday (
 json_encode( array(), );
 
 /*
- * Issue #211 - deal with short array syntax
+ * Issue #211 - deal with short array syntax within parameters.
  */
 json_encode(['a' => 'b',]);
 json_encode(['a' => $a,]);
@@ -73,3 +73,26 @@ json_encode(['a' => $a, 'b' => $b,] + ['c' => $c]);
 json_encode(['a' => $a, 'b' => $b,] + ['c' => $c,]);
 json_encode(['a' => $a, 'b' => $b, 'c' => $c]);
 json_encode(['a' => $a, 'b' => $b, 'c' => $c,] + ['c' => $c, 'd' => $d,]);
+
+/*
+ * Even though a language construct and not a function call, the functions should
+ * work just as well for long arrays.
+ */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+$foo = array(str_replace("../", "/", trim($value))); // 1
+$foo = array($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+$foo = array(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+$foo = array(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+$foo = array('a' => $a, 'b' => $b, 'c' => $c);
+$foo = array('a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null));
+$foo = array(0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null));
+
+// Same goes for short arrays.
+$bar = [ 1, 2, 3, 4, 5, 6, true ];
+$bar = [str_replace("../", "/", trim($value))]; // 1
+$bar = [$stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]]; // 6
+$bar = [0, 0, date('s'), date('m'), date('d'), date('Y')]; // 6
+$bar = [some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6]; // 6
+$bar = ['a' => $a, 'b' => $b, 'c' => $c];
+$bar = ['a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null)];
+$bar = [0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null)];


### PR DESCRIPTION
The first parameter of a `preg_replace()` function call can be either a string or an array.
Up to now, the sniff always treated the first parameter as a string, leading to false positives (and potentially missing messages for regexes within a passed array).

Ref: http://php.net/manual/en/function.preg-replace.php

Now, each individual entry in the array will be analysed and passed along for inspection.

This PR also fixes potential false positives caused by string concatenation which caused the delimiters to be misidentified.

Ref: http://php.net/manual/en/regexp.reference.delimiters.php

Fixes https://wordpress.org/support/topic/wrong-error-preg_replace-e-modifier-is-forbidden-since-php-7-0/

/cc @octalmage 