### PR TITLE
PHP 7.2: Add sniffing for deprecated mbstring.func_overload ini directive

### DIFF
--- a/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -199,6 +199,10 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompat
         'session.hash_bits_per_character' => array(
             '7.1' => true
         ),
+
+        'mbstring.func_overload' => array(
+            '7.2' => false
+        ),
     );
 
     /**

--- a/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -156,6 +156,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
 
             array('mcrypt.algorithms_dir', '7.1', array(135, 136), '7.0'),
             array('mcrypt.modes_dir', '7.1', array(138, 139), '7.0'),
+
+            array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
         );
     }
 

--- a/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/Tests/sniff-examples/deprecated_ini_directives.php
@@ -162,3 +162,6 @@ class myClass {
 
 ini_setter('ANIMALS', 'dog');
 ini_set();
+
+ini_set('mbstring.func_overload', 2);
+$a = ini_get('mbstring.func_overload');


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2#mbstringfunc_overload
* https://github.com/php/php-src/commit/a8239ff23272a346f6cb8f01bff384f94a3bcb79

Related to #336