### PR TITLE
NewScalarTypeDeclarations: Allow the sniff to report even when the type hint is nullable.

### DIFF
--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -110,6 +110,9 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                 continue;
             }
 
+            // Strip off potential nullable indication.
+            $type_hint = ltrim($param['type_hint'], '?');
+
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(
                     'Type hints were not present in PHP 4.4 or earlier.',
@@ -117,23 +120,23 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                     'TypeHintFound'
                 );
             }
-            else if (isset($this->newTypes[$param['type_hint']])) {
+            else if (isset($this->newTypes[$type_hint])) {
                 $itemInfo = array(
-                    'name'   => $param['type_hint'],
+                    'name'   => $type_hint,
                 );
                 $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
             }
-            else if (isset($this->invalidTypes[$param['type_hint']])) {
+            else if (isset($this->invalidTypes[$type_hint])) {
                 $error = "'%s' is not a valid type declaration. Did you mean %s ?";
                 $data  = array(
-                    $param['type_hint'],
-                    $this->invalidTypes[$param['type_hint']],
+                    $type_hint,
+                    $this->invalidTypes[$type_hint],
                 );
 
                 $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHintFound', $data);
             }
-            else if ($param['type_hint'] === 'self') {
-                if ($this->inClassScope($phpcsFile, $stackPtr) === false) {
+            else if ($type_hint === 'self') {
+                if ($this->inClassScope($phpcsFile, $stackPtr, false) === false) {
                     $phpcsFile->addError(
                         "'self' type cannot be used outside of class scope",
                         $stackPtr,

--- a/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -61,6 +61,8 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
             array('iterable', '7.0', 17, '7.1'),
             array('callable', '5.3', 52, '5.4'),
             array('int', '5.6', 53, '7.0'),
+            array('callable', '5.3', 56, '5.4'),
+            array('int', '5.6', 57, '7.0'),
         );
     }
 

--- a/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -51,3 +51,7 @@ function foo( $a, $b ) {}
 // Type hints in closures.
 function (callable $a) {}
 function(int $a) {}
+
+// Deal with nullable type hints.
+function foo(?callable $a) {}
+function foo(?int $a) {}


### PR DESCRIPTION
Use of scalar type hints was not reported if the type hint was nullable. Case of one sniff hiding behind another.