### PR TITLE
Review test fixtures

### DIFF
--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -27,11 +27,22 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
     protected $helperClass;
 
 
+    /**
+     * Set up fixtures for this unit test.
+     *
+     * @return void
+     */
     public static function setUpBeforeClass()
     {
         require_once dirname(__FILE__) . '/TestHelperPHPCompatibility.php';
+        parent::setUpBeforeClass();
     }
 
+    /**
+     * Sets up this unit test.
+     *
+     * @return void
+     */
     protected function setUp()
     {
         parent::setUp();

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -45,11 +45,22 @@ abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
     protected $helperClass;
 
 
+    /**
+     * Set up fixtures for this unit test.
+     *
+     * @return void
+     */
     public static function setUpBeforeClass()
     {
         require_once dirname(__FILE__) . '/TestHelperPHPCompatibility.php';
+        parent::setUpBeforeClass();
     }
 
+    /**
+     * Sets up this unit test.
+     *
+     * @return void
+     */
     protected function setUp()
     {
         parent::setUp();

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -39,6 +39,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$sniffFiles = array();
+        parent::setUpBeforeClass();
     }
 
     /**
@@ -59,6 +60,8 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
 
         self::$phpcs->process(array(), dirname( __FILE__ ) . '/../');
         self::$phpcs->setIgnorePatterns(array());
+
+        parent::setUp();
     }
 
     /**

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -36,11 +36,11 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for this unit test.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -30,11 +30,11 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for this unit test.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -28,11 +28,11 @@ class InternalInterfacesSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for this unit test.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -30,11 +30,11 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for some of these unit tests.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -30,6 +30,8 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * Set up skip condition.
+     *
+     * @return void
      */
     public static function setUpBeforeClass()
     {
@@ -37,6 +39,8 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
         if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
+
+        parent::setUpBeforeClass();
     }
 
 

--- a/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarReturnTypeDeclarationsSniffTest.php
@@ -23,7 +23,9 @@ class NewScalarReturnTypeDeclarationsSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/new_scalar_return_type_declarations.php';
 
     /**
-     * Set up: skip these tests if the PHPCS version isn't high enough.
+     * Skip the test(s) for low PHPCS versions.
+     *
+     * @return void
      */
     protected function setUp()
     {

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -30,6 +30,8 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
 
     /**
      * Set up skip condition.
+     *
+     * @return void
      */
     public static function setUpBeforeClass()
     {
@@ -37,6 +39,8 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
         if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
+
+        parent::setUpBeforeClass();
     }
 
 

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -31,12 +31,16 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
 
     /**
      * Set up skip condition.
+     *
+     * @return void
      */
     public static function setUpBeforeClass()
     {
         if (version_compare(phpversion(), '7.0', '<')) {
             self::$aspTags = (boolean) ini_get('asp_tags');
         }
+
+        parent::setUpBeforeClass();
     }
 
 

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -31,11 +31,11 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for some of these unit tests.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -30,11 +30,11 @@ class ValidIntegersSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
-     * setUp
+     * Set up the test file for some of these unit tests.
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 


### PR DESCRIPTION
Review the `setUp()` and `setUpBeforeClass()` methods if/when used in test classes.

* Make sure that if a `setUp()` or `setUpBeforeClass()` method is used, the parent is always called as well.
* Make sure that the `setUpBeforeClass()` method is always defined as `public static`.
* Make sure that the `setUp()` method is always defined as `protected` as it is in the parent.
* Make sure that these methods all have a docblock.
* Removed an unused `setUp()` method which only fell through to the parent.