### PR TITLE
Make sure all test classes have one or more consistent group annotations

### DIFF
--- a/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -9,6 +9,9 @@
 /**
  * Function parameters function tests
  *
+ * @group utilityDoesFunctionCallHaveParameters
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
 
     /**
      * testDoesFunctionCallHaveParameters
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataDoesFunctionCallHaveParameters
      *

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -9,6 +9,9 @@
 /**
  * Generic sniff functions sniff tests
  *
+ * @group utilityMiscFunctions
+ * @group utilityFunctions
+ *
  * @uses    PHPUnit_Framework_TestCase
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -39,8 +42,6 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
 
    /**
      * testStringToErrorCode
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataStringToErrorCode
      *
@@ -75,8 +76,6 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
    /**
      * testStripQuotes
      *
-     * @group utilityFunctions
-     *
      * @dataProvider dataStripQuotes
      *
      * @covers PHPCompatibility_Sniff::stripQuotes
@@ -110,8 +109,6 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
 
     /**
      * testArrayKeysToLowercase
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataArrayKeysToLowercase
      *

--- a/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
@@ -9,6 +9,9 @@
 /**
  * Classname determination from double colon token function tests
  *
+ * @group utilityGetFQClassNameFromDoubleColonToken
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodT
 
     /**
      * testGetFQClassNameFromDoubleColonToken
-     *
-     * @group utilityFunctions
      *
      * @requires PHP 5.3
      *

--- a/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
@@ -9,6 +9,9 @@
 /**
  * Classname determination function tests
  *
+ * @group utilityGetFQClassNameFromNewToken
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
 
     /**
      * testGetFQClassNameFromNewToken
-     *
-     * @group utilityFunctions
      *
      * @requires PHP 5.3
      *

--- a/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -9,6 +9,9 @@
 /**
  * Extended class name determination function tests
  *
+ * @group utilityGetFQExtendedClassName
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -22,8 +25,6 @@ class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
      * testGetFQExtendedClassName
      *
      * @requires PHP 5.3
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataGetFQExtendedClassName
      *

--- a/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/Tests/BaseClass/GetFunctionParametersTest.php
@@ -9,6 +9,9 @@
 /**
  * Function parameters count function tests
  *
+ * @group utilityGetFunctionParameters
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
 
     /**
      * testGetFunctionCallParameters
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataGetFunctionCallParameters
      *
@@ -152,8 +153,6 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
     /**
      * testGetFunctionCallParameter
      *
-     * @group utilityFunctions
-     *
      * @dataProvider dataGetFunctionCallParameter
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameter
@@ -207,8 +206,6 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
 
     /**
      * testGetFunctionCallParameterCount
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataGetFunctionCallParameterCount
      *

--- a/Tests/BaseClass/TokenHasScopeTest.php
+++ b/Tests/BaseClass/TokenHasScopeTest.php
@@ -9,6 +9,9 @@
 /**
  * Token scope function tests
  *
+ * @group utilityTokenScope
+ * @group utilityFunctions
+ *
  * @uses    BaseClass_MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
 
     /**
      * testTokenHasScope
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataTokenHasScope
      *
@@ -84,8 +85,6 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
     /**
      * testInClassScope
      *
-     * @group utilityFunctions
-     *
      * @dataProvider dataInClassScope
      *
      * @covers PHPCompatibility_Sniff::inClassScope
@@ -119,8 +118,6 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
 
     /**
      * testInUseScope
-     *
-     * @group utilityFunctions
      *
      * @dataProvider dataInUseScope
      *

--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Constant arrays using define in PHP 7.0 sniff test file
  *
+ * @group constantArraysUsingDefine
+ * @group constants
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -19,8 +22,6 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
 
     /**
      * Verify that checking for a specific version works
-     *
-     * @group constantArraysUsingDefine
      *
      * @dataProvider dataConstantArraysUsingDefine
      *
@@ -55,8 +56,6 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group constantArraysUsingDefine
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/DefaultTimezoneRequiredSniffTest.php
+++ b/Tests/Sniffs/PHP/DefaultTimezoneRequiredSniffTest.php
@@ -8,6 +8,9 @@
 /**
  * Default timezone required sniff test
  *
+ * @group defaultTimezoneRequired
+ * @group iniDirectives
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Deprecated functions sniff tests
  *
+ * @group deprecatedFunctions
+ * @group functions
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Deprecated ini directives sniff tests
  *
+ * @group deprecatedIniDirectives
+ * @group iniDirectives
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -20,8 +23,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * Test valid directive
-     *
-     * @group IniDirectives
      *
      * @return void
      */
