### PR TITLE
Fix false positives on assign-by-reference within function call in ForbiddenCallTimePassByReferenceSniff

### DIFF
--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -179,6 +179,24 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
                 case T_CLOSE_PARENTHESIS:
                     break;
 
+                // Prevent false positive on assign by reference and compare with reference
+                // with function call parameters.
+                case T_EQUAL:
+                case T_AND_EQUAL:
+                case T_OR_EQUAL:
+                case T_CONCAT_EQUAL:
+                case T_DIV_EQUAL:
+                case T_MINUS_EQUAL:
+                case T_MOD_EQUAL:
+                case T_MUL_EQUAL:
+                case T_PLUS_EQUAL:
+                case T_XOR_EQUAL:
+                case T_SL_EQUAL:
+                case T_SR_EQUAL:
+                case T_IS_EQUAL:
+                case T_IS_IDENTICAL:
+                    break;
+
                 // Unfortunately the tokenizer fails to recognize global constants,
                 // class-constants and -attributes. Any of these are returned is
                 // treated as T_STRING.
@@ -200,6 +218,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
                     // If not a class constant: fall through.
 
                 default:
+                    // Deal with T_POW_EQUAL which doesn't exist in PHPCS 1.x
+                    if (defined('T_POW_EQUAL') && $tokens[$tokenBefore]['type'] === 'T_POW_EQUAL') {
+                        break;
+                    }
+
                     // The found T_BITWISE_AND represents a pass-by-reference.
                     return true;
             }

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -76,6 +76,7 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
             array(44), // Bad: call time pass by reference.
             array(45), // Bad: call time pass by reference.
             array(49), // Bad: multiple call time pass by reference.
+            array(71), // Bad: call time pass by reference.
         );
     }
 
@@ -121,6 +122,26 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
 
             array(51), // OK: No variables.
             array(53), // OK: Outside scope of this sniff.
+
+            // Assign by reference within function call.
+            array(56),
+            array(57),
+            array(58),
+            array(59),
+            array(60),
+            array(61),
+            array(62),
+            array(63),
+            array(64),
+            array(65),
+            array(66),
+            array(67),
+            array(68),
+            array(69),
+
+            // Comparison with reference.
+            array(74),
+            array(75),
         );
     }
 

--- a/Tests/sniff-examples/call_time_pass_by_reference.php
+++ b/Tests/sniff-examples/call_time_pass_by_reference.php
@@ -51,3 +51,25 @@ abcd(&$x, &$y, $z, &$aa = false); // Bad: multiple pass by reference.
 bcd(10, true, MYCONST); // OK: does not contain variables.
 
 cde((&$abc)); // OK: outside of the scope of this sniff - will result in parse error.
+
+// Issue https://github.com/wimg/PHPCompatibility/issues/68
+$attr  = $this->doExtraAttributes("h$level", $dummy =& $matches[3]); // OK: assign by reference.
+if (!is_null($done = &$this->cacheKey('autoPurgeCache'))) {} // OK: assign by reference.
+def( $dummy .= &$b );
+def( $dummy += &$b );
+def( $dummy -= &$b );
+def( $dummy *= &$b );
+def( $dummy /= &$b );
+def( $dummy %= &$b );
+def( $dummy **= &$b );
+def( $dummy &= &$b );
+def( $dummy |= &$b );
+def( $dummy ^= &$b );
+def( $dummy <<= &$b );
+def( $dummy >>= &$b );
+
+def( &$dummy .= $b ); // Bad: pass by reference.
+
+// Ok: Comparisons passed as function parameter.
+efg( true == &$b );
+efg( true === &$b );


### PR DESCRIPTION
While assigning to a variable within a function call or conditional might not be good practice, the reality is that there is plenty of userland code out there using it.

This PR should fix false positives for variables being assigned by reference within function calls.

It also should fix false positives for variables being compared by reference within function calls.

Includes additional unit tests.

Refs:
http://php.net/manual/en/language.references.whatdo.php#language.references.whatdo.assign
http://php.net/manual/en/language.operators.assignment.php#40084

Fixes https://github.com/wimg/PHPCompatibility/issues/68#issuecomment-231366445
Fixes https://github.com/wimg/PHPCompatibility/issues/68#issuecomment-265814055

/cc @octalmage 