### PR TITLE
Test consistency: false positive tests

### DIFF
--- a/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -57,15 +57,15 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, $line);
@@ -74,11 +74,11 @@ class ConstantArraysUsingDefineSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(15),

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -415,4 +415,47 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         );
     }
 
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '99.0'); // High version beyond latest deprecated function version.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $testCases = array(
+            array(134),
+            array(135),
+            // array(137), // Not yet accounted for in the code, uncomment when fixed.
+            array(138),
+            array(139),
+            array(140),
+            array(141),
+        );
+
+        // Add an additional testcase which will only be 'no violation' if namespaces are recognized.
+        if (version_compare(phpversion(), '5.3', '>=')) {
+            $testCases[] = array(136);
+        }
+
+        return $testCases;
+    }
+
 }

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -24,44 +24,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/deprecated_ini_directives.php';
 
     /**
-     * testNoFalsePositives
-     *
-     * @dataProvider dataNoFalsePositives
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testNoFalsePositives($line)
-    {
-        $file = $this->sniffFile(self::TEST_FILE);
-        $this->assertNoViolation($file, $line);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testNoFalsePositives()
-     *
-     * @return array
-     */
-    public function dataNoFalsePositives()
-    {
-        return array(
-            array(57),
-            array(58),
-            array(133),
-            array(155),
-            array(156),
-            array(159),
-            array(160),
-            array(163),
-            array(164),
-        );
-    }
-
-
-    /**
      * testDeprecatedRemovedDirectives
      *
      * @dataProvider dataDeprecatedRemovedDirectives
@@ -306,6 +268,44 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('session.entropy_length', '7.1', array(144, 145), '7.0'),
             array('session.hash_function', '7.1', array(147, 148), '7.0'),
             array('session.hash_bits_per_character', '7.1', array(150, 151), '7.0'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(57),
+            array(58),
+            array(133),
+            array(155),
+            array(156),
+            array(159),
+            array(160),
+            array(163),
+            array(164),
         );
     }
 

--- a/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -59,12 +59,13 @@ class DeprecatedNewReferenceSniffTest extends BaseSniffTest
         );
     }
 
+
     /**
-     * testNoReference
+     * testNoFalsePositives
      *
      * @return void
      */
-    public function testNoReference()
+    public function testNoFalsePositives()
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, 8);

--- a/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -57,26 +57,26 @@ class DeprecatedPHP4StyleConstructorsSniffTest extends BaseSniffTest
     /**
      * Test valid methods with the same name as the class.
      *
-     * @dataProvider dataValidMethods
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line Line number where the error should occur.
      *
      * @return void
      */
-    public function testValidMethods($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
     }
 
     /**
-     * dataValidMethods
+     * dataNoFalsePositives
      *
-     * @see testValidMethods()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidMethods()
+    public function dataNoFalsePositives()
 	{
         $testCases = array(
             array(9),

--- a/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -80,15 +80,15 @@ class EmptyNonVariableSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, $line);
@@ -97,11 +97,11 @@ class EmptyNonVariableSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
@@ -64,15 +64,15 @@ class ForbiddenBreakContinueOutsideLoopSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -81,11 +81,11 @@ class ForbiddenBreakContinueOutsideLoopSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(8),

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -106,15 +106,15 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $this->assertNoViolation($this->_sniffFile, $line);
     }
@@ -122,11 +122,11 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(8),

--- a/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -85,15 +85,15 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $this->assertNoViolation($this->_sniffFile, $line);
     }
@@ -101,11 +101,11 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4), // OK: Declaring a parameter by reference.

--- a/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
@@ -57,28 +57,28 @@ class ForbiddenEmptyListAssignmentSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidListAssignment
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidListAssignment
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line Line number with a valid list assignment.
      *
      * @return void
      */