@@ -35,8 +36,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testDeprecatedRemovedDirectives
-     *
-     * @group IniDirectives
      *
      * @dataProvider dataDeprecatedRemovedDirectives
      *
@@ -115,8 +114,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     /**
      * testDeprecatedDirectives
      *
-     * @group IniDirectives
-     *
      * @dataProvider dataDeprecatedDirectives
      *
      * @param string $iniName           Name of the ini directive.
@@ -175,8 +172,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     /**
      * testRemovedWithAlternative
      *
-     * @group IniDirectives
-     *
      * @dataProvider dataRemovedWithAlternative
      *
      * @param string $iniName        Name of the ini directive.
@@ -224,8 +219,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testRemovedDirectives
-     *
-     * @group IniDirectives
      *
      * @dataProvider dataRemovedDirectives
      *

--- a/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Deprecated new reference sniff tests
  *
+ * @group deprecatedNewReference
+ * @group references
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -8,6 +8,8 @@
 /**
  * PHP4 style constructors sniff test
  *
+ * @group deprecatedPHP4StyleConstructors
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Koen Eelen <koen.eelen@cu.be>
@@ -18,8 +20,6 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
 
     /**
      * Test PHP4 style constructors.
-     *
-     * @group deprecatedPHP4Constructors
      *
      * @dataProvider dataIsDeprecated
      *
@@ -54,8 +54,6 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
 
     /**
      * Test valid methods with the same name as the class.
-     *
-     * @group deprecatedPHP4Constructors
      *
      * @dataProvider dataValidMethods
      *

--- a/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Empty with non variable sniff test file
  *
+ * @group emptyNonVariable
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +21,6 @@ class EmptyNonVariableSniffTest extends BaseSniffTest
 
     /**
      * testEmptyNonVariable
-     *
-     * @group emptyNonVariable
      *
      * @dataProvider dataEmptyNonVariable
      *
@@ -79,8 +79,6 @@ class EmptyNonVariableSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group emptyNonVariable
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
@@ -11,6 +11,9 @@
  *
  * Checks for using break and continue outside of a looping structure.
  *
+ * @group forbiddenBreakContinueOutsideLoop
+ * @group breakContinue
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -21,8 +24,6 @@ class ForbiddenBreakContinueOutsideLoopSniffTest extends BaseSniffTest
 
     /**
      * testForbiddenBreakContinueOutsideLoop
-     *
-     * @group forbiddenBreakContinueOutsideLoop
      *
      * @dataProvider dataBreakContinueOutsideLoop
      *
@@ -62,8 +63,6 @@ class ForbiddenBreakContinueOutsideLoopSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group forbiddenBreakContinueOutsideLoop
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -13,6 +13,9 @@
  *     break $varname
  *     continue $varname
  *
+ * @group forbiddenBreakContinueVariableArguments
+ * @group breakContinue
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -48,8 +51,6 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
      *
      * In PHP 5.3, none of the statements should give an error.
      *
-     * @group forbiddenBreakContinue
-     *
      * @return void
      */
     public function testAllowedBreakAndContinueVariableArgument()
