### PR TITLE
Document & test the `supportsBelow()`, `supportsAbove()` and `getTestVersion()` methods

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -56,29 +56,31 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     );
 
 
-/* The testVersion configuration variable may be in any of the following formats:
- * 1) Omitted/empty, in which case no version is specified.  This effectively
- *    disables all the checks provided by this standard.
- * 2) A single PHP version number, e.g. "5.4" in which case the standard checks that
- *    the code will run on that version of PHP (no deprecated features or newer
- *    features being used).
- * 3) A range, e.g. "5.0-5.5", in which case the standard checks the code will run
- *    on all PHP versions in that range, and that it doesn't use any features that
- *    were deprecated by the final version in the list, or which were not available
- *    for the first version in the list.
- * PHP version numbers should always be in Major.Minor format.  Both "5", "5.3.2"
- * would be treated as invalid, and ignored.
- * This standard doesn't support checking against PHP4, so the minimum version that
- * is recognised is "5.0".
- */
-
+    /**
+     * Get the testVersion configuration variable.
+     *
+     * The testVersion configuration variable may be in any of the following formats:
+     * 1) Omitted/empty, in which case no version is specified. This effectively
+     *    disables all the checks for new PHP features provided by this standard.
+     * 2) A single PHP version number, e.g. "5.4" in which case the standard checks that
+     *    the code will run on that version of PHP (no deprecated features or newer
+     *    features being used).
+     * 3) A range, e.g. "5.0-5.5", in which case the standard checks the code will run
+     *    on all PHP versions in that range, and that it doesn't use any features that
+     *    were deprecated by the final version in the list, or which were not available
+     *    for the first version in the list.
+     * PHP version numbers should always be in Major.Minor format.  Both "5", "5.3.2"
+     * would be treated as invalid, and ignored.
+     *
+     * @return array $arrTestVersions will hold an array containing min/max version
+     *               of PHP that we are checking against (see above).  If only a
+     *               single version number is specified, then this is used as
+     *               both the min and max.
+     *
+     * @throws PHP_CodeSniffer_Exception If testVersion is invalid.
+     */
     private function getTestVersion()
     {
-        /**
-         * var $arrTestVersions will hold an array containing min/max version of PHP
-         *   that we are checking against (see above).  If only a single version
-         *   number is specified, then this is used as both the min and max.
-         */
         static $arrTestVersions = array();
 
         $testVersion = trim(PHP_CodeSniffer::getConfigData('testVersion'));
@@ -114,6 +116,19 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         }
     }
 
+
+    /**
+     * Check whether a specific PHP version is equal to or higher than the maximum
+     * supported PHP version as provided by the user in `testVersion`.
+     *
+     * Should be used when sniffing for *old* PHP features (deprecated/removed).
+     *
+     * @param string $phpVersion A PHP version number in 'major.minor' format.
+     *
+     * @return bool True if testVersion has not been provided or if the PHP version
+     *              is equal to or higher than the highest supported PHP version
+     *              in testVersion. False otherwise.
+     */
     public function supportsAbove($phpVersion)
     {
         $testVersion = $this->getTestVersion();
@@ -128,6 +143,19 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         }
     }//end supportsAbove()
 
+
+    /**
+     * Check whether a specific PHP version is equal to or lower than the minimum
+     * supported PHP version as provided by the user in `testVersion`.
+     *
+     * Should be used when sniffing for *new* PHP features.
+     *
+     * @param string $phpVersion A PHP version number in 'major.minor' format.
+     *
+     * @return bool True if the PHP version is equal to or lower than the lowest
+     *              supported PHP version in testVersion.
+     *              False otherwise or if no testVersion is provided.
+     */
     public function supportsBelow($phpVersion)
     {
         $testVersion = $this->getTestVersion();

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -51,7 +51,228 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
     }
 
 
