### PR TITLE
PregReplaceEModifier: fix another false positive.

### DIFF
--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -105,19 +105,19 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
     }//end process()
 
 
-	/**
+    /**
      * Analyse a potential regex pattern for usage of the /e modifier.
      *
      * @param array                $pattern      Array containing the start and end token
-	 *                                           pointer of the potential regex pattern and
-	 *                                           the raw string value of the pattern.
+     *                                           pointer of the potential regex pattern and
+     *                                           the raw string value of the pattern.
      * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
      * @param int                  $stackPtr     The position of the current token in the
      *                                           stack passed in $tokens.
      * @param string               $functionName The function which contained the pattern.
      *
      * @return void
-	 */
+     */
     protected function processRegexPattern($pattern, $phpcsFile, $stackPtr, $functionName)
     {
         $tokens = $phpcsFile->getTokens();
@@ -137,8 +137,11 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
                 $regex .= trim($content);
             }
         }
+
         // Deal with multi-line regexes which were broken up in several string tokens.
-        $regex = $this->stripQuotes($regex);
+        if ($tokens[$pattern['start']]['line'] !== $tokens[$pattern['end']]['line']) {
+            $regex = $this->stripQuotes($regex);
+        }
 
         if ($regex === '') {
             // No string token found in the first parameter, so skip it (e.g. if variable passed in).

--- a/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -103,6 +103,9 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
             // Interpolated variables.
             array(204),
             array(205),
+
+            // Quote as a delimiter.
+            array(211),
         );
     }
 
@@ -173,6 +176,9 @@ class PregReplaceEModifierSniffTest extends BaseSniffTest
 
             // Interpolated variables.
             array(206),
+
+            // Quote as a delimiter.
+            array(210),
         );
     }
 

--- a/Tests/sniff-examples/preg_replace_e_modifier.php
+++ b/Tests/sniff-examples/preg_replace_e_modifier.php
@@ -204,3 +204,8 @@ $this->value = preg_replace( $this->field['preg']['pattern'], $this->field['preg
 preg_replace("/dou$ble-quoted/e", $Replace, $Source); // Bad.
 preg_replace("/dou$ble-quoted/me$me", $Replace, $Source); // Bad.
 preg_replace("/double-quoted/$e", $Replace, $Source); // Ok.
+
+// Yet another false positive. Who the heck uses a quote character as a delimiter ?!?!?!?
+// https://wordpress.org/support/topic/false-positive-preg_replace-e-modifier/
+$code = preg_replace("'(?<![\$.a-zA-Z0-9_])while\('", '3#(', $code); // Ok.
+$code = preg_replace("'(?<![\$.a-zA-Z0-9_])while\('e", '3#(', $code); // Bad.


### PR DESCRIPTION
While IMHO people who use a quote character as a regex delimiter should ~~^%^&%*~~~~ (censored) _find another profession_, it **is** a valid delimiter.

This PR fixes the issue.

Includes unit tests.

Fixes https://github.com/wpengine/phpcompat/issues/115
Originally reported: https://wordpress.org/support/topic/false-positive-preg_replace-e-modifier/