### PR TITLE
Backport the NewAnonymousClassesSniff for older PHPCS versions.

### DIFF
--- a/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
@@ -21,15 +21,7 @@
 class NewAnonymousClassesSniffTest extends BaseSniffTest
 {
 
-    protected function setUp()
-    {
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '<')) {
-            $this->markTestSkipped();
-        }
-        else {
-            parent::setUp();
-        }
-    }
+    const TEST_FILE = 'sniff-examples/new_anonymous_classes.php';
 
     /**
      * Test anonymous classes
@@ -38,10 +30,23 @@ class NewAnonymousClassesSniffTest extends BaseSniffTest
      */
     public function testAnonymousClasses()
     {
-        $file = $this->sniffFile('sniff-examples/new_anonymous_classes.php', '5.6');
-        $this->assertError($file, 4, "Anonymous classes are not supported in PHP 5.6 or earlier");
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertError($file, 4, 'Anonymous classes are not supported in PHP 5.6 or earlier');
 
-        $file = $this->sniffFile('sniff-examples/new_anonymous_classes.php', '7.0');
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, 4);
     }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, 3);
+    }
+
 }


### PR DESCRIPTION
This seemed like a quick fix to make.

In PHPCS 2.3.4 - 2.5.2, this sniff would throw an error about the `T_ANON_CLASS` constant not being defined (as it wasn't fully implemented properly in PHPCS until PHPCS 2.6.0).
Pre-PHPCS 2.3.4, the sniff was disregarded and the test skipped.

Includes additional test against false positives (test case was already in place, just not tested).
Removes test exclusion for this sniff on PHPCS <2.3.4.