### PR TITLE
Improve test code coverage

### DIFF
--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -80,6 +80,12 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
     {
         return array(
             array(15),
+            array(18),
+            array(19),
+            array(22),
+            array(23),
+            array(26),
+            array(28),
         );
     }
 

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -22,17 +22,42 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/deprecated_ini_directives.php';
 
     /**
-     * Test valid directive
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidDirective()
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
-        $this->assertNoViolation($file, 57);
-        $this->assertNoViolation($file, 58);
-        $this->assertNoViolation($file, 133);
+        $this->assertNoViolation($file, $line);
     }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(57),
+            array(58),
+            array(133),
+            array(155),
+            array(156),
+            array(159),
+            array(160),
+            array(163),
+            array(164),
+        );
+    }
+
 
     /**
      * testDeprecatedRemovedDirectives

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -18,6 +18,9 @@
  */
 class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/forbidden_function_parameters_with_same_name.php';
+
+
     /**
      * testSettingTestVersion
      *
@@ -25,11 +28,40 @@ class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
      */
     public function testSettingTestVersion()
     {
-        $file = $this->sniffFile('sniff-examples/forbidden_function_parameters_with_same_name.php', '5.6');
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, 3);
-        
-        $file = $this->sniffFile('sniff-examples/forbidden_function_parameters_with_same_name.php', '7.0');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertError($file, 3, 'Functions can not have multiple parameters with the same name since PHP 7.0');
+    }
+
+    /**
+     * testNoViolation
+     *
+     * @dataProvider dataNoViolation
+     *
+     * @param int $line Line number with valid code.
+     *
+     * @return void
+     */
+    public function testNoViolation($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoViolation
+     *
+     * @see testNoViolation()
+     *
+     * @return array
+     */
+    public function dataNoViolation() {
+        return array(
+            array(5),
+            array(8),
+        );
     }
 }
 

--- a/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
@@ -55,15 +55,15 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidSwitchStatement
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidSwitchStatement
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidSwitchStatement($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -72,16 +72,17 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidSwitchStatement()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidSwitchStatement()
+    public function dataNoFalsePositives()
     {
         return array(
             array(14),
             array(23),
             array(43),
+            array(67), // Live coding.
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -82,6 +82,7 @@ class NewMultiCatchSniffTest extends BaseSniffTest
             array(10),
             array(12),
             array(23),
+            array(30), // Live coding.
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -179,4 +179,34 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
         );
     }
 
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.0-7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(48),
+            array(49),
+        );
+    }
 }

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -215,7 +215,7 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     public function dataDeprecatedRemovedExtensionWithAlternative()
     {
         return array(
-            array('ereg', '5.3', '7.0', 'pcre', array(65), '5.2'),
+            array('ereg', '5.3', '7.0', 'pcre', array(65, 76), '5.2'),
             array('mysql_', '5.5', '7.0', 'mysqli', array(38), '5.4'),
         );
     }
@@ -270,52 +270,39 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
 
 
     /**
-     * testNotAFunctionCall
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNotAFunctionCall()
+    public function testNoFalsePositives($line)
     {
-        $this->assertNoViolation($this->_sniffFile, 57);
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file, $line);
     }
 
     /**
-     * testFunctionDeclaration
+     * Data provider.
      *
-     * @return void
+     * @see testNoFalsePositives()
+     *
+     * @return array
      */
-    public function testFunctionDeclaration()
+    public function dataNoFalsePositives()
     {
-        $this->assertNoViolation($this->_sniffFile, 58);
+        return array(
+            array(57), // Not a function call.
+            array(58), // Function declaration.
+            array(59), // Class instantiation.
+            array(60), // Method call.
+            array(68), // Whitelisted function.
+            array(74), // Whitelisted function array.
+            array(75), // Whitelisted function array.
+            array(78), // Live coding
+        );
     }
 