-    public function testValidListAssignment($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile('sniff-examples/forbidden_empty_list_assignment.php');
         $this->assertNoViolation($file, $line);
     }
 
     /**
-     * dataValidListAssignment
+     * dataNoFalsePositives
      *
-     * @see testValidListAssignment()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidListAssignment() {
+    public function dataNoFalsePositives() {
         return array(
             array(13),
             array(14),

--- a/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -57,28 +57,28 @@ class ForbiddenFunctionParametersWithSameNameSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line Line number with valid code.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
     }
 
     /**
-     * dataNoViolation
+     * dataNoFalsePositives
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation() {
+    public function dataNoFalsePositives() {
         return array(
             array(5),
             array(10),

--- a/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -58,7 +58,7 @@ class ForbiddenGlobalVariableVariableSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoFalsePositive
+     * testNoFalsePositives
      *
      * @dataProvider dataNoFalsePositives
      *

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -76,15 +76,15 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
         $this->assertNoViolation($file, $line);
@@ -93,11 +93,11 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(6),

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -113,11 +113,11 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
     }
 
     /**
-     * Test setting test version option
+     * testNoFalsePositives
      *
      * @return void
      */
-    public function testSettingTestVersion()
+    public function testNoFalsePositives()
     {
         $file = $this->sniffFile('sniff-examples/forbidden-names/class.php', '4.4');
         $this->assertNoViolation($file, 3);

--- a/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -55,15 +55,15 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -72,11 +72,11 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(6),

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -90,4 +90,34 @@ class InternalInterfacesSniffTest extends BaseSniffTest
         $this->assertError($this->_sniffFile, 9, 'The interface DATETIMEINTERFACE is intended for type hints only and is not implementable.');
         $this->assertError($this->_sniffFile, 10, 'The interface datetimeinterface is intended for type hints only and is not implementable.');
     }
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $this->assertNoViolation($this->_sniffFile, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(13),
+            array(14),
+        );
+    }
+
 }

--- a/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
+++ b/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
@@ -86,15 +86,15 @@ class LateStaticBindingSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
         $this->assertNoViolation($file, $line);
@@ -103,11 +103,11 @@ class LateStaticBindingSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(7),

--- a/Tests/Sniffs/PHP/LongArraysSniffTest.php
+++ b/Tests/Sniffs/PHP/LongArraysSniffTest.php
@@ -76,15 +76,15 @@ class LongArraysSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, $line);
@@ -93,11 +93,11 @@ class LongArraysSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             // Issue #268 - class properties named after long array variables.

--- a/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -64,15 +64,15 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.1');
         $this->assertNoViolation($file, $line);
@@ -81,11 +81,11 @@ class MbstringReplaceEModifierSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -103,15 +103,15 @@ class NewClassesSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, $line);
@@ -120,11 +120,11 @@ class NewClassesSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(6),

--- a/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -20,6 +20,8 @@
  */
 class NewClosureSniffTest extends BaseSniffTest
 {
+    const TEST_FILE = 'sniff-examples/new_closure.php';
+
     /**
      * Test closures
      *
@@ -27,10 +29,23 @@ class NewClosureSniffTest extends BaseSniffTest
      */
     public function testClosure()
     {
-        $file = $this->sniffFile('sniff-examples/new_closure.php', '5.2');
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
         $this->assertError($file, 3, 'Closures / anonymous functions are not available in PHP 5.2 or earlier');
 
-        $file = $this->sniffFile('sniff-examples/new_closure.php', '5.3');
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 3);
     }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, 6);
+    }
+
 }

--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -62,15 +62,15 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3'); // Arbitrary pre-PHP 7.1 version.
         $this->assertNoViolation($file, $line);
@@ -79,11 +79,11 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(3),