@@ -61,8 +62,6 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 
     /**
      * testBreakAndContinueVariableArgument
-     *
-     * @group forbiddenBreakContinue
      *
      * @dataProvider dataBreakAndContinueVariableArgument
      *
@@ -106,8 +105,6 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group forbiddenBreakContinue
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Forbidden call time pass by reference sniff test
  *
+ * @group forbiddenCallTimePassByReference
+ * @group references
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -39,8 +42,6 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
 
     /**
      * testForbiddenCallTimePassByReference
-     *
-     * @group forbiddenCallTimePassByReference
      *
      * @dataProvider dataForbiddenCallTimePassByReference
      *
@@ -82,8 +83,6 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group forbiddenCallTimePassByReference
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Empty list() assignments have been removed in PHP 7.0 sniff test file
  *
+ * @group forbiddenEmptyListAssignment
+ * @group listAssignments
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -17,8 +20,6 @@ class ForbiddenEmptyListAssignmentSniffTest extends BaseSniffTest
 {
     /**
      * testEmptyListAssignment
-     *
-     * @group forbiddenEmptyListAssignment
      *
      * @dataProvider dataEmptyListAssignment
      *
@@ -55,8 +56,6 @@ class ForbiddenEmptyListAssignmentSniffTest extends BaseSniffTest
 
     /**
      * testValidListAssignment
-     *
-     * @group forbiddenEmptyListAssignment
      *
      * @dataProvider dataValidListAssignment
      *

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Functions can not have multiple parameters with the same name since PHP 7.0 sniff test
  *
+ * @group forbiddenFunctionParametersWithSameName
+ * @group functionDeclarations
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -17,8 +20,6 @@ class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
 {
     /**
      * testSettingTestVersion
-     *
-     * @group forbiddenFunctionParamsSameName
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Global with variable variables have been removed in PHP 7.0 sniff test file
  *
+ * @group forbiddenGlobalVariableVariable
+ * @group variableVariables
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Forbidden names as declared name for class, interface, trait or namespace.
  *
+ * @group forbiddenNamesAsDeclared
+ * @group reservedKeywords
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
 
     /**
      * testReservedKeyword
-     *
-     * @group forbiddenNamesAsDeclared
      *
      * @dataProvider dataReservedKeyword
      *
@@ -74,8 +75,6 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group forbiddenNamesAsDeclared
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Forbidden names as function invocations sniff test file
  *
+ * @group forbiddenNamesAsInvokedFunctions
+ * @group reservedKeywords
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Forbidden names sniff test
  *
+ * @group forbiddenNames
+ * @group reservedKeywords
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -18,8 +21,6 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
 
     /**
      * testNamespace
-     *
-     * @group forbiddenNames
      *
      * @dataProvider usecaseProvider
      *
@@ -86,8 +87,6 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
     /**
      * testCorrectUsageOfKeywords
      *
-     * @group forbiddenNames
-     *
      * @return void
      */
     public function testCorrectUsageOfKeywords()
@@ -103,8 +102,6 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
     /**
      * testCorrectUsageUseFunctionConst
      *
-     * @group forbiddenNames
-     *
      * @return void
      */
     public function testCorrectUsageUseFunctionConst()
