### PR TITLE
Review analysis of text strings

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -187,7 +187,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Strip quotes surrounding an arbitrary string.
      *
-     * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING.
+     * Intended for use with the content of a T_CONSTANT_ENCAPSED_STRING / T_DOUBLE_QUOTED_STRING.
      *
      * @param string $string The raw string.
      *
@@ -1148,7 +1148,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         }
 
         /**
-         * Algorithm is a T_CONSTANT_ENCAPSED_STRING, so we need to remove the quotes.
+         * Algorithm is a text string, so we need to remove the quotes.
          */
         $algo = strtolower(trim($algoParam['raw']));
         $algo = $this->stripQuotes($algo);

--- a/Sniff.php
+++ b/Sniff.php
@@ -22,6 +22,8 @@
 abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 {
 
+    const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
+
     /**
      * List of functions using hash algorithm as parameter (always the first parameter).
      *
@@ -193,6 +195,24 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      */
     public function stripQuotes($string) {
         return preg_replace('`^([\'"])(.*)\1$`Ds', '$2', $string);
+    }
+
+
+    /**
+     * Strip variables from an arbitrary double quoted string.
+     *
+     * Intended for use with the content of a T_DOUBLE_QUOTED_STRING.
+     *
+     * @param string $string The raw string.
+     *
+     * @return string String without variables in it.
+     */
+    public function stripVariables($string) {
+        if (strpos($string, '$') === false) {
+            return $string;
+        }
+
+        return preg_replace( self::REGEX_COMPLEX_VARS, '', $string );
     }
 
 

--- a/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -73,21 +73,30 @@ class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompa
             return;
         }
 
-        $stringToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $optionsParam['start'], $optionsParam['end'] + 1);
+        $stringToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
         if ($stringToken === false) {
             // No string token found in the options parameter, so skip it (e.g. variable passed in).
             return;
         }
 
+        $options = '';
+
         /**
-         * Get the content of any string tokens in the options parameter and remove the quotes.
+         * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
-        $options = $this->stripQuotes($tokens[$stringToken]['content']);
-        if ($stringToken !== $optionsParam['end']) {
-            while ($stringToken = $phpcsFile->findNext(T_CONSTANT_ENCAPSED_STRING, $stringToken + 1, $optionsParam['end'] + 1)) {
-                if ($tokens[$stringToken]['code'] === T_CONSTANT_ENCAPSED_STRING) {
-                    $options .= $this->stripQuotes($tokens[$stringToken]['content']);
-                }
+        for ($i = $stringToken; $i <= $optionsParam['end']; $i++) {
+            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === false) {
+                continue;
+            }
+
+            $content = $this->stripQuotes($tokens[$i]['content']);
+            if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+                $content = $this->stripVariables($content);
+            }
+            $content = trim($content);
+
+            if (empty($content) === false) {
+                $options .= $content;
             }
         }
 

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -260,7 +260,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if ($tokens[$stackPtr]['code'] === T_CONSTANT_ENCAPSED_STRING) {
+        if (in_array($tokens[$stackPtr]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
             $value = $this->stripQuotes($value);
         }
 

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -147,4 +147,68 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
         );
     }
 
+
+   /**
+     * testStripVariables
+     *
+     * @dataProvider dataStripVariables
+     *
+     * @covers PHPCompatibility_Sniff::stripQuotes
+     *
+     * @param string $input    The input string.
+     * @param string $expected The expected function output.
+     */
+    public function testStripVariables($input, $expected)
+    {
+        $this->assertSame($expected, $this->helperClass->stripVariables($input));
+    }
+
+    /**
+     * dataStripVariables
+     *
+     * @see testStripVariables()
+     *
+     * @return array
+     */
+    public function dataStripVariables()
+    {
+        return array(
+            // These would need to be matched when testing double quoted strings for variables.
+            array('"He drank some $juice juice."', '"He drank some  juice."'),
+            array('"He drank some juice made of $juices."', '"He drank some juice made of ."'),
+            array('"He drank some juice made of ${juice}s."', '"He drank some juice made of s."'),
+            array('"He drank some $juices[0] juice."', '"He drank some  juice."'),
+            array('"He drank some $juices[1] juice."', '"He drank some  juice."'),
+            array('"He drank some $juices[koolaid1] juice."', '"He drank some  juice."'),
+            array('"$people->john drank some $juices[0] juice."', '" drank some  juice."'),
+            array('"$people->john then said hello to $people->jane."', '" then said hello to ."'),
+            array('"$people->john\'s wife greeted $people->robert."', '"\'s wife greeted ."'),
+            array('"The element at index -3 is $array[-3]."', '"The element at index -3 is ."'),
+            array('"This is {$great}"', '"This is "'),
+            array('"This square is {$square->width}00 centimeters broad."', '"This square is 00 centimeters broad."'),
+            array('"This works: {$arr[\'key\']}"', '"This works: "'),
+            array('"This works: {$arr[4][3]}"', '"This works: "'),
+            array('"This is wrong: {$arr[foo][3]}"', '"This is wrong: "'),
+            array('"This works: {$arr[\'foo\'][3]}"', '"This works: "'),
+            array('"This works too: {$obj->values[3]->name}"', '"This works too: "'),
+
+            array('"This is the value of the var named $name: {${$name}}"', '"This is the value of the var named : "'),
+            array('"This is the value of the var named \$name: {${$name}}"', '"This is the value of the var named \$name: "'),
+            array('"This is the value of the var named by the return value of getName(): {${getName()}}"', '"This is the value of the var named by the return value of getName(): "'),
+            array('"This is the value of the var named by the return value of getName(): {${getName( $test )}}"', '"This is the value of the var named by the return value of getName(): "'),
+            array('"This is the value of the var named by the return value of getName(): {${getName( \'abc\' )}}"', '"This is the value of the var named by the return value of getName(): "'),
+            array('"This is the value of the var named by the return value of \$object->getName(): {${$object->getName()}}"', '"This is the value of the var named by the return value of \$object->getName(): "'),
+            array('"{$foo->$bar}\n"', '"\n"'),
+            array('"I\'d like an {${beers::softdrink}}\n"', '"I\'d like an \n"'),
+            array('"I\'d like an {${beers::$ale}}\n"', '"I\'d like an \n"'),
+
+            array('"{$foo->{$baz[1]}}\n"', '"{->}\n"'), // Problem var, only one I haven't managed to work out properly.
+
+            // These shouldn't match and should be returned as is.
+            array('"He drank some \\\\$juice juice."', '"He drank some \\\\$juice juice."'),
+            array('"This is { $great}"', '"This is { }"'),
+            array('"This is the return value of getName(): {getName()}"', '"This is the return value of getName(): {getName()}"'),
+        );
+    }
+
 }

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -56,6 +56,9 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
             array(14),
             array(15),
             array(16),
