### PR TITLE
ForbiddenNames: backport forbidden names recognition for namespaces to PHP 5.2

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -258,9 +258,15 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
     {
         $tokenContentLc = strtolower($tokens[$stackPtr]['content']);
 
-        // Special case for 5.3 where we want to find usage of traits, but
-        // trait is not a token.
-        if ($tokenContentLc === 'trait') {
+        /*
+         * Special case for PHP versions where the target is not yet identified as
+         * its own token, but presents as T_STRING.
+         * - namespace keyword in PHP < 5.3
+         * - trait keyword in PHP < 5.4
+         */
+        if ((version_compare(phpversion(), '5.3', '<') && $tokenContentLc === 'namespace')
+            || (version_compare(phpversion(), '5.4', '<') && $tokenContentLc === 'trait')
+        ) {
             $this->processNonString($phpcsFile, $stackPtr, $tokens);
             return;
         }

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -60,7 +60,8 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
      */
     public function usecaseProvider()
     {
-        $data = array(
+        return array(
+            array('namespace'),
             array('use'),
             array('use-as'),
             array('class'),
@@ -79,12 +80,8 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
             array('interface'),
             array('interface-extends'),
         );
-        if (version_compare(phpversion(), '5.3', '>=')) {
-            $data[] = array('namespace');
-        }
-
-        return $data;
     }
+
 
     /**
      * testCorrectUsageOfKeywords


### PR DESCRIPTION
Getting rid of one more test exclusion by adding the missing functionality.