### PR TITLE
Defer to upstream `hasCondition()` method for scope determination.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -504,24 +504,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return true;
         }
 
-        if (is_int($validScopes)) {
-            // Received an integer, so cast to array.
-            $validScopes = (array) $validScopes;
-        }
-
-        if (empty($validScopes) || is_array($validScopes) === false) {
-            // No valid scope types received, so will not comply.
-            return false;
-        }
-
-        // Check for required scope types.
-        foreach ($tokens[$stackPtr]['conditions'] as $pointer => $tokenCode) {
-            if (in_array($tokenCode, $validScopes, true)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $phpcsFile->hasCondition($stackPtr, $validScopes);
     }
 
 
@@ -544,7 +527,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             $validScopes[] = T_TRAIT;
         }
 
-        return $this->tokenHasScope($phpcsFile, $stackPtr, $validScopes);
+        return $phpcsFile->hasCondition($stackPtr, $validScopes);
     }
 
 
@@ -579,7 +562,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
         // PHPCS 2.0.
         if ($isLowPHPCS === false) {
-            return $this->tokenHasScope($phpcsFile, $stackPtr, T_USE);
+            return $phpcsFile->hasCondition($stackPtr, T_USE);
         } else {
             // PHPCS 1.x.
             $tokens         = $phpcsFile->getTokens();

--- a/Sniff.php
+++ b/Sniff.php
@@ -522,6 +522,10 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     public function inClassScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $strict = true)
     {
         $validScopes = array(T_CLASS);
+        if (defined('T_ANON_CLASS') === true) {
+            $validScopes[] = T_ANON_CLASS;
+        }
+
         if ($strict === false) {
             $validScopes[] = T_INTERFACE;
             $validScopes[] = T_TRAIT;

--- a/Tests/BaseClass/TokenHasScopeTest.php
+++ b/Tests/BaseClass/TokenHasScopeTest.php
@@ -115,9 +115,10 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
     {
         return array(
             array(181, true), // $property
-            array(185, true), // function
-            array(202, false), // function
-            array(220, true), // function
+            array(185, true), // function in class
+            array(202, false), // global function
+            array(220, true), // function in namespaced class
+            array(391, true), // function in anon class
         );
     }
 

--- a/Tests/sniff-examples/utility-functions/token_has_scope.php
+++ b/Tests/sniff-examples/utility-functions/token_has_scope.php
@@ -55,3 +55,7 @@ class Foobar { use BazTrait { oldfunction as Baz } }
 class Foobar { use BazTrait { oldfunction as public Baz } }
 class Foobar { use BazTrait { oldfunction as protected Baz } }
 class Foobar { use BazTrait { oldfunction as private Baz } }
+
+new class {
+    function something() {}
+}


### PR DESCRIPTION
Sometimes you suddenly discover an upstream method you didn't know about before - and it even turns out that the method already existed in PHPCS 1.x.... ;-)

As the functions do still have added value to reduce duplicate code, I've elected to leave them in, but defer to the upstream method for the actual scope determination.

[Edit]:
Added an additional commit to also allow for anonymous classes in the `inClassScope()` method. (+ additional unit test)