@@ -115,8 +112,6 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
 
     /**
      * Test setting test version option
-     *
-     * @group forbiddenNames
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
+ * @group forbiddenNegativeBitshift
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -19,8 +21,6 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
 
     /**
      * testForbiddenNegativeBitshift
-     *
-     * @group forbiddenNegativeBitshift
      *
      * @dataProvider dataForbiddenNegativeBitshift
      *
@@ -54,8 +54,6 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group forbiddenNegativeBitshift
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Switch statements can only have one default case in PHP 7.0
  *
+ * @group forbiddenSwitchWithMultipleDefaultBlocks
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -19,8 +21,6 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniffTest extends BaseSniffTest
 
     /**
      * testForbiddenSwitchWithMultipleDefaultBlocks
-     *
-     * @group forbiddenSwitchMultipleDefault
      *
      * @dataProvider dataForbiddenSwitchWithMultipleDefaultBlocks
      *
@@ -56,8 +56,6 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniffTest extends BaseSniffTest
 
     /**
      * testValidSwitchStatement
-     *
-     * @group forbiddenSwitchMultipleDefault
      *
      * @dataProvider dataValidSwitchStatement
      *

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Internal Interfaces Sniff tests
  *
+ * @group internalInterfaces
+ * @group interfaces
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
+++ b/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Late static binding sniff test file
  *
+ * @group lateStaticBinding
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +21,6 @@ class LateStaticBindingSniffTest extends BaseSniffTest
 
     /**
      * testLateStaticBinding
-     *
-     * @group lateStaticBinding
      *
      * @dataProvider dataLateStaticBinding
      *
@@ -56,8 +56,6 @@ class LateStaticBindingSniffTest extends BaseSniffTest
     /**
      * testLateStaticBindingOutsideClassScope
      *
-     * @group lateStaticBinding
-     *
      * @dataProvider dataLateStaticBindingOutsideClassScope
      *
      * @param int $line The line number.
@@ -87,8 +85,6 @@ class LateStaticBindingSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group lateStaticBinding
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Long Arrays Sniff tests
  *
+ * @group longArrays
+ * @group superglobals
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -20,8 +23,6 @@ class LongArraysSniffTest extends BaseSniffTest
 
     /**
      * testLongVariable
-     *
-     * @group longArrays
      *
      * @dataProvider dataLongVariable
      *
@@ -74,8 +75,6 @@ class LongArraysSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group longArrays
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Deprecated Mbstring regex replace e modifier test file.
  *
+ * @group mbstringReplaceEModifier
+ * @group regexEModifier
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +22,6 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
 
     /**
      * testMbstringEModifier
-     *
-     * @group mbstringEModifier
      *
      * @dataProvider dataMbstringEModifier
      *
@@ -59,8 +60,6 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group mbstringEModifier
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Anonymous Classes Sniff tests
  *
+ * @group newAnonymousClasses
+ * @group closures
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Classes Sniff tests
  *
+ * @group newClasses
+ * @group classes
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -20,8 +23,6 @@ class NewClassesSniffTest extends BaseSniffTest
 
     /**
      * testNewClass
-     *
-     * @group newClasses
      *
      * @dataProvider dataNewClass
      *
@@ -101,8 +102,6 @@ class NewClassesSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group newClasses
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Closure Sniff tests
  *
+ * @group newClosure
+ * @group closures
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New const visibility sniff test file
  *
+ * @group constVisibility
+ * @group constants
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +22,6 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
 
     /**
      * testConstVisibility
-     *
-     * @group constVisibility
      *
      * @dataProvider dataConstVisibility
      *
@@ -60,8 +61,6 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group constVisibility
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New execution directives test file
  *
+ * @group newExecutionDirectives
+ * @group executionDirectives
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -38,8 +41,6 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testNewExecutionDirective
-     *
-     * @group newExecutionDirectives
      *
      * @dataProvider dataNewExecutionDirective
      *
@@ -92,8 +93,6 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
     /**
      * testInvalidDirectiveValue
      *
-     * @group newExecutionDirectives
-     *
      * @dataProvider dataInvalidDirectiveValue
      *
      * @param string $directive Name of the execution directive.
@@ -124,8 +123,6 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testInvalidEncodingDirectiveValue
-     *
-     * @group newExecutionDirectives
      *
      * @requires function mb_list_encodings
      *
@@ -160,8 +157,6 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
     /**
      * testInvalidDirective
      *
-     * @group newExecutionDirectives
-     *
      * @return void
      */
     public function testInvalidDirective()
@@ -172,8 +167,6 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testIncompleteDirective
-     *
-     * @group newExecutionDirectives
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * New function array dereferencing sniff tests
  *
+ * @group newFunctionArrayDereferencing
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -19,8 +21,6 @@ class NewFunctionArrayDereferencingSniffTest extends BaseSniffTest
 
     /**
      * testArrayDereferencing
-     *
-     * @group functionArrayDereferencing
      *
      * @dataProvider dataArrayDereferencing
      *
@@ -56,8 +56,6 @@ class NewFunctionArrayDereferencingSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group functionArrayDereferencing
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Functions Parameter Sniff tests
  *
+ * @group newFunctionParameters
+ * @group functionParameters
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Functions Sniff tests
  *
+ * @group newFunctions
+ * @group functions
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -25,8 +28,6 @@ class NewFunctionsSniffTest extends BaseSniffTest
      *
      * @requires PHP 5.3
      *
-     * @group newFunctions
-     *
      * @return void
      */
     public function testFunctionsThatShouldntBeFlagged()
