### PR TITLE
Allow for array parameters in a function call used in a define.

### DIFF
--- a/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -73,13 +73,20 @@ class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPComp
             return;
         }
 
+        $targetNestingLevel = 0;
+        if (isset($tokens[$secondParam['start']]['nested_parenthesis'])) {
+            $targetNestingLevel = count($tokens[$secondParam['start']]['nested_parenthesis']);
+        }
+
         $array = $phpcsFile->findNext(array(T_ARRAY, T_OPEN_SHORT_ARRAY), $secondParam['start'], ($secondParam['end'] + 1));
         if ($array !== false) {
-            $phpcsFile->addError(
-                'Constant arrays using define are not allowed in PHP 5.6 or earlier',
-                $array,
-                'Found'
-            );
+            if ((isset($tokens[$array]['nested_parenthesis']) === false && $targetNestingLevel === 0) || count($tokens[$array]['nested_parenthesis']) === $targetNestingLevel) {
+                $phpcsFile->addError(
+                    'Constant arrays using define are not allowed in PHP 5.6 or earlier',
+                    $array,
+                    'Found'
+                );
+            }
         }
     }
 }

--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -67,7 +67,7 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
      */
     public function testNoViolation($line)
     {
-        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, $line);
     }
 
@@ -88,6 +88,8 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
             array(23),
             array(26),
             array(28),
+            array(31),
+            array(32),
         );
     }
 

--- a/Tests/sniff-examples/constant_arrays_using_define.php
+++ b/Tests/sniff-examples/constant_arrays_using_define.php
@@ -26,3 +26,7 @@ class myClass {
 notDefine('ANIMALS', 'dog');
 
 define('ANIMALS');
+
+// Array within a function call.
+define('WPDIRAUTH_LDAP_RETURN_KEYS',serialize(array('sn', 'givenname', 'mail')));
+define('WPDIRAUTH_LDAP_RETURN_KEYS',serialize(['sn', 'givenname', 'mail']));


### PR DESCRIPTION
If a function call is made to set the value of a constant through `define()`, it depends on the function called whether or not the value passed to `define()` is one of the acceptable variable types, but determining what the variable type returned by the function call is (or could be), is outside of the scope of a static analyse tool.

So I believe, in that case we should not throw an error.

Includes additional unit tests.
Also changes the `testVersion` for the `noViolation` / false positives test to `5.6` to prevet interference from the short array syntax sniff.

Fixes the issue reported in https://github.com/wpengine/phpcompat/issues/101