### PR TITLE
Tests: stabilize utility function unit tests

### DIFF
--- a/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -34,12 +34,13 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
      *
      * @covers PHPCompatibility_Sniff::doesFunctionCallHaveParameters
      *
-     * @param int    $stackPtr Stack pointer for a function call T_STRING token
-     *                         or a T_ARRAY token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param bool   $expected      Whether or not the function/array has parameters/values.
      */
-    public function testDoesFunctionCallHaveParameters($stackPtr, $expected) {
-        $result = $this->helperClass->doesFunctionCallHaveParameters($this->_phpcsFile, $stackPtr);
+    public function testDoesFunctionCallHaveParameters($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        $result   = $this->helperClass->doesFunctionCallHaveParameters($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -54,29 +55,29 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
     {
         return array(
             // Function calls.
-            array(12, false),
-            array(17, false),
-            array(23, false),
-            array(31, false),
-            array(42, true),
-            array(50, true),
-            array(60, true),
+            array('/* Case S1 */', false),
+            array('/* Case S2 */', false),
+            array('/* Case S3 */', false),
+            array('/* Case S4 */', false),
+            array('/* Case S5 */', true),
+            array('/* Case S6 */', true),
+            array('/* Case S7 */', true),
 
             // Arrays.
-            array(80, false),
-            array(89, false),
-            array(99, false),
-            array(111, false),
-            array(121, false),
-            array(129, false),
-            array(138, false),
-            array(149, false),
-            array(163, true),
-            array(175, true),
-            array(189, true),
-            array(199, true),
-            array(210, true),
-            array(223, true),
+            array('/* Case A1 */', false),
+            array('/* Case A2 */', false),
+            array('/* Case A3 */', false),
+            array('/* Case A4 */', false),
+            array('/* Case A5 */', false),
+            array('/* Case A6 */', false),
+            array('/* Case A7 */', false),
+            array('/* Case A8 */', false),
+            array('/* Case A9 */', true),
+            array('/* Case A10 */', true),
+            array('/* Case A11 */', true),
+            array('/* Case A12 */', true),
+            array('/* Case A13 */', true),
+            array('/* Case A14 */', true),
         );
     }
 

--- a/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
@@ -36,11 +36,13 @@ class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodT
      *
      * @covers PHPCompatibility_Sniff::getFQClassNameFromDoubleColonToken
      *
-     * @param int    $stackPtr Stack pointer for a T_DOUBLE_COLON token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param string $commentString The comment which prefaces the T_DOUBLE_COLON token in the test file.
+     * @param string $expected      The expected fully qualified class name.
      */
-    public function testGetFQClassNameFromDoubleColonToken($stackPtr, $expected) {
-        $result = $this->helperClass->getFQClassNameFromDoubleColonToken($this->_phpcsFile, $stackPtr);
+    public function testGetFQClassNameFromDoubleColonToken($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, T_DOUBLE_COLON);
+        $result   = $this->helperClass->getFQClassNameFromDoubleColonToken($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -54,25 +56,25 @@ class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodT
     public function dataGetFQClassNameFromDoubleColonToken()
     {
         return array(
-            array(3, '\DateTime'),
-            array(8, '\DateTime'),
-            array(13, '\DateTime'),
-            array(21, '\DateTime'),
-            array(30, '\DateTime'),
-            array(39, '\AnotherNS\DateTime'),
-            array(49, '\FQNS\DateTime'),
-            array(61, '\DateTime'),
-            array(76, '\AnotherNS\DateTime'),
-            array(90, '\Testing\DateTime'),
-            array(96, '\Testing\DateTime'),
-            array(102, '\Testing\DateTime'),
-            array(127, '\Testing\MyClass'),
-            array(135, ''),
-            array(141, ''),
-            array(173, '\MyClass'),
-            array(181, ''),
-            array(187, ''),
-            array(247, ''),
+            array('/* Case 1 */', '\DateTime'),
+            array('/* Case 2 */', '\DateTime'),
+            array('/* Case 3 */', '\DateTime'),
+            array('/* Case 4 */', '\DateTime'),
+            array('/* Case 5 */', '\DateTime'),
+            array('/* Case 6 */', '\AnotherNS\DateTime'),
+            array('/* Case 7 */', '\FQNS\DateTime'),
+            array('/* Case 8 */', '\DateTime'),
+            array('/* Case 9 */', '\AnotherNS\DateTime'),
+            array('/* Case 10 */', '\Testing\DateTime'),
+            array('/* Case 11 */', '\Testing\DateTime'),
+            array('/* Case 12 */', '\Testing\DateTime'),
+            array('/* Case 13 */', '\Testing\MyClass'),
+            array('/* Case 14 */', ''),
+            array('/* Case 15 */', ''),
+            array('/* Case 16 */', '\MyClass'),
+            array('/* Case 17 */', ''),
+            array('/* Case 18 */', ''),
+            array('/* Case 19 */', ''),
         );
     }
 

--- a/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
+++ b/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
@@ -36,11 +36,13 @@ class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFQClassNameFromNewToken
      *
-     * @param int    $stackPtr Stack pointer for a T_NEW token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param string $commentString The comment which prefaces the T_NEW token in the test file.
+     * @param string $expected      The expected fully qualified class name.
      */
-    public function testGetFQClassNameFromNewToken($stackPtr, $expected) {
-        $result = $this->helperClass->getFQClassNameFromNewToken($this->_phpcsFile, $stackPtr);
+    public function testGetFQClassNameFromNewToken($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, T_NEW);
+        $result   = $this->helperClass->getFQClassNameFromNewToken($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -54,21 +56,22 @@ class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
     public function dataGetFQClassNameFromNewToken()
     {
         return array(
-            array(7, '\MyTesting\DateTime'),
-            array(16, '\MyTesting\DateTime'),
-            array(21, '\DateTime'),
-            array(29, '\MyTesting\anotherNS\DateTime'),
-            array(38, '\FQNS\DateTime'),
-            array(56, '\AnotherTesting\DateTime'),
-            array(66, '\AnotherTesting\DateTime'),
-            array(72, '\DateTime'),
-            array(81, '\AnotherTesting\anotherNS\DateTime'),
-            array(91, '\FQNS\DateTime'),
-            array(104, '\DateTime'),
-            array(109, '\DateTime'),
-            array(115, '\AnotherTesting\DateTime'),
-            array(134, ''),
-            array(145, ''),
+            array('/* Case 1 */', '\DateTime'),
+            array('/* Case 2 */', '\MyTesting\DateTime'),
+            array('/* Case 3 */', '\MyTesting\DateTime'),
+            array('/* Case 4 */', '\DateTime'),
+            array('/* Case 5 */', '\MyTesting\anotherNS\DateTime'),
+            array('/* Case 6 */', '\FQNS\DateTime'),
+            array('/* Case 7 */', '\AnotherTesting\DateTime'),
+            array('/* Case 8 */', '\AnotherTesting\DateTime'),
+            array('/* Case 9 */', '\DateTime'),
+            array('/* Case 10 */', '\AnotherTesting\anotherNS\DateTime'),
+            array('/* Case 11 */', '\FQNS\DateTime'),
+            array('/* Case 12 */', '\DateTime'),
+            array('/* Case 13 */', '\DateTime'),
+            array('/* Case 14 */', '\AnotherTesting\DateTime'),
+            array('/* Case 15 */', ''),
+            array('/* Case 16 */', ''),
         );
     }
 

--- a/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -36,11 +36,13 @@ class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFQExtendedClassName
      *
-     * @param int    $stackPtr Stack pointer for a T_CLASS token in the test file.
-     * @param string $expected The expected fully qualified class name.
+     * @param string $commentString The comment which prefaces the T_CLASS token in the test file.
+     * @param string $expected      The expected fully qualified class name.
      */
-    public function testGetFQExtendedClassName($stackPtr, $expected) {
-        $result = $this->helperClass->getFQExtendedClassName($this->_phpcsFile, $stackPtr);
+    public function testGetFQExtendedClassName($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, T_CLASS);
+        $result   = $this->helperClass->getFQExtendedClassName($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -54,19 +56,21 @@ class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
     public function dataGetFQExtendedClassName()
     {
         return array(
-            array(7, '\MyTesting\DateTime'),
-            array(18, '\DateTime'),
-            array(30, '\MyTesting\anotherNS\DateTime'),
-            array(43, '\FQNS\DateTime'),
-            array(65, '\AnotherTesting\DateTime'),
-            array(77, '\DateTime'),
-            array(90, '\AnotherTesting\anotherNS\DateTime'),
-            array(104, '\FQNS\DateTime'),
-            array(121, '\DateTime'),
-            array(132, '\DateTime'),
-            array(155, '\Yet\More\Testing\DateTime'),
-            array(166, '\Yet\More\Testing\anotherNS\DateTime'),
-            array(179, '\FQNS\DateTime'),
+            array('/* Case 1 */', ''),
+            array('/* Case 2 */', '\DateTime'),
+            array('/* Case 3 */', '\MyTesting\DateTime'),
+            array('/* Case 4 */', '\DateTime'),
+            array('/* Case 5 */', '\MyTesting\anotherNS\DateTime'),
+            array('/* Case 6 */', '\FQNS\DateTime'),
+            array('/* Case 7 */', '\AnotherTesting\DateTime'),
+            array('/* Case 8 */', '\DateTime'),
+            array('/* Case 9 */', '\AnotherTesting\anotherNS\DateTime'),
+            array('/* Case 10 */', '\FQNS\DateTime'),
+            array('/* Case 11 */', '\DateTime'),
+            array('/* Case 12 */', '\DateTime'),
+            array('/* Case 13 */', '\Yet\More\Testing\DateTime'),
+            array('/* Case 14 */', '\Yet\More\Testing\anotherNS\DateTime'),
+            array('/* Case 15 */', '\FQNS\DateTime'),
         );
     }
 

--- a/Tests/BaseClass/GetFunctionParameterCountTest.php
+++ b/Tests/BaseClass/GetFunctionParameterCountTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Function parameter count test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Function parameters count function tests
+ *
+ * @group utilityGetFunctionParameterCount
+ * @group utilityFunctions
+ *
+ * @uses    BaseClass_MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class BaseClass_GetFunctionParameterCountTest extends BaseClass_MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'get_function_parameter_count.php';
+
+    /**
+     * testGetFunctionCallParameterCount
+     *
+     * @dataProvider dataGetFunctionCallParameterCount
+     *
+     * @covers PHPCompatibility_Sniff::getFunctionCallParameterCount
+     *
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param string $expected      The expected parameter count.
+     */
+    public function testGetFunctionCallParameterCount($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        $result   = $this->helperClass->getFunctionCallParameterCount($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataGetFunctionCallParameterCount
+     *
+     * @see testGetFunctionCallParameterCount()
+     *
+     * @return array
+     */
+    public function dataGetFunctionCallParameterCount()
+    {
+        return array(
+            array('/* Case S1 */', 1),
+            array('/* Case S2 */', 2),
+            array('/* Case S3 */', 3),
+            array('/* Case S4 */', 4),
+            array('/* Case S5 */', 5),
+            array('/* Case S6 */', 6),
+            array('/* Case S7 */', 7),
+            array('/* Case S8 */', 1),
+            array('/* Case S9 */', 1),
+            array('/* Case S10 */', 1),
+            array('/* Case S11 */', 2),
+            array('/* Case S12 */', 1),
+            array('/* Case S13 */', 1),
+            array('/* Case S14 */', 1),
+            array('/* Case S15 */', 2),
+            array('/* Case S16 */', 6),
+            array('/* Case S17 */', 6),
+            array('/* Case S18 */', 6),
+            array('/* Case S19 */', 6),
+            array('/* Case S20 */', 6),
+            array('/* Case S21 */', 6),
+            array('/* Case S22 */', 6),
+            array('/* Case S23 */', 3),
+            array('/* Case S24 */', 1),
+            array('/* Case S25 */', 1),
+
+            // Issue #211.
+            array('/* Case S26 */', 1),
+            array('/* Case S27 */', 1),
+            array('/* Case S28 */', 1),
+            array('/* Case S29 */', 1),
+            array('/* Case S30 */', 1),
+            array('/* Case S31 */', 1),
+            array('/* Case S32 */', 1),
+            array('/* Case S33 */', 1),
+            array('/* Case S34 */', 1),
+            array('/* Case S35 */', 1),
+            array('/* Case S36 */', 1),
+            array('/* Case S37 */', 1),
+            array('/* Case S38 */', 1),
+            array('/* Case S39 */', 1),
+            array('/* Case S40 */', 1),
+            array('/* Case S41 */', 1),
+            array('/* Case S42 */', 1),
+            array('/* Case S43 */', 1),
+            array('/* Case S44 */', 1),
+            array('/* Case S45 */', 1),
+            array('/* Case S46 */', 1),
+            array('/* Case S47 */', 1),
+
+            // Long arrays.
+            array('/* Case A1 */', 7),
+            array('/* Case A2 */', 1),
+            array('/* Case A3 */', 6),
+            array('/* Case A4 */', 6),
+            array('/* Case A5 */', 6),
+            array('/* Case A6 */', 3),
+            array('/* Case A7 */', 3),
+            array('/* Case A8 */', 3),
+
+            // Short arrays.
+            array('/* Case A9 */', 7),
+            array('/* Case A10 */', 1),
+            array('/* Case A11 */', 6),
+            array('/* Case A12 */', 6),
+            array('/* Case A13 */', 6),
+            array('/* Case A14 */', 3),
+            array('/* Case A15 */', 3),
+            array('/* Case A16 */', 3),
+        );
+    }
+
+}

--- a/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/Tests/BaseClass/GetFunctionParametersTest.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Function parameter count test file
+ * Function parameter retrieval test file
  *
  * @package PHPCompatibility
  */
 
 
 /**
- * Function parameters count function tests
+ * Function parameters retrieval function tests
  *
  * @group utilityGetFunctionParameters
  * @group utilityFunctions
@@ -34,13 +34,24 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameters
      *
-     * @param int    $stackPtr Stack pointer for a function call T_STRING,
-     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
+     * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected The expected parameter array.
      */
-    public function testGetFunctionCallParameters($stackPtr, $expected)
+    public function testGetFunctionCallParameters($commentString, $expected)
     {
-        $result = $this->helperClass->getFunctionCallParameters($this->_phpcsFile, $stackPtr);
+        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        /*
+         * Start/end token position values in the expected array are set as offsets
+         * in relation to the target token.
+         *
+         * Change these to exact positions based on the retrieved stackPtr.
+         */
+        foreach ($expected as $key => $value) {
+            $expected[$key]['start'] = $stackPtr + $value['start'];
+            $expected[$key]['end']   = $stackPtr + $value['end'];
+        }
+
+        $result   = $this->helperClass->getFunctionCallParameters($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -54,100 +65,100 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
     public function dataGetFunctionCallParameters()
     {
         return array(
-            array(88, array(
+            array('/* Case S1 */', array(
                        1 => array(
-                             'start' => 90,
-                             'end'   => 91,
+                             'start' => 2,
+                             'end'   => 3,
                              'raw'   => '1',
                             ),
                        2 => array(
-                             'start' => 93,
-                             'end'   => 94,
+                             'start' => 5,
+                             'end'   => 6,
                              'raw'   => '2',
                             ),
                        3 => array(
-                             'start' => 96,
-                             'end'   => 97,
+                             'start' => 8,
+                             'end'   => 9,
                              'raw'   => '3',
                             ),
                        4 => array(
-                             'start' => 99,
-                             'end'   => 100,
+                             'start' => 11,
+                             'end'   => 12,
                              'raw'   => '4',
                             ),
                        5 => array(
-                             'start' => 102,
-                             'end'   => 103,
+                             'start' => 14,
+                             'end'   => 15,
                              'raw'   => '5',
                             ),
                        6 => array(
-                             'start' => 105,
-                             'end'   => 106,
+                             'start' => 17,
+                             'end'   => 18,
                              'raw'   => '6',
                             ),
                        7 => array(
-                             'start' => 108,
-                             'end'   => 110,
+                             'start' => 20,
+                             'end'   => 22,
                              'raw'   => 'true',
                             ),
                       ),
 
             ),
-            array(120, array(
+            array('/* Case S2 */', array(
                         1 => array(
-                              'start' => 122,
-                              'end'   => 129,
+                              'start' => 2,
+                              'end'   => 9,
                               'raw'   => 'dirname( __FILE__ )',
                              ),
                        ),
             ),
-            array(250, array(
+            array('/* Case S3 */', array(
                         1 => array(
-                              'start' => 252,
-                              'end'   => 252,
+                              'start' => 2,
+                              'end'   => 2,
                               'raw'   => '$stHour',
                              ),
                         2 => array(
-                              'start' => 254,
-                              'end'   => 255,
+                              'start' => 4,
+                              'end'   => 5,
                               'raw'   => '0',
                              ),
                         3 => array(
-                              'start' => 257,
-                              'end'   => 258,
+                              'start' => 7,
+                              'end'   => 8,
                               'raw'   => '0',
                              ),
                         4 => array(
-                              'start' => 260,
-                              'end'   => 264,
+                              'start' => 10,
+                              'end'   => 14,
                               'raw'   => '$arrStDt[0]',
                              ),
                         5 => array(
-                              'start' => 266,
-                              'end'   => 270,
+                              'start' => 16,
+                              'end'   => 20,
                               'raw'   => '$arrStDt[1]',
                              ),
                         6 => array(
-                              'start' => 272,
-                              'end'   => 276,
+                              'start' => 22,
+                              'end'   => 26,
                               'raw'   => '$arrStDt[2]',
                              ),
                        ),
 
             ),
-            array(535, array(
+            array('/* Case S4 */', array(
                         1 => array(
-                              'start' => 537,
-                              'end'   => 540,
+                              'start' => 2,
+                              'end'   => 5,
                               'raw'   => 'array()',
                              ),
                        ),
 
             ),
-            array(577, array(
+            array('/* Case S5 */', array(
                         1 => array(
-                              'start' => 579,
-                              'end'   => 611,
+                              'start' => 2,
+                              'end'   => 34,
                               'raw'   => '[\'a\' => $a,] + (isset($b) ? [\'b\' => $b,] : [])',
                              ),
                        ),
@@ -155,70 +166,70 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
             ),
 
             // Long array.
-            array(1422, array(
+            array('/* Case A1 */', array(
                         1 => array(
-                              'start' => 1424,
-                              'end'   => 1430,
+                              'start' => 2,
+                              'end'   => 8,
                               'raw'   => 'some_call(5, 1)',
                              ),
                         2 => array(
-                              'start' => 1432,
-                              'end'   => 1436,
+                              'start' => 10,
+                              'end'   => 14,
                               'raw'   => 'another(1)',
                              ),
                         3 => array(
-                              'start' => 1438,
-                              'end'   => 1448,
+                              'start' => 16,
+                              'end'   => 26,
                               'raw'   => 'why(5, 1, 2)',
                              ),
                         4 => array(
-                              'start' => 1450,
-                              'end'   => 1451,
+                              'start' => 28,
+                              'end'   => 29,
                               'raw'   => '4',
                              ),
                         5 => array(
-                              'start' => 1453,
-                              'end'   => 1454,
+                              'start' => 31,
+                              'end'   => 32,
                               'raw'   => '5',
                              ),
                         6 => array(
-                              'start' => 1456,
-                              'end'   => 1457,
+                              'start' => 34,
+                              'end'   => 35,
                               'raw'   => '6',
                              ),
                        ),
             ),
 
             // Short array.
-            array(1667, array(
+            array('/* Case A2 */', array(
                         1 => array(
-                              'start' => 1668,
-                              'end'   => 1668,
+                              'start' => 1,
+                              'end'   => 1,
                               'raw'   => '0',
                              ),
                         2 => array(
-                              'start' => 1670,
-                              'end'   => 1671,
+                              'start' => 3,
+                              'end'   => 4,
                               'raw'   => '0',
                              ),
                         3 => array(
-                              'start' => 1673,
-                              'end'   => 1677,
+                              'start' => 6,
+                              'end'   => 10,
                               'raw'   => 'date(\'s\')',
                              ),
                         4 => array(
-                              'start' => 1679,
-                              'end'   => 1683,
+                              'start' => 12,
+                              'end'   => 16,
                               'raw'   => 'date(\'m\')',
                              ),
                         5 => array(
-                              'start' => 1685,
-                              'end'   => 1689,
+                              'start' => 18,
+                              'end'   => 22,
                               'raw'   => 'date(\'d\')',
                              ),
                         6 => array(
-                              'start' => 1691,
-                              'end'   => 1695,
+                              'start' => 24,
+                              'end'   => 28,
                               'raw'   => 'date(\'Y\')',
                              ),
                        ),
@@ -234,12 +245,21 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::getFunctionCallParameter
      *
-     * @param int    $stackPtr Stack pointer for a function call T_STRING,
-     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
+     * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected The expected array for the specific parameter.
      */
-    public function testGetFunctionCallParameter($stackPtr, $paramPosition, $expected)
+    public function testGetFunctionCallParameter($commentString, $paramPosition, $expected)
     {
+        $stackPtr = $this->getTargetToken($commentString, array(T_STRING, T_ARRAY, T_OPEN_SHORT_ARRAY));
+        /*
+         * Start/end token position values in the expected array are set as offsets
+         * in relation to the target token.
+         *
+         * Change these to exact positions based on the retrieved stackPtr.
+         */
+        $expected['start'] += $stackPtr;
+        $expected['end']   += $stackPtr;
+
         $result = $this->helperClass->getFunctionCallParameter($this->_phpcsFile, $stackPtr, $paramPosition);
         $this->assertSame($expected, $result);
     }
@@ -254,166 +274,66 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
     public function dataGetFunctionCallParameter()
     {
         return array(
-            array(88, 4, array(
-                          'start' => 99,
-                          'end'   => 100,
+            array('/* Case S1 */', 4, array(
+                          'start' => 11,
+                          'end'   => 12,
                           'raw'   => '4',
                          ),
             ),
-            array(120, 1, array(
-                           'start' => 122,
-                           'end'   => 129,
+            array('/* Case S2 */', 1, array(
+                           'start' => 2,
+                           'end'   => 9,
                            'raw'   => 'dirname( __FILE__ )',
                           ),
             ),
-            array(250, 1, array(
-                           'start' => 252,
-                           'end'   => 252,
+            array('/* Case S3 */', 1, array(
+                           'start' => 2,
+                           'end'   => 2,
                            'raw'   => '$stHour',
                           ),
             ),
-            array(250, 6, array(
-                           'start' => 272,
-                           'end'   => 276,
+            array('/* Case S3 */', 6, array(
+                           'start' => 22,
+                           'end'   => 26,
                            'raw'   => '$arrStDt[2]',
                           ),
             ),
-            array(1296, 1, array(
-                           'start' => 1298,
-                           'end'   => 1299,
+            array('/* Case A3 */', 1, array(
+                           'start' => 2,
+                           'end'   => 3,
                            'raw'   => '1',
                           ),
             ),
-            array(1296, 7, array(
-                           'start' => 1316,
-                           'end'   => 1318,
+            array('/* Case A3 */', 7, array(
+                           'start' => 20,
+                           'end'   => 22,
                            'raw'   => 'true',
                           ),
             ),
-            array(1422, 3, array(
-                           'start' => 1438,
-                           'end'   => 1448,
+            array('/* Case A1 */', 3, array(
+                           'start' => 16,
+                           'end'   => 26,
                            'raw'   => 'why(5, 1, 2)',
                           ),
             ),
-            array(1466, 2, array(
-                           'start' => 1474,
-                           'end'   => 1479,
+            array('/* Case A4 */', 2, array(
+                           'start' => 8,
+                           'end'   => 13,
                            'raw'   => '\'b\' => $b',
                           ),
             ),
-            array(1611, 1, array(
-                           'start' => 1612,
-                           'end'   => 1624,
+            array('/* Case A5 */', 1, array(
+                           'start' => 1,
+                           'end'   => 13,
                            'raw'   => 'str_replace("../", "/", trim($value))',
                           ),
             ),
-            array(1814, 3, array(
-                           'start' => 1828,
-                           'end'   => 1850,
+            array('/* Case A6 */', 3, array(
+                           'start' => 14,
+                           'end'   => 36,
                            'raw'   => '(isset($c) ? 6 => $c : 6 => null)',
                           ),
             ),
-        );
-    }
-
-
-    /**
-     * testGetFunctionCallParameterCount
-     *
-     * @dataProvider dataGetFunctionCallParameterCount
-     *
-     * @covers PHPCompatibility_Sniff::getFunctionCallParameterCount
-     *
-     * @param int    $stackPtr Stack pointer for a function call T_STRING,
-     *                         T_ARRAY or T_OPEN_SHORT_ARRAY token in the test file.
-     * @param string $expected The expected parameter count.
-     */
-    public function testGetFunctionCallParameterCount($stackPtr, $expected)
-    {
-        $result = $this->helperClass->getFunctionCallParameterCount($this->_phpcsFile, $stackPtr);
-        $this->assertSame($expected, $result);
-    }
-
-    /**
-     * dataGetFunctionCallParameterCount
-     *
-     * @see testGetFunctionCallParameterCount()
-     *
-     * @return array
-     */
-    public function dataGetFunctionCallParameterCount()
-    {
-        return array(
-            array(5, 1),
-            array(11, 2),
-            array(22, 3),
-            array(34, 4),
-            array(49, 5),
-            array(67, 6),
-            array(88, 7),
-            array(120, 1),
-            array(135, 1),
-            array(150, 1),
-            array(164, 2),
-            array(181, 1),
-            array(194, 1),
-            array(209, 1),
-            array(228, 2),
-            array(250, 6),
-            array(281, 6),
-            array(312, 6),
-            array(351, 6),
-            array(386, 6),
-            array(420, 6),
-            array(454, 6),
-            array(499, 3),
-            array(518, 1),
-            array(535, 1),
-
-            // Issue #211.
-            array(551, 1),
-            array(564, 1),
-            array(577, 1),
-            array(615, 1),
-            array(660, 1),
-            array(710, 1),
-            array(761, 1),
-            array(818, 1),
-            array(874, 1),
-            array(894, 1),
-            array(910, 1),
-            array(930, 1),
-            array(964, 1),
-            array(984, 1),
-            array(1008, 1),
-            array(1038, 1),
-            array(1074, 1),
-            array(1111, 1),
-            array(1154, 1),
-            array(1184, 1),
-            array(1215, 1),
-            array(1241, 1),
-
-            // Long arrays.
-            array(1296, 7),
-            array(1326, 1),
-            array(1349, 6),
-            array(1384, 6),
-            array(1422, 6),
-            array(1466, 3),
-            array(1494, 3),
-            array(1535, 3),
-
-            // Short arrays.
-            array(1582, 7),
-            array(1611, 1),
-            array(1633, 6),
-            array(1667, 6),
-            array(1704, 6),
-            array(1747, 3),
-            array(1774, 3),
-            array(1814, 3),
         );
     }
 

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -104,4 +104,30 @@ abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
 
     }//end tearDown()
 
+
+    /**
+     * Get the token pointer for a target token based on a specific comment found on the line before.
+     *
+     * @param string    $commentString The comment to look for.
+     * @param int|array $tokenType     The type of token(s) to look for.
+     *
+     * @return int
+     */
+    public function getTargetToken($commentString, $tokenType)
+    {
+        $start   = ($this->_phpcsFile->numTokens - 1);
+        $comment = $this->_phpcsFile->findPrevious(
+            T_COMMENT,
+            $start,
+            null,
+            false,
+            $commentString
+        );
+
+        return $this->_phpcsFile->findNext(
+            $tokenType,
+            ($comment + 1)
+        );
+    }
+
 }

--- a/Tests/BaseClass/TokenHasScopeTest.php
+++ b/Tests/BaseClass/TokenHasScopeTest.php
@@ -34,12 +34,14 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::tokenHasScope
      *
-     * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param int    $targetType    The token type for the target token.
      * @param string $expected The expected boolean return value.
      */
-    public function testTokenHasScope($stackPtr, $expected, $validTokens = null)
+    public function testTokenHasScope($commentString, $targetType, $expected, $validTokens = null)
     {
-        $result = $this->helperClass->tokenHasScope($this->_phpcsFile, $stackPtr, $validTokens);
+        $stackPtr = $this->getTargetToken($commentString, $targetType);
+        $result   = $this->helperClass->tokenHasScope($this->_phpcsFile, $stackPtr, $validTokens);
         $this->assertSame($expected, $result);
     }
 
@@ -54,37 +56,37 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
     {
         return array(
             // No scope.
-            array(2, false), // $var
+            array('/* Case 1 */', T_VARIABLE, false), // $var
 
             // Various scopes.
-            array(23, true), // echo within if
-            array(23, true, T_IF), // echo within if
-            array(23, false, array(T_SWITCH) ), // echo within if
+            array('/* Case 2 */', T_ECHO, true), // echo within if
+            array('/* Case 2 */', T_ECHO, true, T_IF), // echo within if
+            array('/* Case 2 */', T_ECHO, false, array(T_SWITCH) ), // echo within if
 
-            array(45, true), // echo within else-if
-            array(45, true, array(T_ELSEIF)), // echo within else-if
-            array(45, false, array(T_IF)), // echo within else-if
+            array('/* Case 3 */', T_ECHO, true), // echo within else-if
+            array('/* Case 3 */', T_ECHO, true, array(T_ELSEIF)), // echo within else-if
+            array('/* Case 3 */', T_ECHO, false, array(T_IF)), // echo within else-if
 
-            array(57, true), // echo within else
-            array(86, true), // echo within for
-            array(107, true), // echo within foreach
+            array('/* Case 4 */', T_ECHO, true), // echo within else
+            array('/* Case 5 */', T_ECHO, true), // echo within for
+            array('/* Case 6 */', T_ECHO, true), // echo within foreach
 
-            array(123, true), // case within switch
-            array(123, true, array(T_SWITCH)), // case within switch
-            array(123, false, array(T_CASE)), // case within switch
+            array('/* Case 7 */', T_CASE, true), // case within switch
+            array('/* Case 7 */', T_CASE, true, array(T_SWITCH)), // case within switch
+            array('/* Case 7 */', T_CASE, false, array(T_CASE)), // case within switch
 
-            array(129, true), // echo within case within switch
-            array(129, true, array(T_SWITCH)), // echo within case within switch
-            array(129, true, T_CASE), // echo within case within switch
-            array(129, true, array(T_SWITCH, T_CASE)), // echo within case within switch
-            array(129, true, array(T_SWITCH, T_IF)), // echo within case within switch
-            array(129, false, array(T_ELSEIF, T_IF)), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, true), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH)), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, true, T_CASE), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH, T_CASE)), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, true, array(T_SWITCH, T_IF)), // echo within case within switch
+            array('/* Case 8 */', T_ECHO, false, array(T_ELSEIF, T_IF)), // echo within case within switch
 
-            array(139, true), // default within switch
-            array(143, true), // echo within default within switch
+            array('/* Case 9 */', T_DEFAULT, true), // default within switch
+            array('/* Case 10 */', T_ECHO, true), // echo within default within switch
 
-            array(164, true), // echo within function
-            array(164, true, array(T_FUNCTION)), // echo within function
+            array('/* Case 11 */', T_ECHO, true), // echo within function
+            array('/* Case 11 */', T_ECHO, true, array(T_FUNCTION)), // echo within function
         );
     }
 
@@ -95,11 +97,13 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::inClassScope
      *
-     * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
-     * @param string $expected The expected boolean return value.
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param int    $targetType    The token type for the target token.
+     * @param string $expected      The expected boolean return value.
      */
-    public function testInClassScope($stackPtr, $expected)
+    public function testInClassScope($commentString, $targetType, $expected)
     {
+        $stackPtr = $this->getTargetToken($commentString, $targetType);
         $result = $this->helperClass->inClassScope($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
@@ -114,11 +118,11 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
     public function dataInClassScope()
     {
         return array(
-            array(181, true), // $property
-            array(185, true), // function in class
-            array(202, false), // global function
-            array(220, true), // function in namespaced class
-            array(391, true), // function in anon class
+            array('/* Case C1 */', T_VARIABLE, true), // $property
+            array('/* Case C2 */', T_FUNCTION, true), // function in class
+            array('/* Case C3 */', T_FUNCTION, false), // global function
+            array('/* Case C4 */', T_FUNCTION, true), // function in namespaced class
+            array('/* Case C5 */', T_FUNCTION, true), // function in anon class
         );
     }
 
@@ -130,12 +134,14 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @covers PHPCompatibility_Sniff::inUseScope
      *
-     * @param int    $stackPtr Stack pointer for an arbitrary token in the test file.
-     * @param string $expected The expected boolean return value.
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param int    $targetType    The token type for the target token.
+     * @param string $expected      The expected boolean return value.
      */
-    public function testInUseScope($stackPtr, $expected)
+    public function testInUseScope($commentString, $targetType, $expected)
     {
-        $result = $this->helperClass->inUseScope($this->_phpcsFile, $stackPtr);
+        $stackPtr = $this->getTargetToken($commentString, $targetType);
+        $result   = $this->helperClass->inUseScope($this->_phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
 
@@ -149,15 +155,15 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
     public function dataInUseScope()
     {
         return array(
-            array(235, false),
-            array(244, false),
-            array(255, false),
-            array(269, false),
-            array(283, false),
-            array(303, true),
-            array(327, true),
-            array(351, true),
-            array(375, true),
+            array('/* Case U1 */', T_STRING, false),
+            array('/* Case U2 */', T_AS, false),
+            array('/* Case U3 */', T_STRING, false),
+            array('/* Case U4 */', T_STRING, false),
+            array('/* Case U5 */', T_STRING, false),
+            array('/* Case U6 */', T_AS, true),
+            array('/* Case U7 */', T_PUBLIC, true),
+            array('/* Case U8 */', T_PROTECTED, true),
+            array('/* Case U9 */', T_PRIVATE, true),
         );
     }
 

--- a/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
+++ b/Tests/sniff-examples/utility-functions/does_function_call_have_parameters.php
@@ -8,16 +8,23 @@
 /*
  * No parameters.
  */
+/* Case S1 */
 some_function();
+/* Case S2 */
 some_function(     );
+/* Case S3 */
 some_function( /*nothing here*/ );
+/* Case S4 */
 some_function(/*nothing here*/);
 
 /*
  * Has parameters.
  */
+/* Case S5 */
 some_function( 1 );
+/* Case S6 */
 some_function(1,2,3);
+/* Case S7 */
 some_function(true);
 
 /*
@@ -27,21 +34,35 @@ some_function(true);
 /*
  * No parameters.
  */
+/* Case A1 */
 $foo = array();
+/* Case A2 */
 $foo = array(     );
+/* Case A3 */
 $foo = array( /*nothing here*/ );
+/* Case A4 */
 $foo = array(/*nothing here*/);
+/* Case A5 */
 $bar = [];
+/* Case A6 */
 $bar = [     ];
+/* Case A7 */
 $bar = [ /*nothing here*/ ];
+/* Case A8 */
 $bar = [/*nothing here*/];
 
 /*
  * Has parameters.
  */
+/* Case A9 */
 $foo = array( 1 );
+/* Case A10 */
 $foo = array(1,2,3);
+/* Case A11 */
 $foo = array(true);
+/* Case A12 */
 $bar = [ 1 ];
+/* Case A13 */
 $bar = [1,2,3];
+/* Case A14 */
 $bar = [true];

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_double_colon_token.php
@@ -1,33 +1,53 @@
 <?php
 
+/* Case 1 */
 DateTime::CONSTANT;
+/* Case 2 */
 DateTime::$static_property;
+/* Case 3 */
 DateTime::static_function();
+/* Case 4 */
 \DateTime::static_function();
+/* Case 5 */
 namespace\DateTime::static_function();
+/* Case 6 */
 AnotherNS\DateTime::static_function();
+/* Case 7 */
 \FQNS\DateTime::static_function();
+/* Case 8 */
 $var = (DateTime::$static_property);
+/* Case 9 */
 $var = (5+AnotherNS\DateTime::$static_property);
 
+
 namespace Testing {
+	/* Case 10 */
 	DateTime::CONSTANT;
+	/* Case 11 */
 	DateTime::$static_property;
+	/* Case 12 */
 	DateTime::static_function();
-	
+
 	class MyClass {
 		function test {
+			/* Case 13 */
 			echo self::CONSTANT;
+			/* Case 14 */
 			echo parent::$static_property;
+			/* Case 15 */
 			static::test_function();
 		}
 	}
 }
 
+
 class MyClass {
 	function test {
+		/* Case 16 */
 		echo self::CONSTANT;
+		/* Case 17 */
 		echo parent::$static_property;
+		/* Case 18 */
 		static::test_function();
 	}
 }
@@ -39,4 +59,5 @@ class Foo {
     }
 }
 $theclass = 'Foo';
+/* Case 19 */
 $theclass::bar(42);

--- a/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
+++ b/Tests/sniff-examples/utility-functions/get_fqclassname_from_new_token.php
@@ -1,27 +1,50 @@
 <?php
+
+/* Case 1 */
+new DateTime;
+
+
 namespace MyTesting;
 
+/* Case 2 */
 new namespace\DateTime();
+/* Case 3 */
 new DateTime;
+/* Case 4 */
 new \DateTime();
+/* Case 5 */
 new anotherNS\DateTime();
+/* Case 6 */
 new \FQNS\DateTime();
 
+
 namespace AnotherTesting {
-	new namespace\DateTime();
-	new DateTime;
-	new \DateTime();
-	new anotherNS\DateTime();
-	new \FQNS\DateTime();
+    /* Case 7 */
+    new namespace\DateTime();
+    /* Case 8 */
+    new DateTime;
+    /* Case 9 */
+    new \DateTime();
+    /* Case 10 */
+    new anotherNS\DateTime();
+    /* Case 11 */
+    new \FQNS\DateTime();
 }
 
+/* Case 12 */
 new DateTime;
+/* Case 13 */
 new \DateTime;
+/* Case 14 */
 new \AnotherTesting\DateTime();
+
 
 // Variant on issue #205.
 $className = 'DateTime';
+/* Case 15 */
 new $className;
 
+
 // Issue #338 - no infinite loop on unfinished code.
+/* Case 16 */
 $var = new

--- a/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
+++ b/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
@@ -1,23 +1,46 @@
 <?php
+
+/* Case 1 */
+class MyTest {}
+/* Case 2 */
+class MyTestX extends DateTime {}
+
+
 namespace MyTesting;
 
+/* Case 3 */
 class MyTestA extends DateTime {}
+/* Case 4 */
 class MyTestB extends \DateTime {}
+/* Case 5 */
 class MyTestD extends anotherNS\DateTime {}
+/* Case 6 */
 class MyTestE extends \FQNS\DateTime {}
 
+
 namespace AnotherTesting {
-	class MyTestF extends DateTime {}
-	class MyTestG extends \DateTime {}
-	class MyTestI extends anotherNS\DateTime {}
-	class MyTestJ extends \FQNS\DateTime {}
+    /* Case 7 */
+    class MyTestF extends DateTime {}
+    /* Case 8 */
+    class MyTestG extends \DateTime {}
+    /* Case 9 */
+    class MyTestI extends anotherNS\DateTime {}
+    /* Case 10 */
+    class MyTestJ extends \FQNS\DateTime {}
 }
 
+
+/* Case 11 */
 class MyTestK extends DateTime {}
+/* Case 12 */
 class MyTestL extends \DateTime {}
+
 
 namespace Yet\More\Testing;
 
+/* Case 13 */
 class MyTestN extends DateTime {}
+/* Case 14 */
 class MyTestO extends anotherNS\DateTime {}
+/* Case 15 */
 class MyTestP extends \FQNS\DateTime {}

--- a/Tests/sniff-examples/utility-functions/get_function_parameter_count.php
+++ b/Tests/sniff-examples/utility-functions/get_function_parameter_count.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * Count function parameters.
+ */
+/* Case S1 */
+myfunction(1);
+/* Case S2 */
+myfunction( 1, 2 );
+/* Case S3 */
+myfunction(1, 2, 3);
+/* Case S4 */
+myfunction(1, 2, 3, 4);
+/* Case S5 */
+myfunction(1, 2, 3, 4, 5);
+/* Case S6 */
+myfunction(1, 2, 3, 4, 5, 6);
+/* Case S7 */
+myfunction( 1, 2, 3, 4, 5, 6, true );
+
+/*
+ * Propertly deal with nested parenthesis.
+ * Also see Github issues #111 / #114 / #151.
+ */
+/* Case S8 */
+dirname( dirname( __FILE__ ) ); // 1
+/* Case S9 */
+(dirname( dirname( __FILE__ ) )); // 1
+/* Case S10 */
+dirname( plugin_basename( __FILE__ ) ); // 1
+/* Case S11 */
+dirname( plugin_basename( __FILE__ ), 2 ); // 2
+/* Case S12 */
+unserialize(trim($value, "'")); // 1
+/* Case S13 */
+dirname(str_replace("../","/", $value)); // 1
+/* Case S14 */
+dirname(str_replace("../", "/", trim($value))); // 1
+/* Case S15 */
+dirname( plugin_basename( __FILE__ ), trim( 2 ) ); // 2
+/* Case S16 */
+mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+/* Case S17 */
+mktime(0, 0, 0, date('m'), date('d'), date('Y')); // 6
+/* Case S18 */
+mktime(0, 0, 0, date('m'), date('d') - 1, date('Y') + 1); // 6
+/* Case S19 */
+mktime(0, 0, 0, date('m') + 1, date('d'), date('Y')); // 6
+/* Case S20 */
+mktime(date('H'), 0, 0, date('m'), date('d'), date('Y')); // 6
+/* Case S21 */
+mktime(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+/* Case S22 */
+mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+
+/*
+ * Testing multi-line function calls.
+ */
+/* Case S23 */
+filter_input_array(
+    INPUT_POST,
+    $args,
+    false
+); // 3
+
+/* Case S24 */
+gettimeofday (
+               true
+             ); // 1
+
+/*
+ * Deal with unnecessary comma after last param.
+ */
+/* Case S25 */
+json_encode( array(), );
+
+/*
+ * Issue #211 - deal with short array syntax within parameters.
+ */
+/* Case S26 */
+json_encode(['a' => 'b',]);
+/* Case S27 */
+json_encode(['a' => $a,]);
+/* Case S28 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []));
+/* Case S29 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b, 'c' => $c,] : []));
+/* Case S30 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d] : []));
+/* Case S31 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d,] : []));
+/* Case S32 */
+json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d, $c => 'c'] : []));
+/* Case S33 */
+json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []) + ['c' => $c, 'd' => $d,]);
+/* Case S34 */
+json_encode(['a' => 'b', 'c' => 'd',]);
+/* Case S35 */
+json_encode(['a' => ['b',],]);
+/* Case S36 */
+json_encode(['a' => ['b' => 'c',],]);
+/* Case S37 */
+json_encode(['a' => ['b' => 'c',], 'd' => ['e' => 'f',],]);
+/* Case S38 */
+json_encode(['a' => $a, 'b' => $b,]);
+/* Case S39 */
+json_encode(['a' => $a,] + ['b' => $b,]);
+/* Case S40 */
+json_encode(['a' => $a] + ['b' => $b, 'c' => $c,]);
+/* Case S41 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d]);
+/* Case S42 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d,]);
+/* Case S43 */
+json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d, $c => 'c']);
+/* Case S44 */
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c]);
+/* Case S45 */
+json_encode(['a' => $a, 'b' => $b,] + ['c' => $c,]);
+/* Case S46 */
+json_encode(['a' => $a, 'b' => $b, 'c' => $c]);
+/* Case S47 */
+json_encode(['a' => $a, 'b' => $b, 'c' => $c,] + ['c' => $c, 'd' => $d,]);
+
+/*
+ * Even though a language construct and not a function call, the functions should
+ * work just as well for long arrays.
+ */
+/* Case A1 */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+/* Case A2 */
+$foo = array(str_replace("../", "/", trim($value))); // 1
+/* Case A3 */
+$foo = array($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
+/* Case A4 */
+$foo = array(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+/* Case A5 */
+$foo = array(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+/* Case A6 */
+$foo = array('a' => $a, 'b' => $b, 'c' => $c);
+/* Case A7 */
+$foo = array('a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null));
+/* Case A8 */
+$foo = array(0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null));
+
+// Same goes for short arrays.
+/* Case A9 */
+$bar = [ 1, 2, 3, 4, 5, 6, true ];
+/* Case A10 */
+$bar = [str_replace("../", "/", trim($value))]; // 1
+/* Case A11 */
+$bar = [$stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]]; // 6
+/* Case A12 */
+$bar = [0, 0, date('s'), date('m'), date('d'), date('Y')]; // 6
+/* Case A13 */
+$bar = [some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6]; // 6
+/* Case A14 */
+$bar = ['a' => $a, 'b' => $b, 'c' => $c];
+/* Case A15 */
+$bar = ['a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null)];
+/* Case A16 */
+$bar = [0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null)];

--- a/Tests/sniff-examples/utility-functions/get_function_parameters.php
+++ b/Tests/sniff-examples/utility-functions/get_function_parameters.php
@@ -1,98 +1,44 @@
 <?php
-/*
- * Count function parameters.
- */
-myfunction(1);
-myfunction( 1, 2 );
-myfunction(1, 2, 3);
-myfunction(1, 2, 3, 4);
-myfunction(1, 2, 3, 4, 5);
-myfunction(1, 2, 3, 4, 5, 6);
+
+/* Case S1 */
 myfunction( 1, 2, 3, 4, 5, 6, true );
 
 /*
  * Propertly deal with nested parenthesis.
  * Also see Github issues #111 / #114 / #151.
  */
+/* Case S2 */
 dirname( dirname( __FILE__ ) ); // 1
-(dirname( dirname( __FILE__ ) )); // 1
-dirname( plugin_basename( __FILE__ ) ); // 1
-dirname( plugin_basename( __FILE__ ), 2 ); // 2
-unserialize(trim($value, "'")); // 1
-dirname(str_replace("../","/", $value)); // 1
-dirname(str_replace("../", "/", trim($value))); // 1
-dirname( plugin_basename( __FILE__ ), trim( 2 ) ); // 2
+/* Case S3 */
 mktime($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
-mktime(0, 0, 0, date('m'), date('d'), date('Y')); // 6
-mktime(0, 0, 0, date('m'), date('d') - 1, date('Y') + 1); // 6
-mktime(0, 0, 0, date('m') + 1, date('d'), date('Y')); // 6
-mktime(date('H'), 0, 0, date('m'), date('d'), date('Y')); // 6
-mktime(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
-mktime(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
-
-/*
- * Testing multi-line function calls.
- */
-filter_input_array(
-    INPUT_POST,
-    $args,
-    false
-); // 3
-
-gettimeofday (
-               true
-             ); // 1
 
 /*
  * Deal with unnecessary comma after last param.
  */
+/* Case S4 */
 json_encode( array(), );
 
 /*
  * Issue #211 - deal with short array syntax within parameters.
  */
-json_encode(['a' => 'b',]);
-json_encode(['a' => $a,]);
+/* Case S5 */
 json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []));
-json_encode(['a' => $a,] + (isset($b) ? ['b' => $b, 'c' => $c,] : []));
-json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d] : []));
-json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d,] : []));
-json_encode(['a' => $a, 'b' => $b] + (isset($c) ? ['c' => $c, 'd' => $d, $c => 'c'] : []));
-json_encode(['a' => $a,] + (isset($b) ? ['b' => $b,] : []) + ['c' => $c, 'd' => $d,]);
-json_encode(['a' => 'b', 'c' => 'd',]);
-json_encode(['a' => ['b',],]);
-json_encode(['a' => ['b' => 'c',],]);
-json_encode(['a' => ['b' => 'c',], 'd' => ['e' => 'f',],]);
-json_encode(['a' => $a, 'b' => $b,]);
-json_encode(['a' => $a,] + ['b' => $b,]);
-json_encode(['a' => $a] + ['b' => $b, 'c' => $c,]);
-json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d]);
-json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d,]);
-json_encode(['a' => $a, 'b' => $b] + ['c' => $c, 'd' => $d, $c => 'c']);
-json_encode(['a' => $a, 'b' => $b,] + ['c' => $c]);
-json_encode(['a' => $a, 'b' => $b,] + ['c' => $c,]);
-json_encode(['a' => $a, 'b' => $b, 'c' => $c]);
-json_encode(['a' => $a, 'b' => $b, 'c' => $c,] + ['c' => $c, 'd' => $d,]);
 
 /*
  * Even though a language construct and not a function call, the functions should
  * work just as well for long arrays.
  */
-$foo = array( 1, 2, 3, 4, 5, 6, true );
-$foo = array(str_replace("../", "/", trim($value))); // 1
-$foo = array($stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]); // 6
-$foo = array(0, 0, date('s'), date('m'), date('d'), date('Y')); // 6
+/* Case A1 */
 $foo = array(some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6); // 6
+/* Case A3 */
+$foo = array( 1, 2, 3, 4, 5, 6, true );
+/* Case A4 */
 $foo = array('a' => $a, 'b' => $b, 'c' => $c);
-$foo = array('a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null));
-$foo = array(0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null));
 
 // Same goes for short arrays.
-$bar = [ 1, 2, 3, 4, 5, 6, true ];
-$bar = [str_replace("../", "/", trim($value))]; // 1
-$bar = [$stHour, 0, 0, $arrStDt[0], $arrStDt[1], $arrStDt[2]]; // 6
+/* Case A2 */
 $bar = [0, 0, date('s'), date('m'), date('d'), date('Y')]; // 6
-$bar = [some_call(5, 1), another(1), why(5, 1, 2), 4, 5, 6]; // 6
-$bar = ['a' => $a, 'b' => $b, 'c' => $c];
-$bar = ['a' => $a, 'b' => $b, (isset($c) ? 'c' => $c : null)];
+/* Case A5 */
+$bar = [str_replace("../", "/", trim($value))]; // 1
+/* Case A6 */
 $bar = [0 => $a, 2 => $b, (isset($c) ? 6 => $c : 6 => null)];

--- a/Tests/sniff-examples/utility-functions/token_has_scope.php
+++ b/Tests/sniff-examples/utility-functions/token_has_scope.php
@@ -1,61 +1,86 @@
 <?php
 
+/* Case 1 */
 $var = false;
 
+/* Case 2 */
 if ($x === true) {
     echo 'test-if';
 }
+/* Case 3 */
 elseif ($y === false) {
     echo 'test-else-if';
 }
+/* Case 4 */
 else {
     echo 'test-else';
 }
 
+/* Case 5 */
 for ($i = 0; $i<5;$i++) {
     echo 'test-for';
 }
 
+/* Case 6 */
 foreach ($dataSet as $data) {
     echo $data;
 }
 
 switch($y) {
+    /* Case 7 */
     case 1:
+        /* Case 8 */
         echo 'test-switch-case';
         break;
+    /* Case 9 */
     default:
+        /* Case 10 */
         echo 'test-switch-default';
         break;
 }
 
+/* Case 11 */
 function something() {
     echo 'test-function';
 }
 
 class MyClass {
+    /* Case C1 */
     public $property;
+    /* Case C2 */
     function something() {}
 }
 
 namespace {
+    /* Case C3 */
     function something() {}
 
     class MyClass {
+        /* Case C4 */
         function something() {}
     }
 }
 
+/* Case U1 */
 use Baz;
+/* Case U2 */
 use Foobar as Baz;
-class Foobar { use Baz }
-class Foobar { use const Baz }
-class Foobar { use function Baz }
+/* Case U3- */
+class Foobar { use /* Case U3 */ Baz }
+/* Case U4- */
+class Foobar { use /* Case U4 */ const Baz }
+/* Case U5- */
+class Foobar { use /* Case U5 */ function Baz }
+/* Case U6 */
 class Foobar { use BazTrait { oldfunction as Baz } }
+/* Case U7 */
 class Foobar { use BazTrait { oldfunction as public Baz } }
+/* Case U8 */
 class Foobar { use BazTrait { oldfunction as protected Baz } }
+/* Case U9 */
 class Foobar { use BazTrait { oldfunction as private Baz } }
 
+/* Case C5 */
 new class {
     function something() {}
 }


### PR DESCRIPTION
Most utility function tests were currently based on an **exact** token position in the test file.
This made adding/changing unit tests unnecessarily complicated and made the tests very error-prone.

I've now added a helper function to the `MethodTestFrame` class to help get the token position being targeted for a unit test based on comments in the test case file.
The principle of this is similar to how these type of functions are being tested in PHPCS upstream.

This will make these unit tests more stable, more reliable and a **lot** easier to add to/adjust.

Notes:
* Includes one extra unit test case for `testGetFQClassNameFromNewToken()`.
* Includes two extra unit test cases for `testGetFQExtendedClassName()`.

* The test for the `getFunctionCallParameterCount()` function has been split off into its own file (+ test case file).
* The test case file for the `testGetFunctionCallParameters()` and the `testGetFunctionCallParameter()` tests has been reduced to only the test cases actually used by those functions and the related test dataproviders have been adjusted to use offset from the stackPtr instead of exact position to allow for the tests to work with finding the target token based on a comment.