### PR TITLE
Allow for multiple variables made global in ForbiddenGlobalVariableVariableSniff

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -20,17 +20,76 @@
  */
 class ForbiddenGlobalVariableVariableSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/forbidden_global_variable_variable.php';
+
     /**
      * Verify that checking for a specific version works
      *
+     * @dataProvider dataGlobalVariableVariable
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testGlobalVariableVariable()
+    public function testGlobalVariableVariable($line)
     {
-        $file = $this->sniffFile('sniff-examples/forbidden_global_variable_variable.php', '5.6');
-        $this->assertNoViolation($file, 3);
-        
-        $file = $this->sniffFile('sniff-examples/forbidden_global_variable_variable.php', '7.0');
-        $this->assertError($file, 3, "Global with variable variables is not allowed since PHP 7.0");
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertError($file, $line, 'Global with variable variables is not allowed since PHP 7.0');
+    }
+
+    /**
+     * Data provider dataGlobalVariableVariable.
+     *
+     * @see testGlobalVariableVariable()
+     *
+     * @return array
+     */
+    public function dataGlobalVariableVariable()
+    {
+        return array(
+            array(6),
+            array(9),
+            array(11),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositive
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(19),
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(28),
+        );
     }
 }

--- a/Tests/sniff-examples/forbidden_global_variable_variable.php
+++ b/Tests/sniff-examples/forbidden_global_variable_variable.php
@@ -1,3 +1,28 @@
 <?php
 
+/*
+ * Forbidden global variable variables.
+ */
 global $$test;
+
+// Multi-variable and multi-line global statements.
+global $test, $$test, $$$test;
+
+global $test,
+    $$obj->$bar,
+    $testing,
+    $$test;
+
+/*
+ * Ok.
+ */
+global $test;
+global ${$test};
+global ${"name"};
+global ${"name_$type"};
+global ${$var['key1']['key2']};
+global ${$obj->$bar};
+global ${$obj->{$var['key']}};
+
+// Live coding.
+global


### PR DESCRIPTION
The `ForbiddenGlobalVariableVariableSniff` would currently only detect variable variables in a `global` statement if it was the first variable of the statement.
It basically didn't take multi-variable `global` statements into account.

Includes additional unit tests.
Includes reworking the test class to use data providers as there are now more test cases.