@@ -42,8 +43,6 @@ class NewFunctionsSniffTest extends BaseSniffTest
 
     /**
      * testNewFunction
-     *
-     * @group newFunctions
      *
      * @dataProvider dataNewFunction
      *

--- a/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * New use group declaration sniff tests
  *
+ * @group newGroupUseDeclarations
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New hash algorithms sniff tests.
  *
+ * @group newHashAlgorithms
+ * @group hashAlgorithms
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +22,6 @@ class NewHashAlgorithmsSniffTest extends BaseSniffTest
 
     /**
      * testNewHashAlgorithms
-     *
-     * @group hashAlgorithms
      *
      * @dataProvider dataNewHashAlgorithms
      *
@@ -67,8 +68,6 @@ class NewHashAlgorithmsSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group hashAlgorithms
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New ini directives sniff tests
  *
+ * @group newIniDirectives
+ * @group iniDirectives
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -20,8 +23,6 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * Test functions that shouldn't be flagged by this sniff
-     *
-     * @group IniDirectives
      *
      * @dataProvider dataFunctionThatShouldntBeFlagged
      *
@@ -55,8 +56,6 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testNewIniDirectives
-     *
-     * @group IniDirectives
      *
      * @dataProvider dataNewIniDirectives
      *
@@ -221,8 +220,6 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
 
     /**
      * testNewIniDirectivesWithAlternative
-     *
-     * @group IniDirectives
      *
      * @dataProvider dataNewIniDirectivesWithAlternative
      *

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Interfaces Sniff tests
  *
+ * @group newInterfaces
+ * @group interfaces
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New keywords sniff tests
  *
+ * @group newKeywords
+ * @group reservedKeywords
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -19,8 +22,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * Test allow_url_include
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -35,8 +36,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * Test insteadof
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -55,8 +54,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test namespace keyword
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testNamespaceKeyword()
@@ -70,8 +67,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * testNamespaceConstant
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -87,8 +82,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test trait keyword
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testTraitKeyword()
@@ -102,8 +95,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * Test trait magic constant
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -119,8 +110,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * Test the use keyword
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testUse()
@@ -134,8 +123,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * Test yield
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -151,8 +138,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testFinally
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testFinally()
@@ -166,8 +151,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * testNowdoc
-     *
-     * @group newKeywords
      *
      * @requires PHP 5.3
      *
@@ -187,8 +170,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testConst
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testConst()
@@ -205,8 +186,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testCallable
      *
-     * @group newKeywords
-     *
      * @return void
      */
     public function testCallable()
@@ -219,8 +198,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
 
     /**
      * testGoto
-     *
-     * @group newKeywords
      *
      * @return void
      */
@@ -236,11 +213,8 @@ class NewKeywordsSniffTest extends BaseSniffTest
     /**
      * testHaltCompiler
      *
-     * @group newKeywords
-     *
      * @requires PHP 5.3
      *
-
      * @return void
      */
     public function testHaltCompiler()

--- a/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * New language constructs sniff tests
  *
+ * @group newLanguageConstructs
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -19,8 +21,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
 
     /**
      * testNamespaceSeparator
-     *
-     * @group NewLanguageConstructs
      *
      * @requires PHP 5.3
      *
@@ -38,8 +38,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     /**
      * testPow
      *
-     * @group NewLanguageConstructs
-     *
      * @return void
      */
     public function testPow()
@@ -53,8 +51,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
 
     /**
      * testPowEquals
-     *
-     * @group NewLanguageConstructs
      *
      * @return void
      */
@@ -70,8 +66,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     /**
      * testSpaceship
      *
-     * @group NewLanguageConstructs
-     *
      * @return void
      */
     public function testSpaceship()
@@ -85,8 +79,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
 
     /**
      * Coalescing operator
-     *
-     * @group NewLanguageConstructs
      *
      * @return void
      */