--- a/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -57,28 +57,28 @@ class NewFunctionArrayDereferencingSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line Line number with valid code.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
         $this->assertNoViolation($file, $line);
     }
 
     /**
-     * dataNoViolation
+     * dataNoFalsePositives
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation() {
+    public function dataNoFalsePositives() {
         return array(
             array(5),
             array(8),

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -175,15 +175,15 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidParameter
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidParameter
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidParameter($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
         $this->assertNoViolation($file, $line);
@@ -192,11 +192,11 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidParameter()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidParameter()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -24,26 +24,6 @@ class NewFunctionsSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/new_functions.php';
 
     /**
-     * Test functions that shouldn't be flagged by this sniff.
-     *
-     * These are either userland methods or namespaced functions.
-     *
-     * @requires PHP 5.3
-     *
-     * @return void
-     */
-    public function testNoFalsePositives()
-    {
-        $file = $this->sniffFile(self::TEST_FILE, '5.3');
-
-        $this->assertNoViolation($file, 4);
-        $this->assertNoViolation($file, 5);
-        $this->assertNoViolation($file, 6);
-        $this->assertNoViolation($file, 7);
-    }
-
-
-    /**
      * testNewFunction
      *
      * @dataProvider dataNewFunction
@@ -394,6 +374,47 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('session_gc', '7.0', array(320), '7.1'),
 
         );
+    }
+
+
+    /**
+     * Test functions that shouldn't be flagged by this sniff.
+     *
+     * These are either userland methods or namespaced functions.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        $testCases = array(
+            array(4),
+            array(5),
+            array(7),
+        );
+
+        // Add an additional testcase which will only be 'no violation' if namespaces are recognized.
+        if (version_compare(phpversion(), '5.3', '>=')) {
+            $testCases[] = array(6);
+        }
+
+        return $testCases;
     }
 
 }

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -32,7 +32,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
      *
      * @return void
      */
-    public function testFunctionsThatShouldntBeFlagged()
+    public function testNoFalsePositives()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
 

--- a/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -61,15 +61,15 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidUseDeclaration
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidUseDeclaration
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidUseDeclaration($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, $line);
@@ -78,11 +78,11 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidUseDeclaration()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidUseDeclaration()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHashAlgorithmSniffTest.php
@@ -69,15 +69,15 @@ class NewHashAlgorithmsSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.0-99.0');
         $this->assertNoViolation($file, $line);
@@ -86,11 +86,11 @@ class NewHashAlgorithmsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(6),

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -24,39 +24,6 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     const TEST_FILE = 'sniff-examples/new_ini_directives.php';
 
     /**
-     * Test functions that shouldn't be flagged by this sniff
-     *
-     * @dataProvider dataNoFalsePositives
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testNoFalsePositives($line)
-    {
-        $file = $this->sniffFile(self::TEST_FILE, '5.1');
-        $this->assertNoViolation($file, $line);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testNoFalsePositives()
-     *
-     * @return array
-     */
-    public function dataNoFalsePositives()
-    {
-        return array(
-            array(2),
-            array(3),
-            array(4),
-            array(5),
-        );
-    }
-
-
-    /**
      * testNewIniDirectives
      *
      * @dataProvider dataNewIniDirectives
@@ -265,6 +232,39 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         return array(
             array('fbsql.batchsize', '5.1', 'fbsql.batchSize', array(167, 168), '5.0'),
             array('zend.detect_unicode', '5.4', 'detect_unicode', array(260, 261), '5.3'),
+        );
+    }
+
+
+    /**
+     * Test functions that shouldn't be flagged by this sniff
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(2),
+            array(3),
+            array(4),
+            array(5),
         );
     }
 

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -26,13 +26,13 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     /**
      * Test functions that shouldn't be flagged by this sniff
      *
-     * @dataProvider dataFunctionThatShouldntBeFlagged
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testFunctionThatShouldntBeFlagged($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.1');
         $this->assertNoViolation($file, $line);
@@ -41,11 +41,11 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testFunctionThatShouldntBeFlagged()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataFunctionThatShouldntBeFlagged()
+    public function dataNoFalsePositives()
     {
         return array(
             array(2),

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -77,7 +77,7 @@ class NewInterfacesSniffTest extends BaseSniffTest
      */
     public function testUnsupportedMethods()
     {
-        $file = $this->sniffFile('sniff-examples/new_interfaces.php');
+        $file = $this->sniffFile(self::TEST_FILE);
         $this->assertError($file, 8, 'Classes that implement interface Serializable do not support the method __sleep(). See http://php.net/serializable');
         $this->assertError($file, 9, 'Classes that implement interface Serializable do not support the method __wakeup(). See http://php.net/serializable');
     }
