### PR TITLE
Make the unit tests compatible with PHPUnit v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,8 @@ before_script:
 
 script:
   - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then ln -s `pwd` vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility; fi
-  - find -L . -path ./Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then find -L . -path ./Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then find -L . -path ./Tests/sniff-examples -prune -o -path ./Tests/TestcaseWrapper_v6.php -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --standard=./phpcs.xml; fi
   - phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml
 

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -12,11 +12,11 @@
  * @group utilityMiscFunctions
  * @group utilityFunctions
  *
- * @uses    PHPUnit_Framework_TestCase
+ * @uses    PHPCompatibility_Testcase_Wrapper
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
+class BaseClass_FunctionsTest extends PHPCompatibility_Testcase_Wrapper
 {
 
     /**
@@ -116,10 +116,16 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      */
     public function testGetTestVersionInvalidRange($testVersion)
     {
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion)
-        );
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException(
+                'PHPUnit_Framework_Error_Warning',
+                sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion)
+            );
+        } else {
+            $this->expectException('PHPUnit\Framework\Error\Warning');
+            $this->expectExceptionMessage(sprintf('Invalid range in testVersion setting: \'%s\'', $testVersion));
+        }
+
         $this->testGetTestVersion($testVersion, array(null, null));
     }
 
@@ -154,12 +160,17 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      */
     public function testGetTestVersionInvalidVersion($testVersion)
     {
-        $this->setExpectedException(
-            'PHPUnit_Framework_Error_Warning',
-            sprintf('Invalid testVersion setting: \'%s\'', $testVersion)
-        );
-        $this->testGetTestVersion($testVersion, array(null, null));
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException(
+                'PHPUnit_Framework_Error_Warning',
+                sprintf('Invalid testVersion setting: \'%s\'', $testVersion)
+            );
+        } else {
+            $this->expectException('PHPUnit\Framework\Error\Warning');
+            $this->expectExceptionMessage(sprintf('Invalid testVersion setting: \'%s\'', $testVersion));
+        }
 
+        $this->testGetTestVersion($testVersion, array(null, null));
     }
 
     /**

--- a/Tests/BaseClass/MethodTestFrame.php
+++ b/Tests/BaseClass/MethodTestFrame.php
@@ -8,11 +8,11 @@
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
  *
- * @uses    BaseSniffTest
+ * @uses    PHPCompatibility_Testcase_Wrapper
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
+abstract class BaseClass_MethodTestFrame extends PHPCompatibility_Testcase_Wrapper
 {
 
     /**

--- a/Tests/BaseSniffTest.php
+++ b/Tests/BaseSniffTest.php
@@ -11,11 +11,11 @@
  * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings
  *
- * @uses PHPUnit_Framework_TestCase
+ * @uses    PHPCompatibility_Testcase_Wrapper
  * @package PHPCompatibility
- * @author Jansen Price <jansen.price@gmail.com>
+ * @author  Jansen Price <jansen.price@gmail.com>
  */
-class BaseSniffTest extends PHPUnit_Framework_TestCase
+class BaseSniffTest extends PHPCompatibility_Testcase_Wrapper
 {
     /**
      * The PHP_CodeSniffer object used for testing.

--- a/Tests/TestcaseWrapper.php
+++ b/Tests/TestcaseWrapper.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Compatibility layer for PHPUnit < 6
+ *
+ * @package PHPCompatibility
+ */
+class PHPCompatibility_Testcase_Wrapper extends PHPUnit_Framework_TestCase {}

--- a/Tests/TestcaseWrapper_v6.php
+++ b/Tests/TestcaseWrapper_v6.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Compatibility layer for PHPUnit 6+
+ *
+ * @package PHPCompatibility
+ */
+class PHPCompatibility_Testcase_Wrapper extends PHPUnit\Framework\TestCase {}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -34,5 +34,17 @@ else {
     }
 }
 
+$phpunitVersion = 0;
+exec('phpunit --version', $output);
+if (preg_match('`PHPUnit ([0-9\.]+) by Sebastian Bergmann`', implode(' ', $output), $matches) > 0 && isset($matches[1])) {
+    $phpunitVersion = $matches[1];
+}
+
+if (version_compare($phpunitVersion, '6.0', '>') === true) {
+    require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'TestcaseWrapper_v6.php';
+} else {
+    require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'TestcaseWrapper.php';
+}
+
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseClass' . DIRECTORY_SEPARATOR . 'MethodTestFrame.php';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,4 +19,9 @@
 		<exclude-pattern>*/RemovedAlternativePHPTags*.php</exclude-pattern>
 	</rule>
 
+	<!-- Verified correct usage: compatibility layer. -->
+	<rule ref="PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound">
+		<exclude-pattern>/Tests/TestcaseWrapper_v6.php</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/phpunit-travis.xml
+++ b/phpunit-travis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="Tests/bootstrap.php" colors="true">
+<phpunit bootstrap="Tests/bootstrap.php" colors="true" backupGlobals="true">
     <testsuites>
         <testsuite name="PHPCompatibility Sniffs Tests">
             <directory>./Tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="Tests/bootstrap.php" colors="true">
+<phpunit bootstrap="Tests/bootstrap.php" colors="true" backupGlobals="true">
     <testsuites>
         <testsuite name="PHPCompatibility Sniffs Tests">
             <directory>./Tests/</directory>


### PR DESCRIPTION
Since today Travis uses PHPUnit 6.x for PHP 7+. The unit tests were not compatible with this and failing because of it.

These relatively minor changes fix that and makes the tests compatible with both PHPUnit < 6 as well as 6+.

Ref: https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0

----
**[Edit]** For argument's sake and to document why I'm proposing the solution pulled here:

The alternative to the solution proposed here, would be to add PHPUnit to the `composer.json` file.

There are a couple of arguments against this though:
1. It would increase the build time even more, while I've been trying to bring it down.
2. We would need different PHPUnit versions for PHP 5.2-5.3 (PHPUnit 4.x) and PHP 5.4-PHP7.1 (PHPUnit 5.x) and PHP 7.2/nightly (PHPUnit 6.x)
3. As PHP 7.2/nightly will most likely only work with PHPUnit 6.x - and test code can not run on PHPUnit 5.x and PHPUnit 6.x without a compability layer as proposed in this PR -, it means we can no longer test PHP 7.2/nightly with the current test suite.

