### PR TITLE
Review travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
   include:
 
     - php: 5.2
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION="1.5.6"
+      env: PHPCS_VERSION="1.5.6"
     - php: 5.2
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION="master"
+      env: PHPCS_VERSION="master"
 
     - php: 5.3
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
@@ -22,52 +22,55 @@ matrix:
       env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
 
     - php: 5.5
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.5
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
     - php: 5.5
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
     - php: 5.6
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.6
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
     - php: 5.6
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
     - php: 7.0
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 7.0
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
     - php: 7.0
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master" SNIFF=1
+
+    - php: 7.1
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+    - php: 7.1
+      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+    - php: 7.1
       env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
-    - php: 7.1
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
-    - php: 7.1
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
-    - php: 7.1
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
 
-
-before_script:
-  - phpenv rehash
-
-install:
+before_install:
+  # PHP 5.3+: set up test environment using Composer.
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer self-update; fi
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer require squizlabs/php_codesniffer:${PHPCS_VERSION}; fi
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer install; fi
+  # PHP 5.2: set up test environment using git cloning.
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_BIN=$(if [[ $PHPCS_VERSION == 3.0 ]]; then echo $PHPCS_DIR/bin/phpcs; else echo $PHPCS_DIR/scripts/phpcs; fi); fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_BIN=$PHPCS_DIR/scripts/phpcs; fi
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_VERSION $PHPCS_DIR; fi
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then $PHPCS_BIN --config-set installed_paths $(pwd); fi
 
+before_script:
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then mkdir -p build/logs; fi
+  - phpenv rehash
+
 script:
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then ln -s `pwd` vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; fi
-  - mkdir -p build/logs
   - find -L . -path ./Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --standard=./phpcs.xml; fi
   - phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml
 
-after_script:
-  - php vendor/bin/coveralls -v -x build/logs/clover.xml
+after_success:
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -23,7 +23,7 @@ if (file_exists($phpcsDir . 'CodeSniffer.php')) {
 }
 else {
     // Otherwise we must be in a composer install.
-    $vendorDir = __DIR__ . '/../vendor';
+    $vendorDir = dirname(__FILE__) . '/../vendor';
 
     if (!@include($vendorDir . '/autoload.php')) {
         echo 'You must set up the project dependencies, run the following commands:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCS Coding Standards for PHPCompatibility">
+	<description>Check the code of the PHPCompatibility standard itself.</description>
+
+	<arg value="sp"/>
+	<arg name="extensions" value="php"/>
+
+	<!-- Exclude test case code. -->
+	<exclude-pattern>/Tests/sniff-examples/*</exclude-pattern>
+
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<config name="testVersion" value="5.1-99.0"/>
+	<rule ref="PHPCompatibility"/>
+
+	<!-- Verified correct usage. -->
+	<rule ref="PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved">
+		<exclude-pattern>*/RemovedAlternativePHPTags*.php</exclude-pattern>
+	</rule>
+
+</ruleset>


### PR DESCRIPTION
* Use the correct coveralls version for each PHP version.
    Coveralls 1.x has a PHP 5.3.3 minimum requirement, coveralls 2.x has a PHP 5.5 minimum requirement.
* Coveralls can not run on PHP 5.2 at all, so no need to define the environment variable, set up the log directory or to attempt to run the coveralls command
* Change `install` to `before_install`. This will mark the build as "errored" if the build fails because the environment could not be set up correctly instead of "failed".
* Change `after_script` to `after_success` as running the coveralls code coverage check is not much use if the unit tests fail.
* Run the code of the standard itself through PHPCS to test for cross-version PHPCompatibility. The `phpcs.xml` can later be extended to also include actual code style sniffs.
     The checking for cross-version compatibility is only done once as the results across PHP version should not change (and testing that is tested by the unit tests).
* Remove the reference to PHPCS 3.x as that is currently not supported and probably won't be for the foreseeable future.