@@ -89,9 +89,40 @@ class NewInterfacesSniffTest extends BaseSniffTest
      */
     public function testCaseInsensitive()
     {
-        $file = $this->sniffFile('sniff-examples/new_interfaces.php', '5.0');
+        $file = $this->sniffFile(self::TEST_FILE, '5.0');
         $this->assertError($file, 20, 'The built-in interface COUNTABLE is not present in PHP version 5.0 or earlier');
         $this->assertError($file, 21, 'The built-in interface countable is not present in PHP version 5.0 or earlier');
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(24),
+            array(25),
+        );
     }
 
 }

--- a/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -160,14 +160,43 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
         $this->assertError($file, 37, '"const" keyword is not present in PHP version 5.2 or earlier');
-        $this->assertNoViolation($file, 40);
-        $this->assertNoViolation($file, 41);
-        $this->assertNoViolation($file, 45);
-        $this->assertNoViolation($file, 46);
 
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, 37);
     }
+
+    /**
+     * testConstNoFalsePositives
+     *
+     * @dataProvider dataConstNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testConstNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testConstNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataConstNoFalsePositives()
+    {
+        return array(
+            array(40),
+            array(41),
+            array(45),
+            array(46),
+        );
+    }
+
 
     /**
      * testCallable

--- a/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -56,15 +56,15 @@ class NewMultiCatchSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0'); // Arbitrary pre-PHP 7.1 version.
         $this->assertNoViolation($file, $line);
@@ -73,11 +73,11 @@ class NewMultiCatchSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(8),

--- a/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -111,15 +111,15 @@ class NewNullableTypesSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0'); // Arbitrary pre-PHP 7.1 version.
         $this->assertNoViolation($file, $line);
@@ -128,11 +128,11 @@ class NewNullableTypesSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(8),

--- a/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
@@ -70,4 +70,36 @@ class NewReturnTypeDeclarationsSniffTest extends BaseSniffTest
             array('callable', '5.6', 20, '7.0'),
         );
     }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(23),
+            array(24),
+        );
+    }
+
 }

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -72,16 +72,16 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     }
 
     /**
-     * testCorrectImplementation
+     * testNoFalsePositives
      *
-     * @dataProvider dataCorrectImplementation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int  $line    The line number.
      * @param bool $isTrait Whether to load the class/interface test file or the trait test file.
      *
      * @return void
      */
