### PR TITLE
Recognize T_SELF as well in variable variables.

### DIFF
--- a/Sniffs/PHP/VariableVariablesSniff.php
+++ b/Sniffs/PHP/VariableVariablesSniff.php
@@ -89,7 +89,7 @@ class PHPCompatibility_Sniffs_PHP_VariableVariablesSniff extends PHPCompatibilit
             // Now let's also prevent false positives when used with self and static which still work fine.
             $classToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
             if ($classToken !== false) {
-                if ($tokens[$classToken]['code'] === T_STATIC) {
+                if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
                     return;
                 }
                 elseif ($tokens[$classToken]['code'] === T_STRING && $tokens[$classToken]['content'] === 'self') {


### PR DESCRIPTION
Fixes failing unit tests caused by changed behavior of PHPCS > 2.7.1.

See:
* https://github.com/squizlabs/PHP_CodeSniffer/commit/79cd3dcd16179d76e72fdf60853745b6c1f8fb40
* https://github.com/squizlabs/PHP_CodeSniffer/issues/1245