### PR TITLE
PHP 7.0: Add new sniff to detect variable variables for which the behaviour has changed

### DIFF
--- a/Sniffs/PHP/VariableVariablesSniff.php
+++ b/Sniffs/PHP/VariableVariablesSniff.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_VariableVariables.
+ *
+ * PHP version 7.0
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_VariableVariables.
+ *
+ * The interpretation of variable variables has changed in PHP 7.0.
+ *
+ * PHP version 7.0
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_VariableVariablesSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_VARIABLE);
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.0') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Verify that the next token is a square open bracket. If not, bow out.
+        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+
+        if ($nextToken === false || $tokens[$nextToken]['code'] !== T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
+            return;
+        }
+
+        // The previous token has to be a $, -> or ::.
+        if (isset($tokens[($stackPtr - 1)]) === false || in_array($tokens[($stackPtr - 1)]['code'], array(T_DOLLAR, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === false) {
+            return;
+        }
+
+        // For static object calls, it only applies when this is a function call.
+        if ($tokens[($stackPtr - 1)]['code'] === T_DOUBLE_COLON) {
+            $hasBrackets = $tokens[$nextToken]['bracket_closer'];
+            while (($hasBrackets = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false ) {
+                if ($tokens[$hasBrackets]['code'] === T_OPEN_SQUARE_BRACKET) {
+                    if (isset($tokens[$hasBrackets]['bracket_closer'])) {
+						$hasBrackets = $tokens[$hasBrackets]['bracket_closer'];
+                        continue;
+                    }
+                    else {
+                        // Live coding.
+                        return;
+                    }
+                }
+                elseif ($tokens[$hasBrackets]['code'] === T_OPEN_PARENTHESIS) {
+                    // Caught!
+                    break;
+                }
+                else {
+                    // Not a function call, so bow out.
+                    return;
+                }
+            }
+
+            // Now let's also prevent false positives when used with self and static which still work fine.
+            $classToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
+            if ($classToken !== false) {
+                if ($tokens[$classToken]['code'] === T_STATIC) {
+                    return;
+                }
+                elseif ($tokens[$classToken]['code'] === T_STRING && $tokens[$classToken]['content'] === 'self') {
+                    return;
+                }
+            }
+        }
+
+        $phpcsFile->addError(
+            'Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity.',
+            $stackPtr,
+            'Found'
+        );
+
+    }//end process()
+
+
+}//end class

--- a/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * VariableVariables sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * VariableVariables sniff test file
+ *
+ * @group variableVariables
+ * @group variables
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_VariableVariablesSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class VariableVariablesSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/variable_variables.php';
+
+    /**
+     * testVariableVariables
+     *
+     * @dataProvider dataVariableVariables
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testVariableVariables($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Indirect access to variables, properties and methods will be evaluated strictly in left-to-right order since PHP 7.0. Use curly braces to remove ambiguity.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testVariableVariables()
+     *
+     * @return array
+     */
+    public function dataVariableVariables()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(6),
+            array(7),
+            array(8),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositive
+     *
+     * @dataProvider dataNoFalsePositive
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositive($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositive()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositive()
+    {
+        return array(
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+
+            array(18),
+            array(19),
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(26),
+            array(27),
+            array(28),
+            array(29),
+            array(32),
+            array(37),
+        );
+    }
+}

--- a/Tests/sniff-examples/variable_variables.php
+++ b/Tests/sniff-examples/variable_variables.php
@@ -1,0 +1,37 @@
+<?php
+
+// Variable variables with changed behaviour between PHP 5 and PHP 7.
+echo $$var['key1']['key2'];
+echo $obj->$var['key'];
+echo $obj->$var['key']();
+echo myClass::$var['key']();
+echo myClass::$var['key1']['key2']['key3']();
+
+// Variable variables which will be interpreted the same in PHP 5 and PHP 7.
+echo ${$var['key1']['key2']};
+echo $obj->{$var['key']};
+echo $obj->{$var['key']}();
+echo myClass::{$var['key']}();
+echo myClass::{$var['key1']['key2']['key3']}();
+
+// Variable variables we're not sniffing for and other potential false positives.
+echo $$foo;
+echo "${foo}";
+echo $var['key1']['key2'];
+echo $obj->var['key'];
+echo $obj->hello();
+echo myClass::$foo;
+echo myClass::$var['key'];
+echo myClass::hello();
+echo ${$obj->getName()};
+echo $obj->{$obj->$hello}();
+echo $obj->{myClass::$foo}();
+echo new self::$transport[$cap_string]();
+class fooBar {
+    function foo() {
+        echo static::$transport[$cap_string]();
+    }
+}
+
+// Live coding.
+echo $$var['key'


### PR DESCRIPTION
Crafted to prevent false positives.

Includes unit tests.

Ref:
http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling
https://wiki.php.net/rfc/uniform_variable_syntax

Fixes #309