### PR TITLE
NewMagicMethods: add tests against false positives

### DIFF
--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -217,6 +217,44 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
 
 
     /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int  $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->getTestFile(false, '4.4'); // Low version below the first addition.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            // Functions of same name outside class context.
+            array(47),
+            array(48),
+            array(49),
+            array(50),
+            array(51),
+            array(52),
+            array(53),
+            array(54),
+        );
+    }
+
+
+    /**
      * Verify no notices are thrown at all.
      *
      * @return void

--- a/Tests/sniff-examples/new_magic_methods.php
+++ b/Tests/sniff-examples/new_magic_methods.php
@@ -40,3 +40,15 @@ interface MyInterface
     public function __invoke($x);
     public function __debugInfo();
 }
+
+/*
+ * Test against false positives. No error when outside class scope.
+ */
+function __get($name) {}
+function __isset($name) {}
+function __unset($name) {}
+function __set_state($properties) {}
+function __toString() {}
+function __callStatic($name, $arguments) {}
+function __invoke($x) {}
+function __debugInfo() {}


### PR DESCRIPTION
Couldn't be added previously as they would conflict with the reserved function names (double underscore prefix) sniff.