### PR TITLE
Minor efficiency tweak to ForbiddenNamesAsDeclaredSniff

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -87,6 +87,10 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if ($this->supportsAbove('7.0') === false) {
+            return;
+        }
+
         $tokens         = $phpcsFile->getTokens();
         $tokenCode      = $tokens[$stackPtr]['code'];
         $tokenContentLc = strtolower($tokens[$stackPtr]['content']);


### PR DESCRIPTION
As this sniff is only relevant if the testVersion includes PHP 7.0+, we might as well bow out early if the `testVersion` does not include PHP 7+.