@@ -103,8 +95,6 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
 
     /**
      * Variadic functions using ...
-     *
-     * @group NewLanguageConstructs
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New Magic Methods Sniff tests.
  *
+ * @group newMagicMethods
+ * @group magicMethods
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -67,8 +70,6 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
     /**
      * Test magic methods that shouldn't be flagged by this sniff.
      *
-     * @group newMagicMethods
-     *
      * @dataProvider dataMagicMethodsThatShouldntBeFlagged
      *
      * @param int $line The line number.
@@ -103,8 +104,6 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * testNewMagicMethod
-     *
-     * @group newMagicMethods
      *
      * @dataProvider dataNewMagicMethod
      *
@@ -169,8 +168,6 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
 	 * for PHPCS 2.5.1 as the Naming Convention sniff in PHPCS < 2.5.1 does not recognize
 	 * __debugInfo() yet, causing the noViolation sniff to fail.
      *
-     * @group newMagicMethods
-     *
      * @dataProvider dataNewDebugInfo
      *
      * @param string $methodName        Name of the method.
@@ -221,8 +218,6 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * testChangedToStringMethod
-     *
-     * @group newMagicMethods
      *
      * @dataProvider dataChangedToStringMethod
      *

--- a/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New catching multiple exception types sniff test file
  *
+ * @group multiCatch
+ * @group exceptions
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +22,6 @@ class NewMultiCatchSniffTest extends BaseSniffTest
 
     /**
      * testNewMultiCatch
-     *
-     * @group multiCatch
      *
      * @dataProvider dataNewMultiCatch
      *
@@ -54,8 +55,6 @@ class NewMultiCatchSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group multiCatch
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New nullable type hints / return types sniff test file
  *
+ * @group nullableTypes
+ * @group typeDeclarations
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -19,8 +22,6 @@ class NewNullableTypesSniffTest extends BaseSniffTest
 
     /**
      * testNewNullableReturnTypes
-     *
-     * @group nullableTypes
      *
      * @dataProvider dataNewNullableReturnTypes
      *
@@ -67,8 +68,6 @@ class NewNullableTypesSniffTest extends BaseSniffTest
     /**
      * testNewNullableTypeHints
      *
-     * @group nullableTypes
-     *
      * @dataProvider dataNewNullableTypeHints
      *
      * @param int $line The line number.
@@ -110,8 +109,6 @@ class NewNullableTypesSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group nullableTypes
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New return types test file
  *
+ * @group newScalarReturnTypeDeclarations
+ * @group typeDeclarations
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -32,8 +35,6 @@ class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
 
     /**
      * testScalarReturnType
-     *
-     * @group scalarReturnType
      *
      * @dataProvider dataScalarReturnType
      *

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * New type declarations test file
  *
+ * @group newScalarTypeDeclarations
+ * @group typeDeclarations
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -19,8 +22,6 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
 
     /**
      * testNewTypeDeclaration
-     *
-     * @group TypeDeclarations
      *
      * @dataProvider dataNewTypeDeclaration
      *
@@ -63,8 +64,6 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
     /**
      * testInvalidTypeDeclaration
      *
-     * @group TypeDeclarations
-     *
      * @dataProvider dataInvalidTypeDeclaration
      *
      * @param string $type The scalar type.
@@ -99,8 +98,6 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
     /**
      * testInvalidSelfTypeDeclaration
      *
-     * @group TypeDeclarations
-     *
      * @dataProvider dataInvalidSelfTypeDeclaration
      *
      * @param int $line Line number on which to expect an error.
@@ -131,8 +128,6 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
 
     /**
      * testTypeDeclaration
-     *
-     * @group TypeDeclarations
      *
      * @dataProvider dataTypeDeclaration
      *

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Non Static Magic Sniff tests
  *
+ * @group nonStaticMagicMethods
+ * @group magicMethods
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -64,8 +67,6 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * testCorrectImplementation
-     *
-     * @group MagicMethods
      *
      * @dataProvider dataCorrectImplementation
      *
@@ -177,8 +178,6 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     /**
      * testWrongMethodVisibility
      *
-     * @group MagicMethods
-     *
      * @dataProvider dataWrongMethodVisibility
      *
      * @param string $methodName        Method name.
@@ -258,8 +257,6 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     /**
      * testWrongStaticMethod
      *
-     * @group MagicMethods
-     *
      * @dataProvider dataWrongStaticMethod
      *
      * @param string $methodName Method name.
@@ -328,8 +325,6 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * testWrongNonStaticMethod
-     *
-     * @group MagicMethods
      *
      * @dataProvider dataWrongNonStaticMethod
      *

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * ParameterShadowSuperGlobalsSniffTest
  *
+ * @group parameterShadowSuperGlobals
+ * @group superglobals
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -20,8 +23,6 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
 
     /**
      * testParameterShadowSuperGlobals
-     *
-     * @group parameterShadowSuperGlobals
      *
      * @dataProvider dataParameterShadowSuperGlobals
      *
@@ -65,8 +66,6 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
 
     /**
      * testValidParameter
-     *
-     * @group parameterShadowSuperGlobals
      *
      * @dataProvider dataValidParameter
      *

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * preg_replace() /e modifier sniff tests
  *
+ * @group pregReplaceEModifier
+ * @group regexEModifier
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -20,8 +23,6 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
 
     /**
      * testDeprecatedEModifier
-     *
-     * @group pregReplaceEModifier
      *
      * @dataProvider dataDeprecatedEModifier
      *
@@ -87,8 +88,6 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group pregReplaceEModifier
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -9,6 +9,8 @@
 /**
  * Removed alternative PHP tags sniff test file
  *
+ * @group removedAlternativePHPTags
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -38,8 +40,6 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
 
     /**
      * testAlternativePHPTags
-     *
-     * @group alternativePHPTags
      *
      * @dataProvider dataAlternativePHPTags
      *
@@ -88,8 +88,6 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
     /**
      * testMaybeASPOpenTag
      *
-     * @group alternativePHPTags
-     *
      * @dataProvider dataMaybeASPOpenTag
      *
      * @param int    $line    The line number.
@@ -137,8 +135,6 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group alternativePHPTags
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Removed extensions sniff tests
  *
+ * @group removedExtensions
+ * @group extensions
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -40,8 +43,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
 
     /**
      * testRemovedExtension
-     *
-     * @group removedExtensions
      *
      * @dataProvider dataRemovedExtension
      *
@@ -102,8 +103,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     /**
      * testRemovedExtensionWithAlternative
      *
-     * @group removedExtensions
-     *
      * @dataProvider dataRemovedExtensionWithAlternative
      *
      * @param string $extensionName  Name of the PHP extension.
@@ -162,8 +161,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
 
     /**
      * testDeprecatedRemovedExtensionWithAlternative
-     *
-     * @group removedExtensions
      *
      * @dataProvider dataDeprecatedRemovedExtensionWithAlternative
      *
@@ -227,8 +224,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     /**
      * testDeprecatedExtensionWithAlternative
      *
-     * @group removedExtensions
-     *
      * @dataProvider dataDeprecatedExtensionWithAlternative
      *
      * @param string $extensionName     Name of the PHP extension.
@@ -277,8 +272,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     /**
      * testNotAFunctionCall
      *
-     * @group removedExtensions
-     *
      * @return void
      */
     public function testNotAFunctionCall()
