### PR TITLE
Improve how string tokens are dealt with in PregReplaceEModifierSniff.

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -129,7 +129,12 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
         $regex = '';
         for ($i = $pattern['start']; $i <= $pattern['end']; $i++ ) {
             if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
-                $regex .= $this->stripQuotes($tokens[$i]['content']);
+                $content = $this->stripQuotes($tokens[$i]['content']);
+                if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
+                    $content = $this->stripVariables($content);
+                }
+
+                $regex .= trim($content);
             }
         }
         // Deal with multi-line regexes which were broken up in several string tokens.

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -99,6 +99,10 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(177),
 
             array(182), // Three errors.
+
+            // Interpolated variables.
+            array(204),
+            array(205),
         );
     }
 
@@ -166,6 +170,9 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             array(178),
             array(187),
             array(201),
+
+            // Interpolated variables.
+            array(206),
         );
     }
 

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -199,3 +199,8 @@ $cleaned = preg_replace(
 // Another false positive.
 // https://wordpress.org/support/topic/wrong-error-preg_replace-e-modifier-is-forbidden-since-php-7-0/
 $this->value = preg_replace( $this->field['preg']['pattern'], $this->field['preg']['replacement'], $this->value );
+
+// Deal correctly with interpolated strings.
+preg_replace("/dou$ble-quoted/e", $Replace, $Source); // Bad.
+preg_replace("/dou$ble-quoted/me$me", $Replace, $Source); // Bad.
+preg_replace("/double-quoted/$e", $Replace, $Source); // Ok.


### PR DESCRIPTION
Includes additional unit tests.

(Sister-PR to #314 which fixed this for the Mbstring /e sniff)