### PR TITLE
PHP 5.3: Detect NOWDOC syntax

### DIFF
--- a/Sniffs/PHP/NewKeywordsSniff.php
+++ b/Sniffs/PHP/NewKeywordsSniff.php
@@ -11,7 +11,7 @@
  */
 
 /**
- * PHPCompatibility_Sniffs_PHP_NewClassesSniff.
+ * PHPCompatibility_Sniffs_PHP_NewKeywordsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -111,16 +111,6 @@ class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_Abst
                                             '5.5' => true,
                                             'description' => '"finally" keyword (in exception handling)',
                                             'content' => 'finally',
-                                        ),
-                                        'T_START_NOWDOC' => array(
-                                            '5.2' => false,
-                                            '5.3' => true,
-                                            'description' => 'nowdoc functionality',
-                                        ),
-                                        'T_END_NOWDOC' => array(
-                                            '5.2' => false,
-                                            '5.3' => true,
-                                            'description' => 'nowdoc functionality',
                                         ),
                                     );
 

--- a/Sniffs/PHP/NewNowdocSniff.php
+++ b/Sniffs/PHP/NewNowdocSniff.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewNowdocSniff.
+ *
+ * PHP version 5.3
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewNowdocSniff.
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewNowdocSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = array();
+
+        if (version_compare(PHP_VERSION, '5.3', '<') === true) {
+            $targets[] = T_SL;
+        }
+
+        if (defined('T_START_NOWDOC')) {
+            $targets[] = constant('T_START_NOWDOC');
+        }
+        if (defined('T_END_NOWDOC')) {
+            $targets[] = constant('T_END_NOWDOC');
+        }
+
+        return $targets;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return int|void On older PHP versions passes a pointer to the nowdoc closer
+     *                  to skip passed anything in between in regards to processing
+     *                  the file for this sniff.
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.2') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        /*
+         * In PHP 5.2 the T_NOWDOC tokens aren't recognized yet and PHPCS does not
+         * backfill for it, so we have to sniff for a specific combination of tokens.
+         */
+        if ($tokens[$stackPtr]['code'] === T_SL) {
+            if (isset($tokens[($stackPtr+1)]) === false || $tokens[($stackPtr + 1)]['code'] !== T_LESS_THAN) {
+                return;
+            }
+
+            if (isset($tokens[($stackPtr+2)]) === false
+                || $tokens[($stackPtr + 2)]['code'] !== T_CONSTANT_ENCAPSED_STRING) {
+                return;
+            }
+
+            /*
+             * Heredoc and nowdoc naming rules:
+             * "it must contain only alphanumeric characters and underscores and
+             *  must start with a non-digit character or underscore"
+             * @link http://php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
+             */
+            if (preg_match('`^\'([a-z][a-z0-9_]*)\'$`iD', $tokens[($stackPtr + 2)]['content'], $matches) < 1) {
+                return;
+            }
+
+            $closer = null;
+
+            for ($i = ($stackPtr + 3); $i < $phpcsFile->numTokens; $i++) {
+                $maybeCloser = $phpcsFile->findNext(T_STRING, $i, null, false, $matches[1]);
+                if ($maybeCloser === false) {
+                    return;
+                }
+
+                // The closing identifier must begin in the first column of the line.
+                if ($tokens[$maybeCloser]['column'] !== 1) {
+                    continue;
+                }
+
+                // The closing identifier must be the only content on that line, except for maybe a semi-colon.
+                $next = $phpcsFile->findNext(array(T_WHITESPACE, T_SEMICOLON), ($maybeCloser + 1), null, true);
+                if ($tokens[$maybeCloser]['line'] === $tokens[$next]['line']) {
+                    continue;
+                }
+
+                $closer = $maybeCloser;
+                break;
+            }
+
+            if (isset($closer) === false) {
+                // No valid closer found.
+                return;
+            }
+        }
+
+        $phpcsFile->addError('Nowdocs are not present in PHP version 5.2 or earlier.', $stackPtr, 'Found');
+
+        if (isset($closer) !== false) {
+            $phpcsFile->addError('Nowdocs are not present in PHP version 5.2 or earlier.', $closer, 'Found');
+            return ($closer + 1);
+        }
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -30,7 +30,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testDirMagicConstant()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 3, "__DIR__ magic constant is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 3, '__DIR__ magic constant is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 3);
@@ -44,8 +44,8 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testInsteadOf()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, 15, "\"insteadof\" keyword (for traits) is not present in PHP version 5.3 or earlier");
-        $this->assertError($file, 16, "\"insteadof\" keyword (for traits) is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 15, '"insteadof" keyword (for traits) is not present in PHP version 5.3 or earlier');
+        $this->assertError($file, 16, '"insteadof" keyword (for traits) is not present in PHP version 5.3 or earlier');
 
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
@@ -61,7 +61,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testNamespaceKeyword()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 20, "\"namespace\" keyword is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 20, '"namespace" keyword is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 20);
@@ -75,7 +75,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testNamespaceConstant()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 22, "__NAMESPACE__ magic constant is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 22, '__NAMESPACE__ magic constant is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 22);
@@ -89,7 +89,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testTraitKeyword()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, 24, "\"trait\" keyword is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 24, '"trait" keyword is not present in PHP version 5.3 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, 24);
@@ -103,7 +103,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testTraitConstant()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, 26, "__TRAIT__ magic constant is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 26, '__TRAIT__ magic constant is not present in PHP version 5.3 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, 26);
@@ -117,7 +117,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testUse()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 14, "\"use\" keyword (for traits/namespaces/anonymous functions) is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 14, '"use" keyword (for traits/namespaces/anonymous functions) is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 14);
@@ -131,7 +131,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testYield()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
-        $this->assertError($file, 33, "\"yield\" keyword (for generators) is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 33, '"yield" keyword (for generators) is not present in PHP version 5.4 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
         $this->assertNoViolation($file, 33);
@@ -145,28 +145,10 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testFinally()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
-        $this->assertError($file, 9, "\"finally\" keyword (in exception handling) is not present in PHP version 5.4 or earlier");
+        $this->assertError($file, 9, '"finally" keyword (in exception handling) is not present in PHP version 5.4 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
         $this->assertNoViolation($file, 9);
-    }
-
-    /**
-     * testNowdoc
-     *
-     * @requires PHP 5.3
-     *
-     * @return void
-     */
-    public function testNowdoc()
-    {
-        $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 37, "nowdoc functionality is not present in PHP version 5.2 or earlier");
-        $this->assertError($file, 41, "nowdoc functionality is not present in PHP version 5.2 or earlier");
-
-        $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertNoViolation($file, 37);
-        $this->assertNoViolation($file, 41);
     }
 
     /**
@@ -177,14 +159,14 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testConst()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 43, "\"const\" keyword is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 37, '"const" keyword is not present in PHP version 5.2 or earlier');
+        $this->assertNoViolation($file, 40);
+        $this->assertNoViolation($file, 41);
+        $this->assertNoViolation($file, 45);
         $this->assertNoViolation($file, 46);
-        $this->assertNoViolation($file, 47);
-        $this->assertNoViolation($file, 51);
-        $this->assertNoViolation($file, 52);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertNoViolation($file, 43);
+        $this->assertNoViolation($file, 37);
     }
 
     /**
@@ -195,7 +177,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testCallable()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, 55, "\"callable\" keyword is not present in PHP version 5.3 or earlier");
+        $this->assertError($file, 49, '"callable" keyword is not present in PHP version 5.3 or earlier');
 
         // Not testing no violations as the ForbiddenNames sniff will also kick in.
     }
@@ -208,10 +190,10 @@ class NewKeywordsSniffTest extends BaseSniffTest
     public function testGoto()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 57, "\"goto\" keyword is not present in PHP version 5.2 or earlier");
+        $this->assertError($file, 51, '"goto" keyword is not present in PHP version 5.2 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertNoViolation($file, 57);
+        $this->assertNoViolation($file, 51);
     }
 
     /**
@@ -226,7 +208,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
         if (version_compare(phpversion(), '5.3', '=')) {
             // PHP 5.3 actually shows the warning.
             $file = $this->sniffFile(self::TEST_FILE, '5.0');
-            $this->assertError($file, 63, "\"__halt_compiler\" keyword is not present in PHP version 5.0 or earlier");
+            $this->assertError($file, 63, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');
         }
         else {
             /*

--- a/Tests/Sniffs/PHP/NewNowdocSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNowdocSniffTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * New nowdoc sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New nowdoc sniff tests
+ *
+ * @group newNowdoc
+ * @group reservedKeywords
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_NewNowdocSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewNowdocSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_nowdoc.php';
+
+
+    /**
+     * testNowdoc
+     *
+     * @dataProvider dataNowdoc
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNowdoc($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertError($file, $line, 'Nowdocs are not present in PHP version 5.2 or earlier.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNowdoc()
+     *
+     * @return array
+     */
+    public function dataNowdoc()
+    {
+        return array(
+            array(11),
+            array(15),
+            array(17),
+            array(21),
+            array(25),
+            array(28),
+            array(30),
+            array(33),
+            array(36),
+            array(44),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $data = array(
+            array(4),
+            array(8),
+            array(26),
+            array(32),
+        );
+
+        // PHPCS 1.x does not support skipping forward.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '>=')) {
+            $data[] = array(38);
+            $data[] = array(42);
+        }
+
+        return $data;
+    }
+
+}

