### PR TITLE
Make the NewNullableTypesSniff work consistently in PHPCS < 2.6.0

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -992,14 +992,14 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 break;
             case T_ARRAY_HINT:
             case T_CALLABLE:
-                $typeHint = $tokens[$i]['content'];
+                $typeHint .= $tokens[$i]['content'];
                 break;
             case T_SELF:
             case T_PARENT:
             case T_STATIC:
                 // Self is valid, the others invalid, but were probably intended as type hints.
                 if ($defaultStart === null) {
-                    $typeHint = $tokens[$i]['content'];
+                    $typeHint .= $tokens[$i]['content'];
                 }
                 break;
             case T_STRING:

--- a/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -33,11 +33,6 @@ class NewNullableTypesSniffTest extends BaseSniffTest
      */
     public function testNewNullableReturnTypes($line)
     {
-        // Skip this test for low PHPCS versions.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '<')) {
-            $this->markTestSkipped();
-        }
-
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertError($file, $line, 'Nullable return types are not supported in PHP 7.0 or earlier.');
 


### PR DESCRIPTION
When reviewing test skip conditions I came across this one which was not that difficult to backport.

* Fixes: `self` and `callable` not being recognized as T_RETURN_TYPE in PHPCS < 2.6.0
* Fixes: return types not recognized at all in PHPCS < 2.4.0
* Fixes: the `?` of a nullable type hint not being added correctly to the typehint content for `array`, `callable` and `self`.

Removes test exclusion for this sniff on older PHPCS versions.