+            array(24),
+            array(25),
+            array(26),
         );
     }
 
@@ -91,6 +94,9 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
             array(9),
             array(10),
             array(11),
+            array(19),
+            array(20),
+            array(21),
         );
     }
 }

--- a/Tests/sniff-examples/mbstring_replace_e_modifier.php
+++ b/Tests/sniff-examples/mbstring_replace_e_modifier.php
@@ -14,3 +14,13 @@ mb_regex_set_options( 'ims' );
 mb_ereg_replace( $pattern, $replace, $subject, 'e' );
 mb_eregi_replace( $pattern, $replace, $subject, "seim" );
 mb_regex_set_options( 'im' . 'se' );
+
+// Interpolated strings: These should NOT be flagged.
+mb_ereg_replace( $pattern, $replace, $subject, "$e" );
+mb_eregi_replace( $pattern, $replace, $subject, "s$eim" );
+mb_regex_set_options( 'im' . "$se" );
+
+// Interpolated strings: These should all be flagged.
+mb_ereg_replace( $pattern, $replace, $subject, "e$m" );
+mb_eregi_replace( $pattern, $replace, $subject, "me$i" );
+mb_regex_set_options( 'im' . "{$se}e" );


### PR DESCRIPTION
Text strings can be tokenized as either `T_CONSTANT_ENCAPSED_STRING` or as a `T_DOUBLE_QUOTED_STRING`.
In the few sniffs which look at text strings, only `T_CONSTANT_ENCAPSED_STRING`s were properly taken into account.

This PR fixes that.

The few times the content of the text strings are analysed, we need the pure text - excluding any potential interpolated strings which could be part of a `T_DOUBLE_QUOTED_STRING` -. To that end a new utility function has been introduced which strips variables out of a given string.
The new function deals correctly with all but one possible situation, but that specific case will not cause any issues for this PHPCS standard.

PR includes unit tests for the new function containing all possible interpolated variables which will be interpreted by PHP as listed in the manual: http://php.net/manual/en/language.types.string.php

A similar adjustment as is made in this PR for the Mbstring sniff is needed for PCRE sniff. That will be dealt with in a separate PR once PR #300 has been merged to prevent conflicts.