### PR TITLE
Tests: minor efficiency tweaks related to the error messages.

### DIFF
--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -51,8 +51,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn}";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, $error);
         }
     }
 
@@ -101,8 +102,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+            $this->assertWarning($file, $line, $error);
         }
     }
 
@@ -229,8 +231,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Function {$functionName}() is removed since PHP {$removedIn}";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Function {$functionName}() is removed since PHP {$removedIn}");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -292,8 +295,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn}";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, $error);
         }
 
         if (isset($removedVersion)){
@@ -302,8 +306,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -363,8 +368,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+            $this->assertWarning($file, $line, $error);
         }
 
         if (isset($removedVersion)){
@@ -373,8 +379,9 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead");
+            $this->assertError($file, $line, $error);
         }
     }
 

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -53,8 +53,9 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, $error);
         }
 
         if (isset($removedVersion)){
@@ -63,8 +64,9 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
+        $error        = "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}";
+        $this->assertError($file, $lines[0], $error);
+        $this->assertWarning($file, $lines[1], $error);
     }
 
     /**
@@ -127,8 +129,9 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "INI directive '{$iniName}' is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, $error);
         }
     }
 
@@ -155,7 +158,6 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('mcrypt.modes_dir', '7.1', array(138, 139), '7.0'),
         );
     }
-
 
 
     /**
@@ -186,8 +188,9 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}; Use '{$alternative}' instead");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}; Use '{$alternative}' instead");
+        $error        = "INI directive '{$iniName}' is removed since PHP {$removedIn}; Use '{$alternative}' instead";
+        $this->assertError($file, $lines[0], $error);
+        $this->assertWarning($file, $lines[1], $error);
     }
 
     /**
@@ -205,6 +208,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('mbstring.script_encoding', '5.4', 'zend.script_encoding', array(128, 129), '5.3'),
         );
     }
+
 
     /**
      * testRemovedDirectives
@@ -233,8 +237,9 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is removed since PHP {$removedIn}");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is removed since PHP {$removedIn}");
+        $error        = "INI directive '{$iniName}' is removed since PHP {$removedIn}";
+        $this->assertError($file, $lines[0], $error);
+        $this->assertWarning($file, $lines[1], $error);
     }
 
     /**

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -74,7 +74,7 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
      */
     public function testBreakAndContinueVariableArgument($line, $errorType)
     {
-        $this->assertError($this->_sniffFile, $line, 'Using ' . $errorType . ' on break or continue is forbidden since PHP 5.4');
+        $this->assertError($this->_sniffFile, $line, "Using {$errorType} on break or continue is forbidden since PHP 5.4");
     }
 
     /**

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -37,9 +37,10 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
      */
     public function testReservedKeyword($keyword, $lines, $introducedIn, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $introducedIn);
+        $file  = $this->sniffFile(self::TEST_FILE, $introducedIn);
+        $error = "'{$keyword}' is a reserved keyword as of PHP version {$introducedIn} and cannot be used to name a class, interface or trait or as part of a namespace";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "'{$keyword}' is a reserved keyword as of PHP version {$introducedIn} and cannot be used to name a class, interface or trait or as part of a namespace");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -37,9 +37,10 @@ class ForbiddenNamesAsInvokedFunctionsSniffTest extends BaseSniffTest
      */
     public function testReservedKeyword($keyword, $lines, $introducedIn, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $introducedIn);
+        $file  = $this->sniffFile(self::TEST_FILE, $introducedIn);
+        $error = "'{$keyword}' is a reserved keyword introduced in PHP version {$introducedIn} and cannot be invoked as a function";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "'{$keyword}' is a reserved keyword introduced in PHP version {$introducedIn} and cannot be invoked as a function");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -37,9 +37,10 @@ class NewClassesSniffTest extends BaseSniffTest
      */
     public function testNewClass($className, $lastVersionBefore, $lines, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $file  = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $error = "The built-in class {$className} is not present in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The built-in class {$className} is not present in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -57,15 +57,17 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
      */
     public function testNewExecutionDirective($directive, $lastVersionBefore, $lines, $okVersion, $conditionalVersion = null, $condition = null)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $file  = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $error = "Directive {$directive} is not present in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "Directive {$directive} is not present in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, $error);
         }
 
         if (isset($conditionalVersion, $condition)) {
-            $file = $this->sniffFile(self::TEST_FILE, $conditionalVersion);
+            $file  = $this->sniffFile(self::TEST_FILE, $conditionalVersion);
+            $error = "Directive {$directive} is present in PHP version {$conditionalVersion} but will be disregarded unless PHP is compiled with {$condition}";
             foreach ($lines as $line) {
-                $this->assertWarning($file, $line, "Directive {$directive} is present in PHP version {$conditionalVersion} but will be disregarded unless PHP is compiled with {$condition}");
+                $this->assertWarning($file, $line, $error);
             }
         }
 