@@ -288,8 +281,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
 
     /**
      * testFunctionDeclaration
-     *
-     * @group removedExtensions
      *
      * @return void
      */
@@ -301,8 +292,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     /**
      * testNewClass
      *
-     * @group removedExtensions
-     *
      * @return void
      */
     public function testNewClass()
@@ -313,8 +302,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     /**
      * testMethod
      *
-     * @group removedExtensions
-     *
      * @return void
      */
     public function testMethod()
@@ -324,8 +311,6 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
 
     /**
      * testWhiteListing
-     *
-     * @group removedExtensions
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Removed Functions Parameter Sniff test file
  *
+ * @group removedFunctionParameters
+ * @group functionParameters
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Removed global variables sniff tests
  *
+ * @group removedGlobalVariables
+ * @group superglobals
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>
@@ -19,8 +22,6 @@ class RemovedGlobalVariablesSniffTest  extends BaseSniffTest
 
     /**
      * testRemovedGlobalVariables
-     *
-     * @group removedGlobalVariables
      *
      * @dataProvider dataRemovedGlobalVariables
      *
@@ -58,8 +59,6 @@ class RemovedGlobalVariablesSniffTest  extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group removedGlobalVariables
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Removed hash algorithms sniff tests
  *
+ * @group removedHashAlgorithms
+ * @group hashAlgorithms
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -19,8 +22,6 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
 
     /**
      * testRemovedHashAlgorithms
-     *
-     * @group hashAlgorithms
      *
      * @dataProvider dataRemovedHashAlgorithms
      *
@@ -69,8 +70,6 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
      * As the function hash_pbkdf2() itself was only introduced in PHP 5.5, we cannot test the noViolation case
      * (as it would still show an error for use of a new function).
      *
-     * @group hashAlgorithms
-     *
      * return void
      */
     public function testRemovedHashAlgorithmsPbkdf2()
