### PR TITLE
Make sure all sniff test classes have a `@covers` annotation.

### DIFF
--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -12,6 +12,8 @@
  * @group constantArraysUsingDefine
  * @group constants
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/DefaultTimezoneRequiredSniffTest.php
+++ b/Tests/Sniffs/PHP/DefaultTimezoneRequiredSniffTest.php
@@ -11,6 +11,8 @@
  * @group defaultTimezoneRequired
  * @group iniDirectives
  *
+ * @covers PHPCompatibility_Sniffs_PHP_DefaultTimezoneRequiredSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -12,6 +12,8 @@
  * @group deprecatedFunctions
  * @group functions
  *
+ * @covers PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -12,6 +12,8 @@
  * @group deprecatedIniDirectives
  * @group iniDirectives
  *
+ * @covers PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -12,6 +12,8 @@
  * @group deprecatedNewReference
  * @group references
  *
+ * @covers PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -10,6 +10,8 @@
  *
  * @group deprecatedPHP4StyleConstructors
  *
+ * @covers PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Koen Eelen <koen.eelen@cu.be>

--- a/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group emptyNonVariable
  *
+ * @covers PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
@@ -14,6 +14,8 @@
  * @group forbiddenBreakContinueOutsideLoop
  * @group breakContinue
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoopSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -16,6 +16,8 @@
  * @group forbiddenBreakContinueVariableArguments
  * @group breakContinue
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenCallTimePassByReference
  * @group references
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenEmptyListAssignment
  * @group listAssignments
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenFunctionParametersWithSameName
  * @group functionDeclarations
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenGlobalVariableVariable
  * @group variableVariables
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenNamesAsDeclared
  * @group reservedKeywords
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenNamesAsInvokedFunctions
  * @group reservedKeywords
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -12,6 +12,8 @@
  * @group forbiddenNames
  * @group reservedKeywords
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group forbiddenNegativeBitshift
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group forbiddenSwitchWithMultipleDefaultBlocks
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -12,6 +12,8 @@
  * @group internalInterfaces
  * @group interfaces
  *
+ * @covers PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
+++ b/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group lateStaticBinding
  *
+ * @covers PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -12,6 +12,8 @@
  * @group longArrays
  * @group superglobals
  *
+ * @covers PHPCompatibility_Sniffs_PHP_LongArraysSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -12,6 +12,8 @@
  * @group mbstringReplaceEModifier
  * @group regexEModifier
  *
+ * @covers PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
@@ -12,6 +12,8 @@
  * @group newAnonymousClasses
  * @group closures
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -12,6 +12,8 @@
  * @group newClasses
  * @group classes
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewClassesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -12,6 +12,8 @@
  * @group newClosure
  * @group closures
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewClosureSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -12,6 +12,8 @@
  * @group constVisibility
  * @group constants
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -12,6 +12,8 @@
  * @group newExecutionDirectives
  * @group executionDirectives
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group newFunctionArrayDereferencing
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -12,6 +12,8 @@
  * @group newFunctionParameters
  * @group functionParameters
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -12,6 +12,8 @@
  * @group newFunctions
  * @group functions
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewFunctionsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group newGroupUseDeclarations
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
@@ -12,6 +12,8 @@
  * @group newHashAlgorithms
  * @group hashAlgorithms
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -12,6 +12,8 @@
  * @group newIniDirectives
  * @group iniDirectives
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -12,6 +12,8 @@
  * @group newInterfaces
  * @group interfaces
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewInterfacesSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -12,6 +12,8 @@
  * @group newKeywords
  * @group reservedKeywords
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewKeywordsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group newLanguageConstructs
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -12,6 +12,8 @@
  * @group newMagicMethods
  * @group magicMethods
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -12,6 +12,8 @@
  * @group multiCatch
  * @group exceptions
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewMultiCatchSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -12,6 +12,8 @@
  * @group nullableTypes
  * @group typeDeclarations
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewNullableTypesSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
@@ -12,6 +12,8 @@
  * @group newScalarReturnTypeDeclarations
  * @group typeDeclarations
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewScalarReturnTypeDeclarationsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -12,6 +12,8 @@
  * @group newScalarTypeDeclarations
  * @group typeDeclarations
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -12,6 +12,8 @@
  * @group nonStaticMagicMethods
  * @group magicMethods
  *
+ * @covers PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -12,6 +12,8 @@
  * @group parameterShadowSuperGlobals
  * @group superglobals
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -12,6 +12,8 @@
  * @group pregReplaceEModifier
  * @group regexEModifier
  *
+ * @covers PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -11,6 +11,8 @@
  *
  * @group removedAlternativePHPTags
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -12,6 +12,8 @@
  * @group removedExtensions
  * @group extensions
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -12,6 +12,8 @@
  * @group removedFunctionParameters
  * @group functionParameters
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -12,6 +12,8 @@
  * @group removedGlobalVariables
  * @group superglobals
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Wim Godden <wim@cu.be>

--- a/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -12,6 +12,8 @@
  * @group removedHashAlgorithms
  * @group hashAlgorithms
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
@@ -12,6 +12,8 @@
  * @group requiredOptionalFunctionParameters
  * @group functionParameters
  *
+ * @covers PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>

--- a/Tests/Sniffs/PHP/ShortArraySniffTest.php
+++ b/Tests/Sniffs/PHP/ShortArraySniffTest.php
@@ -12,6 +12,8 @@
  * @group shortArray
  * @group arraySyntax
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ShortArraySniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  */

--- a/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group ternaryOperators
  *
+ * @covers PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff
+ *
  * @uses BaseSniffTest
  * @package PHPCompatibility
  * @author Jansen Price <jansen.price@gmail.com>

--- a/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -11,6 +11,8 @@
  *
  * @group validIntegers
  *
+ * @covers PHPCompatibility_Sniffs_PHP_ValidIntegersSniff
+ *
  * @uses    BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>


### PR DESCRIPTION
The @covers annotation makes sure that the coverage of tests is only recorded for the class/method/function etc which the specific unit test is supposed to test and doesn't record (accidental) side-effects of tests.
Ref: https://phpunit.de/manual/current/en/code-coverage-analysis.html#code-coverage-analysis.specifying-covered-methods

For the tests related to utility functions the `@covers` annotation is at function level.