### PR TITLE
Travis script: Path fix for PHP 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_BIN=$PHPCS_DIR/scripts/phpcs; fi
   - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_VERSION $PHPCS_DIR; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then $PHPCS_BIN --config-set installed_paths $(pwd); fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then $PHPCS_BIN --config-set installed_paths "$(dirname "$(pwd)")"; fi
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then mkdir -p build/logs; fi


### PR DESCRIPTION
The `installed_paths` variable has to point to a top-level `standards` directory, not to an individual standard.

Wasn't causing any problems for now, but should be fixed anyhow (as it will cause an issue with an upcoming PR).