-    public function testCorrectImplementation($line, $isTrait = false)
+    public function testNoFalsePositives($line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
             $this->markTestSkipped();
@@ -95,11 +95,11 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testCorrectImplementation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataCorrectImplementation()
+    public function dataNoFalsePositives()
     {
         return array(
             /*

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -71,115 +71,6 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
         }
     }
 
-    /**
-     * testNoFalsePositives
-     *
-     * @dataProvider dataNoFalsePositives
-     *
-     * @param int  $line    The line number.
-     * @param bool $isTrait Whether to load the class/interface test file or the trait test file.
-     *
-     * @return void
-     */
-    public function testNoFalsePositives($line, $isTrait = false)
-    {
-        if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
-            return;
-        }
-
-        $file = $this->getTestFile($isTrait);
-        $this->assertNoViolation($file, $line);
-    }
-
-    /**
-     * Data provider.
-     *
-     * @see testNoFalsePositives()
-     *
-     * @return array
-     */
-    public function dataNoFalsePositives()
-    {
-        return array(
-            /*
-             * nonstatic_magic_methods.php
-             */
-            // Plain class.
-            array(5),
-            array(6),
-            array(7),
-            array(8),
-            array(9),
-            array(10),
-            array(11),
-            array(12),
-            array(13),
-            // Normal class.
-            array(18),
-            array(19),
-            array(20),
-            array(21),
-            array(22),
-            array(23),
-            array(24),
-            array(25),
-            array(26),
-            array(27),
-
-            // Alternative property order & stacked.
-            array(58),
-
-            // Plain interface.
-            array(71),
-            array(72),
-            array(73),
-            array(74),
-            array(75),
-            array(76),
-            array(77),
-            array(78),
-            array(79),
-            // Normal interface.
-            array(84),
-            array(85),
-            array(86),
-            array(87),
-            array(88),
-            array(89),
-            array(90),
-            array(91),
-            array(92),
-            array(93),
-
-            /*
-             * nonstatic_magic_methods_traits.php
-             */
-            // Plain trait.
-            array(5, true),
-            array(6, true),
-            array(7, true),
-            array(8, true),
-            array(9, true),
-            array(10, true),
-            array(11, true),
-            array(12, true),
-            array(13, true),
-            // Normal trait.
-            array(18, true),
-            array(19, true),
-            array(20, true),
-            array(21, true),
-            array(22, true),
-            array(23, true),
-            array(24, true),
-            array(25, true),
-            array(26, true),
-            array(27, true),
-
-        );
-    }
-
 
     /**
      * testWrongMethodVisibility
@@ -378,6 +269,116 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
             // Trait.
             array('__callStatic', 49, true),
             array('__set_state', 50, true),
+
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int  $line    The line number.
+     * @param bool $isTrait Whether to load the class/interface test file or the trait test file.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->getTestFile($isTrait);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            /*
+             * nonstatic_magic_methods.php
+             */
+            // Plain class.
+            array(5),
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            // Normal class.
+            array(18),
+            array(19),
+            array(20),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(26),
+            array(27),
+
+            // Alternative property order & stacked.
+            array(58),
+
+            // Plain interface.
+            array(71),
+            array(72),
+            array(73),
+            array(74),
+            array(75),
+            array(76),
+            array(77),
+            array(78),
+            array(79),
+            // Normal interface.
+            array(84),
+            array(85),
+            array(86),
+            array(87),
+            array(88),
+            array(89),
+            array(90),
+            array(91),
+            array(92),
+            array(93),
+
+            /*
+             * nonstatic_magic_methods_traits.php
+             */
+            // Plain trait.
+            array(5, true),
+            array(6, true),
+            array(7, true),
+            array(8, true),
+            array(9, true),
+            array(10, true),
+            array(11, true),
+            array(12, true),
+            array(13, true),
+            // Normal trait.
+            array(18, true),
+            array(19, true),
+            array(20, true),
+            array(21, true),
+            array(22, true),
+            array(23, true),
+            array(24, true),
+            array(25, true),
+            array(26, true),
+            array(27, true),
 
         );
     }

