### PR TITLE
Allow for closures for a number of sniffs which only checked functions.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -1014,8 +1014,9 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      * 'default' with the value of the default as a string.
      *
      * {@internal Duplicate of same method as contained in the `PHP_CodeSniffer_File`
-     * class, but with some improvements which will probably be introduced in
-     * PHPCS 2.7.2. {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1117},
+     * class, but with some improvements which have been introduced in
+     * PHPCS 2.8.0.
+     * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1117},
      * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1193} and
      * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1293}.
      *

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -30,7 +30,10 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(
+            T_FUNCTION,
+            T_CLOSURE,
+        );
 
     }//end register()
 
@@ -57,7 +60,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
         }
 
         // Get all parameters from method signature.
-        $parameters = $phpcsFile->getMethodParameters($stackPtr);
+        $parameters = $this->getMethodParameters($phpcsFile, $stackPtr);
         if (empty($parameters) || is_array($parameters) === false) {
             return;
         }

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -79,7 +79,10 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
      */
     public function register()
     {
-        return array(T_FUNCTION);
+        return array(
+            T_FUNCTION,
+            T_CLOSURE,
+        );
     }//end register()
 
 

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -36,7 +36,10 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
      * @return array
      */
     public function register() {
-        return array(T_FUNCTION);
+        return array(
+            T_FUNCTION,
+            T_CLOSURE,
+        );
     }
 
     /**
@@ -53,7 +56,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
         }
 
         // Get all parameters from function signature.
-        $parameters = $phpcsFile->getMethodParameters($stackPtr);
+        $parameters = $this->getMethodParameters($phpcsFile, $stackPtr);
         if (empty($parameters) || is_array($parameters) === false) {
             return;
         }

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -24,18 +24,37 @@ class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
 
 
     /**
-     * testSettingTestVersion
+     * testFunctionParametersWithSameName
+     *
+     * @dataProvider dataFunctionParametersWithSameName
+     *
+     * @param int $line Line number.
      *
      * @return void
      */
-    public function testSettingTestVersion()
+    public function testFunctionParametersWithSameName($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertNoViolation($file, 3);
+        $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, 3, 'Functions can not have multiple parameters with the same name since PHP 7.0');
+        $this->assertError($file, $line, 'Functions can not have multiple parameters with the same name since PHP 7.0');
     }
+
+    /**
+     * dataFunctionParametersWithSameName
+     *
+     * @see testFunctionParametersWithSameName()
+     *
+     * @return array
+     */
+    public function dataFunctionParametersWithSameName() {
+        return array(
+            array(3),
+            array(7),
+        );
+    }
+
 
     /**
      * testNoViolation
@@ -62,7 +81,7 @@ class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
     public function dataNoViolation() {
         return array(
             array(5),
-            array(8),
+            array(10),
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -59,6 +59,8 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
             array('float', '5.6', 13, '7.0'),
             array('string', '5.6', 14, '7.0'),
             array('iterable', '7.0', 17, '7.1'),
+            array('callable', '5.3', 52, '5.4'),
+            array('int', '5.6', 53, '7.0'),
         );
     }
 
@@ -178,6 +180,8 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
             array(37),
             array(41, true),
             array(44),
+            array(52),
+            array(53),
         );
     }
 

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -62,6 +62,9 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
             array('$_SESSION', 10),
             array('$_REQUEST', 11),
             array('$_ENV', 12),
+            array('$GLOBALS', 20),
+            array('$_SERVER', 21),
+            array('$_GET', 22),
         );
     }
 

--- a/Tests/sniff-examples/forbidden_function_parameters_with_same_name.php
+++ b/Tests/sniff-examples/forbidden_function_parameters_with_same_name.php
@@ -4,5 +4,7 @@ function foo($a, $b, $unused, $unused) { }
 
 function foobaz() {} // No parameters = no error.
 
+function ($a, $b, $unused, $unused) {} // Anonymous function with params of same name.
+
 // Don't throw errors during live code review.
 function foobar($a,$a

--- a/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -47,3 +47,7 @@ namespace test {
 // Ok: No function parameters or no type hints.
 function foo() {}
 function foo( $a, $b ) {}
+
+// Type hints in closures.
+function (callable $a) {}
+function(int $a) {}

--- a/Tests/sniff-examples/parameter_shadow_superglobals.php
+++ b/Tests/sniff-examples/parameter_shadow_superglobals.php
@@ -15,3 +15,8 @@ function testingI( $_ENV ) {}
 function testingJ( $globals ) {}
 function testingK( $_post ) {}
 function testingL( $POST ) {}
+
+// Closures: these should be flagged.
+function ( $GLOBALS ) {}
+function( $_SERVER ) {}
+function($_GET) {}


### PR DESCRIPTION
* Adjusted the `getMethodParameters()` method to also allow `T_CLOSURE` tokens to be processed. The same change has been PR-ed and merged upstream https://github.com/squizlabs/PHP_CodeSniffer/pull/1293.
* Made sure that any calls from the PHPCompatibility sniffs to that method are made to the local version and not to the PHPCS native one.
* Register the `T_CLOSURE` token for three sniffs which should also be applied to anonymous functions.
* Added unit tests for the same.

The same fix as was made here, but then for the `NewNullableTypes` and `NewReturnTypes`sniffs is contained within #323.

N.B. The unit test failure is due to the issue reported in #330 and will be fixed once #323 has been merged.