@@ -82,8 +81,6 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group hashAlgorithms
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Required Optional Parameter Sniff test file
  *
+ * @group requiredOptionalFunctionParameters
+ * @group functionParameters
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/ShortArraySniffTest.php
+++ b/Tests/Sniffs/PHP/ShortArraySniffTest.php
@@ -9,6 +9,9 @@
 /**
  * Short array syntax sniff tests
  *
+ * @group shortArray
+ * @group arraySyntax
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  */
@@ -18,8 +21,6 @@ class ShortArraySniffTest extends BaseSniffTest
 
     /**
      * testViolation
-     *
-     * @group shortArraySyntax
      *
      * @dataProvider dataViolation
      *
@@ -56,8 +57,6 @@ class ShortArraySniffTest extends BaseSniffTest
 
     /**
      * testNoViolation
-     *
-     * @group shortArraySyntax
      *
      * @dataProvider dataNoViolation
      *

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Ternary Operators Sniff tests
  *
+ * @group ternaryOperators
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>
@@ -25,8 +27,6 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
     /**
      * Test ternary operators that are acceptable in all PHP versions.
      *
-     * @group ternaryOperators
-     *
      * @return void
      */
     public function testStandardTernaryOperators()
@@ -37,8 +37,6 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
 
     /**
      * 5.2 doesn't support elvis operator.
-     *
-     * @group ternaryOperators
      *
      * @return void
      */
@@ -53,8 +51,6 @@ class TernaryOperatorsSniffTest extends BaseSniffTest
 
     /**
      * 5.3 does support elvis operator.
-     *
-     * @group ternaryOperators
      *
      * @return void
      */

--- a/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -9,6 +9,8 @@
 /**
  * Valid Integers Sniff tests
  *
+ * @group validIntegers
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
@@ -40,8 +42,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
 
     /**
      * testBinaryInteger
-     *
-     * @group ValidIntegers
      *
      * @dataProvider dataBinaryInteger
      *
@@ -84,8 +84,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
     /**
      * testInvalidBinaryInteger
      *
-     * @group ValidIntegers
-     *
      * @return void
      */
     public function testInvalidBinaryInteger()
@@ -96,8 +94,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
 
     /**
      * testInvalidOctalInteger
-     *
-     * @group ValidIntegers
      *
      * @dataProvider dataInvalidOctalInteger
      *
@@ -136,8 +132,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
     /**
      * testValidOctalInteger
      *
-     * @group ValidIntegers
-     *
      * @return void
      */
     public function testValidOctalInteger() {
@@ -147,8 +141,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
 
     /**
      * testHexNumericString
-     *
-     * @group ValidIntegers
      *
      * @return void
      */


### PR DESCRIPTION
The `@group` annotation allows for the running of groups of tests based on a command line/xml property being set.
As the test suite is quite large, this allows for quicker/easier testing of a select group of changed tests/sniffs.

This PR covers:
- Every class has a `@group` annotation mirroring the name of the sniff being tested.
- Classes with tests covering related sniffs, have a secondary group annotation for the larger group, i.e. `InternalInterfaces` and `NewInterfaces`, both have their own group as well as a secondary `interfaces` group.
- For utility function test classes, the group name is `utility`+ the name of the function.
- Removed the `@group` annotations for single tests in sniff test files as having the annotation for the class will assign it to all tests in that class and that's how it was currently used anyway.