-   /**
+    /**
+     * testGetTestVersion
+     *
+     * @dataProvider dataGetTestVersion
+     *
+     * @covers PHPCompatibility_Sniff::getTestVersion
+     *
+     * @requires PHP 5.3.2
+     * @internal Requirement is needed to be able to test the private method
+     *           using `ReflectionMethod::setAccessible()`.
+     *           The function itself works fine in PHP < 5.3.2.
+     *
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param string $expected    The expected testVersion array.
+     */
+    public function testGetTestVersion($testVersion, $expected)
+    {
+        if (isset($testVersion)) {
+            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+        }
+
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
+
+        // Clean up / reset the value.
+        PHP_CodeSniffer::setConfigData('testVersion', null, true);
+    }
+
+    /**
+     * dataGetTestVersion
+     *
+     * @see testGetTestVersion()
+     *
+     * @return array
+     */
+    public function dataGetTestVersion()
+    {
+        return array(
+            array(null, array(null, null)), // No testVersion provided.
+            array('5.0', array('5.0', '5.0')), // Single version.
+            array('7.1', array('7.1', '7.1')), // Single version.
+            array('4.0-99.0', array('4.0', '99.0')), // Range of versions.
+            array('5.1-5.5', array('5.1', '5.5')), // Range of versions.
+            array('7.0-7.5', array('7.0', '7.5')), // Range of versions.
+            array('5.6-5.6', array('5.6', '5.6')), // Range of versions - min & max the same.
+            array('4.0 - 99.0', array('4.0', '99.0')), // Range of versions with spaces around dash.
+        );
+    }
+
+
+    /**
+     * testGetTestVersionInvalidRange
+     *
+     * @dataProvider dataGetTestVersionInvalidRange
+     *
+     * @covers PHPCompatibility_Sniff::getTestVersion
+     *
+     * @requires PHP 5.3.2
+     * @internal Requirement is needed to be able to test the private method
+     *           using `ReflectionMethod::setAccessible()`.
+     *           The function itself works fine in PHP < 5.3.2.
+     *
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     */
+    public function testGetTestVersionInvalidRange($testVersion)
+    {
+        $this->setExpectedException(
+            'PHPUnit_Framework_Error_Warning',
+            sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion)
+        );
+        $this->testGetTestVersion($testVersion, array(null, null));
+    }
+
+    /**
+     * dataGetTestVersionInvalidRange
+     *
+     * @see testGetTestVersionInvalidRange()
+     *
+     * @return array
+     */
+    public function dataGetTestVersionInvalidRange()
+    {
+        return array(
+            array('5.6-5.4'), // Range of versions - min > max.
+        );
+    }
+
+
+    /**
+     * testGetTestVersionInvalidVersion
+     *
+     * @dataProvider dataGetTestVersionInvalidVersion
+     *
+     * @covers PHPCompatibility_Sniff::getTestVersion
+     *
+     * @requires PHP 5.3.2
+     * @internal Requirement is needed to be able to test the private method
+     *           using `ReflectionMethod::setAccessible()`.
+     *           The function itself works fine in PHP < 5.3.2.
+     *
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     */
+    public function testGetTestVersionInvalidVersion($testVersion)
+    {
+        $this->setExpectedException(
+            'PHPUnit_Framework_Error_Warning',
+            sprintf('Invalid testVersion setting: \'%s\'', $testVersion)
+        );
+        $this->testGetTestVersion($testVersion, array(null, null));
+
+    }
+
+    /**
+     * dataGetTestVersionInvalidVersion
+     *
+     * @see testGetTestVersionInvalidVersion()
+     *
+     * @return array
+     */
+    public function dataGetTestVersionInvalidVersion()
+    {
+        return array(
+            array('5'), // Not in major.minor format.
+            array('568'), // Not in major.minor format.
+            array('5.6.28'), // Not in major.minor format.
+            array('seven.one'), // Non numeric.
+        );
+    }
+
+
+    /**
+     * testSupportsAbove
+     *
+     * @dataProvider dataSupportsAbove
+     *
+     * @covers PHPCompatibility_Sniff::supportsAbove
+     *
+     * @param string $phpVersion  The PHP version we want to test.
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param string $expected    Expected result.
+     */
+    public function testSupportsAbove($phpVersion, $testVersion, $expected)
+    {
+        if (isset($testVersion)) {
+            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+        }
+
+        $this->assertSame($expected, $this->helperClass->supportsAbove($phpVersion));
+
+        // Clean up / reset the value.
+        PHP_CodeSniffer::setConfigData('testVersion', null, true);
+    }
+
+    /**
+     * dataSupportsAbove
+     *
+     * @see testSupportsAbove()
+     *
+     * @return array
+     */
+    public function dataSupportsAbove()
+    {
+        return array(
+            array('5.0', null, true),
+            array('5.0', '5.2', true),
+            array('5.0', '5.1-5.4', true),
+            array('5.0', '5.3-7.0', true),
+
+            array('7.1', null, true),
+            array('7.1', '5.2', false),
+            array('7.1', '5.1-5.4', false),
+            array('7.1', '5.3-7.0', false),
+        );
+    }
+
+
+    /**
+     * testSupportsBelow
+     *
+     * @dataProvider dataSupportsBelow
+     *
+     * @covers PHPCompatibility_Sniff::supportsBelow
+     *
+     * @param string $phpVersion  The PHP version we want to test.
+     * @param string $testVersion The testVersion as normally set via the command line or ruleset.
+     * @param string $expected    Expected result.
+     */
+    public function testSupportsBelow($phpVersion, $testVersion, $expected)
+    {
+        if (isset($testVersion)) {
+            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+        }
+
+        $this->assertSame($expected, $this->helperClass->supportsBelow($phpVersion));
+
+        // Clean up / reset the value.
+        PHP_CodeSniffer::setConfigData('testVersion', null, true);
+    }
+
+    /**
+     * dataSupportsBelow
+     *
+     * @see testSupportsBelow()
+     *
+     * @return array
+     */
+    public function dataSupportsBelow()
+    {
+        return array(
+            array('5.0', null, false),
+            array('5.0', '5.2', false),
+            array('5.0', '5.1-5.4', false),
+            array('5.0', '5.3-7.0', false),
+
+            array('7.1', null, false),
+            array('7.1', '5.2', true),
+            array('7.1', '5.1-5.4', true),
+            array('7.1', '5.3-7.0', true),
+        );
+    }
+
+
+    /**
      * testStringToErrorCode
      *
      * @dataProvider dataStringToErrorCode
@@ -220,6 +441,25 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
             array('"This is { $great}"', '"This is { }"'),
             array('"This is the return value of getName(): {getName()}"', '"This is the return value of getName(): {getName()}"'),
         );
+    }
+
+
+    /**
+     * Test helper: Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     *
+     * @return mixed Method return.
+     */
+    private function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
     }
 
 }


### PR DESCRIPTION
Hoping that this will make the use of these functions slightly clearer.

Related to #142