### PR TITLE
PHP 7.2: Add sniffing for new socket related functions.

### DIFF
--- a/Sniffs/PHP/NewFunctionsSniff.php
+++ b/Sniffs/PHP/NewFunctionsSniff.php
@@ -1239,6 +1239,23 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_Abs
                                             '7.0' => false,
                                             '7.1' => true
                                         ),
+
+                                        'socket_addrinfo_lookup' => array(
+                                            '7.1' => false,
+                                            '7.2' => true
+                                        ),
+                                        'socket_addrinfo_connect' => array(
+                                            '7.1' => false,
+                                            '7.2' => true
+                                        ),
+                                        'socket_addrinfo_bind' => array(
+                                            '7.1' => false,
+                                            '7.2' => true
+                                        ),
+                                        'socket_addrinfo_explain' => array(
+                                            '7.1' => false,
+                                            '7.2' => true
+                                        ),
                                     );
 
 

--- a/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -376,6 +376,10 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('session_create_id', '7.0', array(319), '7.1'),
             array('session_gc', '7.0', array(320), '7.1'),
 
+            array('socket_addrinfo_lookup', '7.1', array(322), '7.2'),
+            array('socket_addrinfo_connect', '7.1', array(323), '7.2'),
+            array('socket_addrinfo_bind', '7.1', array(324), '7.2'),
+            array('socket_addrinfo_explain', '7.1', array(325), '7.2'),
         );
     }
 

--- a/Tests/sniff-examples/new_functions.php
+++ b/Tests/sniff-examples/new_functions.php
@@ -318,3 +318,8 @@ is_iterable();
 pcntl_async_signals();
 session_create_id();
 session_gc();
+
+socket_addrinfo_lookup();
+socket_addrinfo_connect();
+socket_addrinfo_bind();
+socket_addrinfo_explain();


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/socket_getaddrinfo
* https://github.com/php/php-src/pull/2078