### PR TITLE
Make it clearer that non-version specific parsed sniff files are also being cached

### DIFF
--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -89,13 +89,13 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
      * @param string $targetPhpVersion Value of 'testVersion' to set on PHPCS object
      * @return PHP_CodeSniffer_File|false File object
      */
-    public function sniffFile($filename, $targetPhpVersion = null)
+    public function sniffFile($filename, $targetPhpVersion = 'none')
     {
         if ( isset(self::$sniffFiles[$filename][$targetPhpVersion])) {
             return self::$sniffFiles[$filename][$targetPhpVersion];
         }
 
-        if (null !== $targetPhpVersion) {
+        if ('none' !== $targetPhpVersion) {
             PHP_CodeSniffer::setConfigData('testVersion', $targetPhpVersion, true);
         }
 


### PR DESCRIPTION
They already were on the array key `''` (empty string), but this behaviour might change at any moment, so better be safe than sorry.