--- a/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -70,15 +70,15 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidParameter
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidParameter
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidParameter($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
         $this->assertNoViolation($file, $line);
@@ -87,11 +87,11 @@ class ParameterShadowSuperGlobalsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidParameter()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidParameter()
+    public function dataNoFalsePositives()
     {
         return array(
             array(15),

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -108,15 +108,15 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line Line number where no error should occur.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, $line);
@@ -129,13 +129,13 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
     }
 
     /**
-     * dataNoViolation
+     * dataNoFalsePositives
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation() {
+    public function dataNoFalsePositives() {
         return array(
             // No or only valid modifiers.
             array(9),

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -140,15 +140,15 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
         $this->assertNoViolation($file, $line);
@@ -157,11 +157,11 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(3),

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -120,15 +120,15 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidParameter
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidParameter
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidParameter($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -137,11 +137,11 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidParameter()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidParameter()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -60,15 +60,15 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -77,11 +77,11 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(5),

--- a/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -82,15 +82,15 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.0-99.0');
         $this->assertNoViolation($file, $line);
@@ -99,11 +99,11 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(6),

--- a/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
@@ -66,15 +66,15 @@ class RequiredOptionalFunctionParameterSniffTest extends BaseSniffTest
 
 
     /**
-     * testValidParameter
+     * testNoFalsePositives
      *
-     * @dataProvider dataValidParameter
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testValidParameter($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -83,11 +83,11 @@ class RequiredOptionalFunctionParameterSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testValidParameter()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataValidParameter()
+    public function dataNoFalsePositives()
     {
         return array(
             array(4),

--- a/Tests/Sniffs/PHP/ShortArraySniffTest.php
+++ b/Tests/Sniffs/PHP/ShortArraySniffTest.php
@@ -61,15 +61,15 @@ class ShortArraySniffTest extends BaseSniffTest
 
 
     /**
-     * testNoViolation
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoViolation
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoViolation($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertNoViolation($file, $line);
@@ -78,11 +78,11 @@ class ShortArraySniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoViolation()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoViolation()
+    public function dataNoFalsePositives()
     {
         return array(
             array(5),

--- a/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
@@ -60,15 +60,15 @@ class VariableVariablesSniffTest extends BaseSniffTest
 
 
     /**
-     * testNoFalsePositive
+     * testNoFalsePositives
      *
-     * @dataProvider dataNoFalsePositive
+     * @dataProvider dataNoFalsePositives
      *
      * @param int $line The line number.
      *
      * @return void
      */
-    public function testNoFalsePositive($line)
+    public function testNoFalsePositives($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, $line);
@@ -77,11 +77,11 @@ class VariableVariablesSniffTest extends BaseSniffTest
     /**
      * Data provider.
      *
-     * @see testNoFalsePositive()
+     * @see testNoFalsePositives()
      *
      * @return array
      */
-    public function dataNoFalsePositive()
+    public function dataNoFalsePositives()
     {
         return array(
             array(11),

--- a/Tests/sniff-examples/deprecated_functions.php
+++ b/Tests/sniff-examples/deprecated_functions.php
@@ -129,3 +129,12 @@ mcrypt_module_is_block_mode();
 mcrypt_module_open();
 mcrypt_module_self_test();
 mdecrypt_generic();
+
+// Test against false positives.
+$class->php_check_syntax();
+MyClass::php_check_syntax();
+MyNamespace\php_check_syntax();
+echo PHP_CHECK_SYNTAX; // Constant.
+const php_check_syntax;
+use php_check_syntax;
+function php_check_syntax() {}

--- a/Tests/sniff-examples/internal_interfaces.php
+++ b/Tests/sniff-examples/internal_interfaces.php
@@ -8,3 +8,7 @@ class MyMultiple implements SomeInterface, Throwable, AnotherInterface, Traversa
 
 class MyUppercase implements DATETIMEINTERFACE {} // Test case-insensitivity.
 class MyLowercase implements datetimeinterface {} // Test case-insensitivity.
+
+// These shouldn't throw errors.
+class MyTraversable implements TraversableSomething {}
+class MyTraversable implements myNameSpace\Traversable {}

--- a/Tests/sniff-examples/new_closure.php
+++ b/Tests/sniff-examples/new_closure.php
@@ -2,3 +2,5 @@
 
 spl_autoload_register( function ( $class ) {
 } );
+
+function something() {}

--- a/Tests/sniff-examples/new_interfaces.php
+++ b/Tests/sniff-examples/new_interfaces.php
@@ -19,3 +19,7 @@ class MyMultiple implements SplSubject, JsonSerializable, Countable {}
 // Test case-insensitive matching
 class MyUppercase implements COUNTABLE {}
 class MyLowercase implements countable {}
+
+// These shouldn't throw errors.
+class MyJsonSerializable implements JsonSerializableSomething {}
+class MyJsonSerializable implements myNameSpace\JsonSerializable {}

--- a/Tests/sniff-examples/new_return_type_declarations.php
+++ b/Tests/sniff-examples/new_return_type_declarations.php
@@ -18,3 +18,7 @@ function foo($a): void {}
 
 // Anonymous function.
 function($a): callable {}
+
+// OK: no return type hint.
+function foo($a) {}
+function ($a) {}


### PR DESCRIPTION
* Make the function names for the false positive tests consistent
* Make the function order for the false positive tests consistent - test files test for what the sniff is all about first, after that test against false positives. I.e. move some functions down.
* Add some false positive tests for sniffs which didn't have any.

P.S.: this PR will be easiest to review by reviewing the commits individually.