### PR TITLE
Minor tweaks to the utility tests

### DIFF
--- a/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -16,7 +16,13 @@
 class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestFrame
 {
 
-	public $filename = '../sniff-examples/utility-functions/does_function_call_have_parameters.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'does_function_call_have_parameters.php';
 
     /**
      * testDoesFunctionCallHaveParameters

--- a/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
@@ -16,7 +16,13 @@
 class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = '../sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'get_fqclassname_from_double_colon_token.php';
 
     /**
      * testGetFQClassNameFromDoubleColonToken

--- a/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
@@ -16,7 +16,13 @@
 class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = '../sniff-examples/utility-functions/get_fqclassname_from_new_token.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'get_fqclassname_from_new_token.php';
 
     /**
      * testGetFQClassNameFromNewToken

--- a/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -16,7 +16,13 @@
 class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = '../sniff-examples/utility-functions/get_fqextended_classname.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'get_fqextended_classname.php';
 
     /**
      * testGetFQExtendedClassName

--- a/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/Tests/BaseClass/GetFunctionParametersTest.php
@@ -16,7 +16,13 @@
 class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = '../sniff-examples/utility-functions/get_function_parameters.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'get_function_parameters.php';
 
     /**
      * testGetFunctionCallParameters

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -15,7 +15,20 @@
 abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
 {
 
-    public $filename;
+    /**
+     * The file name for the file containing the test cases within the $case_directory.
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * The path to the directory containing the test file for stand-alone method tests
+     * relative to this file.
+     *
+     * @var string
+     */
+    protected $case_directory = '../sniff-examples/utility-functions/';
 
     /**
      * The PHP_CodeSniffer_File object containing parsed contents of this file.
@@ -43,7 +56,7 @@ abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
 
         $this->helperClass = new BaseClass_TestHelperPHPCompatibility;
 
-        $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->filename;
+        $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->case_directory . $this->filename;
         $phpcs    = new PHP_CodeSniffer();
 
         if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<')) {

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -5,10 +5,6 @@
  * @package PHPCompatibility
  */
 
-if (class_exists('BaseSniffTest', true) === false) {
-    require_once dirname(dirname(__FILE__)) . '/BaseSniffTest.php';
-}
-
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
  *
@@ -16,7 +12,7 @@ if (class_exists('BaseSniffTest', true) === false) {
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class BaseClass_MethodTestFrame extends BaseSniffTest
+abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
 {
 
     public $filename;

--- a/Tests/BaseClass/TokenHasScopeTest.php
+++ b/Tests/BaseClass/TokenHasScopeTest.php
@@ -16,7 +16,13 @@
 class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
 {
 
-    public $filename = '../sniff-examples/utility-functions/token_has_scope.php';
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'token_has_scope.php';
 
     /**
      * testTokenHasScope


### PR DESCRIPTION
Uncouple the `MethodTestFrame` from the `BaseSniffTest` & set the directory path for the utility test files in the parent class.

Also:
- Add documentation for the `$filename` property in all utility test files.
- Make the property `protected`.