### PR TITLE
Make the NewGroupUseDeclarationsSniff available in PHPCS < 2.6.0

### DIFF
--- a/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -22,15 +22,6 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
 
     const TEST_FILE = 'sniff-examples/new_group_use_declarations.php';
 
-    protected function setUp()
-    {
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '<')) {
-            $this->markTestSkipped();
-        }
-        else {
-            parent::setUp();
-        }
-    }
 
     /**
      * testGroupUseDeclaration
@@ -62,8 +53,9 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
     public function dataGroupUseDeclaration()
     {
         return array(
-            array(13),
-            array(14),
+            array(23),
+            array(24),
+            array(25),
         );
     }
 
@@ -79,7 +71,7 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
      */
     public function testValidUseDeclaration($line)
     {
-        $file = $this->sniffFile(self::TEST_FILE);
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, $line);
     }
 
@@ -98,7 +90,11 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
             array(6),
             array(8),
             array(9),
-            array(10),
+            array(11),
+            array(13),
+            array(15),
+            array(19),
+            array(20),
         );
     }
 }

--- a/Tests/sniff-examples/new_group_use_declarations.php
+++ b/Tests/sniff-examples/new_group_use_declarations.php
@@ -1,14 +1,25 @@
 <?php
 
 // Pre PHP 7 code
-use some\oddnamespace\ClassA;
-use some\oddnamespace\ClassB;
-use some\oddnamespace\ClassC as C;
+use ArrayObject;
+use some\namespace\ClassA;
+use some\namespace\ClassC as C;
 
-use somefunction some\oddnamespace\fn_a;
-use somefunction some\oddnamespace\fn_b;
-use somefunction some\oddnamespace\fn_c;
+use function some\namespace\fn_a;
+use function My\Full\functionName as func;
+
+use const some\namespace\ConstA;
+
+use My\Full\Classname as Another, My\Full\NSname;
+
+use A, B {
+   B::smallTalk insteadof A;
+   A::bigTalk insteadof B;
+}
+use HelloWorld { sayHello as protected; }
+use HelloWorld { sayHello as private myPrivateHello; }
 
 // PHP 7+ code
-use some\oddnamespace\{ClassA, ClassB, ClassC as C};
-use somefunction some\oddnamespace\{fn_a, fn_b, fn_c};
+use some\namespace\{ClassA, ClassB, ClassC as C};
+use function some\namespace\{fn_a, fn_b, fn_c};
+use const some\namespace\{ConstA, ConstB, ConstC};


### PR DESCRIPTION
When looking to increase code coverage, this seemed like a quick fix to make.

I've also tested it against various PHPCS versions and the version number previously used for exclusion/test skipping appears wrong and the sniff was throwing notices about an undefined constant in some versions. Turns out the `T_OPEN_USE_GROUP` token was only introduced into PHPCS in v2.6.0.

Includes additional unit test cases to test for more differentiation in syntax.

Removes test exclusion for this sniff on older PHPCS versions.