### PR TITLE
Fix anonymous class exclusion for PHPCS < 2.3.4 for ForbiddenNamesSniff

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -228,7 +228,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
         $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty !== false
             && $tokens[$prevNonEmpty]['type'] === 'T_NEW'
-            && $tokens[$stackPtr]['type'] === 'T_ANON_CLASS'
+            && ($tokens[$stackPtr]['type'] === 'T_ANON_CLASS' || $tokens[$stackPtr]['type'] === 'T_CLASS')
         ) {
             return;
         }


### PR DESCRIPTION
In PHPCS < 2.3.4, the type of the `class` keyword for anonymous classes is still `T_CLASS`.

This fix allows for that.