-    /**
-     * testNewClass
-     *
-     * @return void
-     */
-    public function testNewClass()
-    {
-        $this->assertNoViolation($this->_sniffFile, 59);
-    }
-
-    /**
-     * testMethod
-     *
-     * @return void
-     */
-    public function testMethod()
-    {
-        $this->assertNoViolation($this->_sniffFile, 60);
-    }
-
-    /**
-     * testWhiteListing
-     *
-     * @return void
-     */
-    public function testWhiteListing()
-    {
-        $this->assertNoViolation($this->_sniffFile, 68);
-    }
 }

--- a/Tests/sniff-examples/constant_arrays_using_define.php
+++ b/Tests/sniff-examples/constant_arrays_using_define.php
@@ -13,3 +13,16 @@ define('ANIMALS', array(
 ));
 
 define('ANIMALS', 'dog');
+
+// Test correct function detection.
+myClass::define('ANIMALS', 'dog');
+$object->define('ANIMALS', 'dog');
+
+class myClass {
+	const define = true;
+	function define() {}
+}
+
+notDefine('ANIMALS', 'dog');
+
+define('ANIMALS');

--- a/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/Tests/sniff-examples/deprecated_ini_directives.php
@@ -149,3 +149,16 @@ $a = ini_get('session.hash_function');
 
 ini_set('session.hash_bits_per_character', 1);
 $a = ini_get('session.hash_bits_per_character');
+
+
+// Test correct function & parameter detection.
+myClass::ini_set('ANIMALS', 'dog');
+$object->ini_get('ANIMALS', 'dog');
+
+class myClass {
+	const ini_set = true;
+	function ini_get() {}
+}
+
+ini_setter('ANIMALS', 'dog');
+ini_set();

--- a/Tests/sniff-examples/forbidden_function_parameters_with_same_name.php
+++ b/Tests/sniff-examples/forbidden_function_parameters_with_same_name.php
@@ -1,3 +1,8 @@
 <?php
 
 function foo($a, $b, $unused, $unused) { }
+
+function foobaz() {} // No parameters = no error.
+
+// Don't throw errors during live code review.
+function foobar($a,$a

--- a/Tests/sniff-examples/forbidden_switch_with_multiple_default_blocks.php
+++ b/Tests/sniff-examples/forbidden_switch_with_multiple_default_blocks.php
@@ -62,3 +62,6 @@ switch ($something) {
     default:
         break;
 }
+
+// Don't throw errors on live code review.
+switch ($something) {

--- a/Tests/sniff-examples/new_multi_catch.php
+++ b/Tests/sniff-examples/new_multi_catch.php
@@ -23,3 +23,8 @@ try {
 } catch (\Exception $e) {
    // ...
 }
+
+// Don't throw errors during live code review.
+try {
+   // Some code...
+} catch (

--- a/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -43,3 +43,7 @@ namespace test {
 
     function foo(self $a) {} // Invalid - not within a class.
 }
+
+// Ok: No function parameters or no type hints.
+function foo() {}
+function foo( $a, $b ) {}

--- a/Tests/sniff-examples/removed_extensions.php
+++ b/Tests/sniff-examples/removed_extensions.php
@@ -53,7 +53,7 @@ w32api();
 
 yp();
 
-// examples of extension names that should not be considered wrong
+// Examples of extension names that should not be considered wrong.
 mnogosearch;
 function pfpro() {}
 $ok = new Sybase();
@@ -69,3 +69,11 @@ mysql_to_rfc3339();
 
 // PHP 7.1 removed extensions:
 mcrypt_encrypt();
+
+// @codingStandardsChangeSetting PHPCompatibility.PHP.RemovedExtensions functionWhitelist ereg_convert,ereg_translate_to_preg
+ereg_convert();
+ereg_translate_to_preg();
+ereg_replace(); // Non-whitelisted.
+
+// Don't throw errors during live code review.
+ereg($a, $b


### PR DESCRIPTION
If/when #307 will be merged, the code coverage will decrease because unintentionally covered lines will no longer be covered, exposing them more clearly.

For this PR I've gone through the code coverage results of #307 and made a first round of improvements.

This mostly involves the addition of some extra test cases against false positives.