### PR TITLE
Add partial-range support to testVersion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Using the compatibility sniffs
 * Use the coding standard with `phpcs --standard=PHPCompatibility`
 * You can specify which PHP version you want to test against by specifying `--runtime-set testVersion 5.5`.
 * You can also specify a range of PHP versions that your code needs to support.  In this situation, compatibility issues that affect any of the PHP versions in that range will be reported:
-`--runtime-set testVersion 5.3-5.5`
+`--runtime-set testVersion 5.3-5.5`.  You can omit one or other part of the range if you want to support everything above/below a particular version (e.g. `--runtime-set testVersion 7.0-` to support PHP 7 and above).
 
 More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 

--- a/Sniff.php
+++ b/Sniff.php
@@ -69,6 +69,8 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      *    on all PHP versions in that range, and that it doesn't use any features that
      *    were deprecated by the final version in the list, or which were not available
      *    for the first version in the list.
+     *    We accept ranges where one of the components is missing, e.g. "-5.6" means
+     *    all versions up to PHP 5.6, and "7.0-" means all versions above PHP 7.0.
      * PHP version numbers should always be in Major.Minor format.  Both "5", "5.3.2"
      * would be treated as invalid, and ignored.
      *
@@ -101,6 +103,21 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 else {
                     $arrTestVersions[$testVersion] = array($matches[1], $matches[2]);
                 }
+            }
+            elseif (preg_match('/^\d+\.\d+-$/', $testVersion)) {
+                $testVersion = substr($testVersion, 0, -1);
+                // If no upper-limit is set, we set the max version to 99.9.
+                // This is *probably* safe... :-)
+                $arrTestVersions[$testVersion] = array($testVersion, '99.9');
+            }
+            elseif (preg_match('/^-\d+\.\d+$/', $testVersion)) {
+                $testVersion = substr($testVersion, 1);
+                // If no lower-limit is set, we set the min version to 4.0.
+                // Whilst development focuses on PHP 5 and above, we also accept
+                // sniffs for PHP 4, so we include that as the minimum.
+                // (It makes no sense to support PHP 3 as this was effectively a
+                // different language).
+                $arrTestVersions[$testVersion] = array('4.0', $testVersion);
             }
             elseif (!$testVersion == '') {
                 trigger_error("Invalid testVersion setting: '" . $testVersion

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -96,6 +96,8 @@ class BaseClass_FunctionsTest extends PHPCompatibility_Testcase_Wrapper
             array('7.0-7.5', array('7.0', '7.5')), // Range of versions.
             array('5.6-5.6', array('5.6', '5.6')), // Range of versions - min & max the same.
             array('4.0 - 99.0', array('4.0', '99.0')), // Range of versions with spaces around dash.
+            array('-5.6', array('4.0', '5.6')), // Range, with no minimum.
+            array('7.0-', array('7.0', '99.9')), // Range, with no maximum.
         );
     }
 


### PR DESCRIPTION
I've improved the testVersion setting so that is now possible to specify partial ranges.

For example:
* "-5.6" means all versions up to PHP 5.6
* "7.0-" means all versions above PHP 7.0

Unit tests and documentation updated.