--- a/Tests/sniff-examples/new_keywords.php
+++ b/Tests/sniff-examples/new_keywords.php
@@ -34,12 +34,6 @@ function gen_one_to_three() {
     }
 }
 
-$str = <<<'EOD'
-Example of string
-spanning multiple lines
-using nowdoc syntax.
-EOD;
-
 const TEST = 'Hello';
 
 class testing {

--- a/Tests/sniff-examples/new_nowdoc.php
+++ b/Tests/sniff-examples/new_nowdoc.php
@@ -1,0 +1,44 @@
+<?php
+
+// Heredoc is ok.
+$str = <<<EOD
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+EOD;
+
+// Nowdoc is not.
+$str = <<<'LABEL'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+LABEL;
+
+$array = array( 'nowdoc' => <<<'a_c'
+Example of string
+spanning multiple lines
+using nowdoc syntax.
+a_c
+);
+
+// Test properly identifying the closer.
+$str = <<<'LABEL'
+Now this is not the end: LABEL;
+The next line is ;-)
+LABEL;
+
+$str = <<<'LABEL'
+This is not the end:
+LABEL; The next line is ;-)
+LABEL;
+
+// Test skipping forward. Doesn't work in PHPCS < 2.0.
+echo <<<'NECHO'
+You create a nowdoc using the
+following syntax <<<'ID' to start
+and you end the nowdoc with
+the ID on a line by itself, like
+so:
+ID;
+Easy, isn't it ?
+NECHO;


### PR DESCRIPTION
When reviewing test skip conditions I came across the `NewKeywords` sniff which skipped for Nowdoc recognition in PHP 5.2 which is where it is actually important that it *is* recognized.
Turned out this was not that difficult to backport.

* I've removed nowdoc checking from the NewKeywords sniff as the logic is quite distinct and unrelated to anything else in that sniff.
* And I've added a new sniff specifically targetting Nowdoc syntax.

N.B. The unit test failure is due to the issue reported in #330 and will be fixed once #323 has been merged.