### PR TITLE
NewConstVisibilitySniff: Add support for anonymous classes

### DIFF
--- a/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -56,7 +56,18 @@ class PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff extends PHPCompatibili
             return;
         }
 
-        if ($this->tokenHasScope($phpcsFile, $stackPtr, array(T_CLASS, T_INTERFACE)) === true && $this->supportsBelow('7.0') === true) {
+        $targetScopes = array(
+            T_CLASS,
+            T_INTERFACE,
+        );
+
+        if (defined('T_ANON_CLASS')) {
+            $targetScopes[] = constant('T_ANON_CLASS');
+        }
+
+        if ($this->tokenHasScope($phpcsFile, $stackPtr, $targetScopes) === true
+            && $this->supportsBelow('7.0') === true
+        ) {
             $error = 'Visibility indicators for class constants are not supported in PHP 7.0 or earlier. Found "%s const"';
             $data  = array($tokens[$prevToken]['content']);
 

--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -54,6 +54,10 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
             array(20),
             array(23),
             array(24),
+
+            array(33),
+            array(34),
+            array(35),
         );
     }
 
@@ -86,6 +90,7 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
             array(3),
             array(7),
             array(17),
+            array(30),
         );
     }
 

--- a/Tests/sniff-examples/new_const_visibility.php
+++ b/Tests/sniff-examples/new_const_visibility.php
@@ -23,3 +23,14 @@ interface InterfaceDemo
     protected const PROTECTED_CONST = 3;
     private const PRIVATE_CONST = 4;
 }
+
+// Test anonymous classes.
+$a = new class
+{
+    const PUBLIC_CONST_A = 1;
+
+    // PHP 7.1+
+    public const PUBLIC_CONST_B = 2;
+    protected const PROTECTED_CONST = 3;
+    private const PRIVATE_CONST = 4;
+}


### PR DESCRIPTION
Includes unit tests.

One of several PRs to fix #351