--- a/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionParameterSniffTest.php
@@ -45,8 +45,9 @@ class NewFunctionParameterSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
+        $error        = "The function {$functionName}() does not have a parameter \"{$parameterName}\" in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName}() does not have a parameter \"{$parameterName}\" in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -45,8 +45,9 @@ class NewFunctionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
+        $error        = "The function {$functionName}() is not present in PHP version {$lastVersionBefore} or earlier";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "The function {$functionName}() is not present in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -45,9 +45,10 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier");
 
+        $error        = "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier";
+        $this->assertError($file, $lines[0], $error);
+        $this->assertWarning($file, $lines[1], $error);
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach( $lines as $line ) {
@@ -211,8 +212,9 @@ class NewIniDirectivesSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
         }
-        $this->assertError($file, $lines[0], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier. This directive was previously called '{$alternative}'.");
-        $this->assertWarning($file, $lines[1], "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier. This directive was previously called '{$alternative}'.");
+        $error        = "INI directive '{$iniName}' is not present in PHP version {$lastVersionBefore} or earlier. This directive was previously called '{$alternative}'.";
+        $this->assertError($file, $lines[0], $error);
+        $this->assertWarning($file, $lines[1], $error);
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach($lines as $line) {

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -37,9 +37,10 @@ class NewInterfacesSniffTest extends BaseSniffTest
      */
     public function testNewInterface($interfaceName, $lastVersionBefore, $lines, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $file  = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        $error = "The built-in interface {$interfaceName} is not present in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The built-in interface {$interfaceName} is not present in PHP version {$lastVersionBefore} or earlier");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -45,7 +45,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testPow()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, 5, "power operator (**) is not present in PHP version 5.5 or earlier");
+        $this->assertError($file, 5, 'power operator (**) is not present in PHP version 5.5 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, 5);
@@ -59,7 +59,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testPowEquals()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, 6, "power assignment operator (**=) is not present in PHP version 5.5 or earlier");
+        $this->assertError($file, 6, 'power assignment operator (**=) is not present in PHP version 5.5 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, 6);
@@ -73,7 +73,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testSpaceship()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertError($file, 12, "spaceship operator (<=>) is not present in PHP version 5.6 or earlier");
+        $this->assertError($file, 12, 'spaceship operator (<=>) is not present in PHP version 5.6 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, 12);
@@ -87,7 +87,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testCoalescing()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
-        $this->assertError($file, 8, "null coalescing operator (??) is not present in PHP version 5.6 or earlier");
+        $this->assertError($file, 8, 'null coalescing operator (??) is not present in PHP version 5.6 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
         $this->assertNoViolation($file, 8);
@@ -101,7 +101,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testCoalesceEquals()
     {
         $file = $this->sniffFile(self::TEST_FILE, '7.1');
-        $this->assertError($file, 10, "null coalesce equal operator (??=) is not present in PHP version 7.1 or earlier");
+        $this->assertError($file, 10, 'null coalesce equal operator (??=) is not present in PHP version 7.1 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '7.2');
         $this->assertNoViolation($file, 10);
@@ -115,7 +115,7 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
     public function testEllipsis()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, 14, "variadic functions using ... is not present in PHP version 5.5 or earlier");
+        $this->assertError($file, 14, 'variadic functions using ... is not present in PHP version 5.5 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.6');
         $this->assertNoViolation($file, 14);

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -128,9 +128,10 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
             return;
         }
 
-        $file = $this->getTestFile($isTrait, $lastVersionBefore);
+        $file  = $this->getTestFile($isTrait, $lastVersionBefore);
+        $error = "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.";
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.");
+            $this->assertWarning($file, $line, $error);
         }
 
         $file = $this->getTestFile($isTrait, $okVersion);
@@ -191,9 +192,10 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
             return;
         }
 
-        $file = $this->getTestFile($isTrait, $lastVersionBefore);
+        $file  = $this->getTestFile($isTrait, $lastVersionBefore);
+        $error = "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.";
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The method {$methodName}() was not magical in PHP version {$lastVersionBefore} and earlier. The associated magic functionality will not be invoked.");
+            $this->assertWarning($file, $line, $error);
         }
 
 		if (version_compare(PHP_CodeSniffer::VERSION, '2.5.1', '>=')) {
@@ -240,7 +242,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
         }
 
         $file = $this->getTestFile($isTrait, '5.1');
-        $this->assertWarning($file, $line, "The method __toString() was not truly magical in PHP version 5.1 and earlier. The associated magic functionality will only be called when directly combined with echo or print.");
+        $this->assertWarning($file, $line, 'The method __toString() was not truly magical in PHP version 5.1 and earlier. The associated magic functionality will only be called when directly combined with echo or print.');
 
         $file = $this->getTestFile($isTrait, '5.2');
         $this->assertNoViolation($file, $line);

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -111,7 +111,7 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
     public function testInvalidSelfTypeDeclaration($line)
     {
         $file = $this->sniffFile(self::TEST_FILE);
-        $this->assertError($file, $line, "'self' type cannot be used outside of class scope");
+        $this->assertError($file, $line, '\'self\' type cannot be used outside of class scope');
     }
 
     /**

--- a/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
+++ b/Tests/Sniffs/PHP/RemovedAlternativePHPTagsUnitTest.php
@@ -66,7 +66,7 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
         $this->assertNoViolation($file, $line);
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, $type . ' style opening tags have been removed in PHP 7.0. Found "' . $snippet . '"');
+        $this->assertError($file, $line, "{$type} style opening tags have been removed in PHP 7.0. Found \"{$snippet}\"");
     }
 
     /**
@@ -116,7 +116,7 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
             // PHP 5.2 does not generate the snippet correctly.
             $warning = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: <%';
         } else {
-            $warning = 'Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: ' . $snippet;
+            $warning = "Possible use of ASP style opening tags detected. ASP style opening tags have been removed in PHP 7.0. Found: {$snippet}";
         }
         $this->assertWarning($file, $line, $warning);
     }

--- a/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -70,8 +70,9 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Extension '{$extensionName}' is removed since PHP {$removedIn}";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Extension '{$extensionName}' is removed since PHP {$removedIn}");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -130,8 +131,9 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Extension '{$extensionName}' is removed since PHP {$removedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Extension '{$extensionName}' is removed since PHP {$removedIn}; Use {$alternative} instead");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -192,8 +194,9 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+            $this->assertWarning($file, $line, $error);
         }
 
         if (isset($removedVersion)){
@@ -202,8 +205,9 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertError($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}; Use {$alternative} instead");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -251,8 +255,9 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
         }
+        $error        = "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
         foreach($lines as $line) {
-            $this->assertWarning($file, $line, "Extension '{$extensionName}' is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead");
+            $this->assertWarning($file, $line, $error);
         }
     }
 

--- a/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedFunctionParameterSniffTest.php
@@ -50,8 +50,9 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
         else {
             $file = $this->sniffFile(self::TEST_FILE, $removedIn);
         }
+        $error        = "The \"{$parameterName}\" parameter for function {$functionName}() is removed since PHP {$removedIn}";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is removed since PHP {$removedIn}");
+            $this->assertError($file, $line, $error);
         }
     }
 
@@ -92,14 +93,16 @@ class RemovedFunctionParameterSniffTest extends BaseSniffTest
             $this->assertNoViolation($file, $line);
         }
 
-        $file = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
+        $file  = $this->sniffFile(self::TEST_FILE, $deprecatedIn);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}";
         foreach ($lines as $line) {
-            $this->assertWarning($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn}");
+            $this->assertWarning($file, $line, $error);
         }
 
-        $file = $this->sniffFile(self::TEST_FILE, $removedIn);
+        $file  = $this->sniffFile(self::TEST_FILE, $removedIn);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName}() is deprecated since PHP {$deprecatedIn} and removed since PHP {$removedIn}");
+            $this->assertError($file, $line, $error);
         }
     }
 

--- a/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -77,7 +77,7 @@ class RemovedHashAlgorithmsSniffTest extends BaseSniffTest
     public function testRemovedHashAlgorithmsPbkdf2()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertError($file, 25, "The salsa20 hash algorithm is removed since PHP 5.4");
+        $this->assertError($file, 25, 'The salsa20 hash algorithm is removed since PHP 5.4');
     }
 
 

--- a/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
+++ b/Tests/Sniffs/PHP/RequiredOptionalFunctionParameterSniffTest.php
@@ -38,9 +38,10 @@ class RequiredOptionalFunctionParameterSniffTest extends BaseSniffTest
      */
     public function testRequiredOptionalParameter($functionName, $parameterName, $requiredUpTo, $lines, $okVersion)
     {
-        $file = $this->sniffFile(self::TEST_FILE, $requiredUpTo);
+        $file  = $this->sniffFile(self::TEST_FILE, $requiredUpTo);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName} is missing, but was required for PHP version {$requiredUpTo} and lower";
         foreach ($lines as $line) {
-            $this->assertError($file, $line, "The \"{$parameterName}\" parameter for function {$functionName} is missing, but was required for PHP version {$requiredUpTo} and lower");
+            $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);

--- a/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -59,7 +59,7 @@ class ValidIntegersSniffTest extends BaseSniffTest
     {
 		
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
-        $this->assertError($file, $line, 'Binary integer literals were not present in PHP version 5.3 or earlier. Found: ' . $binary);
+        $this->assertError($file, $line, "Binary integer literals were not present in PHP version 5.3 or earlier. Found: {$binary}");
 
 
 		if ($testNoViolation === true) {
@@ -106,7 +106,7 @@ class ValidIntegersSniffTest extends BaseSniffTest
      */
     public function testInvalidOctalInteger($line, $octal)
     {
-        $error = 'Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: ' . $octal;
+        $error = "Invalid octal integer detected. Prior to PHP 7 this would lead to a truncated number. From PHP 7 onwards this causes a parse error. Found: {$octal}";
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertWarning($file, $line, $error);


### PR DESCRIPTION
* No need to rebuild the same error message every time when the test assertion is in a loop
* Use the most appropriate quote style - single vs double - for each error message