### PR TITLE
Pre-PHP 5.5: Add sniff to detect use of non-lowercase `self`, `static` and `parent` keywords

### DIFF
--- a/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
+++ b/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff.
+ *
+ * Prior to PHP 5.5, cases existed where the self, parent, and static keywords
+ * were treated in a case sensitive fashion.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+			T_SELF,
+			T_STATIC,
+			T_PARENT,
+		);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+			return;
+		}
+
+        $tokens         = $phpcsFile->getTokens();
+        $tokenContentLC = strtolower($tokens[$stackPtr]['content']);
+        
+        if ($tokenContentLC !== $tokens[$stackPtr]['content']) {
+            $phpcsFile->addError(
+                'The keyword \'%s\' was treated in a case-sensitive fashion in certain cases in PHP 5.4 or earlier. Use the lowercase version for consistent support.',
+                $stackPtr,
+                'NonLowercaseFound',
+                array($tokenContentLC)
+            );
+        }
+    }
+}

--- a/Tests/Sniffs/PHP/CaseSensitiveKeywordsSniffTest.php
+++ b/Tests/Sniffs/PHP/CaseSensitiveKeywordsSniffTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * CaseSensitiveKeywordsSniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * self, parent and static were sometimes treated case sensitively prior to PHP 5.5.
+ *
+ * @group caseSensitiveKeywords
+ * @group keywords
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class CaseSensitiveKeywordsSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/case_sensitive_keywords.php';
+
+    /**
+     * testCaseSensitiveKeywords
+     *
+     * @dataProvider dataCaseSensitiveKeywords
+     *
+     * @param int    $line    The line number.
+     * @param string $keyword The keyword.
+     *
+     * @return void
+     */
+    public function testCaseSensitiveKeywords($line, $keyword)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, "The keyword '{$keyword}' was treated in a case-sensitive fashion in certain cases in PHP 5.4 or earlier. Use the lowercase version for consistent support.");
+    }
+
+    /**
+     * Data provider dataCaseSensitiveKeywords.
+     *
+     * @see testCaseSensitiveKeywords()
+     *
+     * @return array
+     */
+    public function dataCaseSensitiveKeywords()
+    {
+        return array(
+            array(18, 'self'),
+            array(19, 'static'),
+            array(20, 'parent'),
+            array(21, 'self'),
+            array(22, 'static'),
+            array(23, 'parent'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/case_sensitive_keywords.php
+++ b/Tests/sniff-examples/case_sensitive_keywords.php
@@ -1,0 +1,25 @@
+<?php
+
+class MyClass {
+	const SOMETHING = 123;
+
+	$prop = 'string';
+
+	public function test() {
+		// Correct usage.
+		echo self::SOMETHING;
+		echo static::SOMETHING;
+		echo parent::SOMETHING;
+		echo self::$prop;
+		echo static::$prop;
+		echo parent::$prop;
+
+		// Problematic pre-PHP 5.5.
+		echo SELF::SOMETHING;
+		echo STATIC::SOMETHING;
+		echo PARENT::SOMETHING;
+		echo SELF::$prop;
+		echo STATIC::$prop;
+		echo PARENT::$prop;
+	}
+}


### PR DESCRIPTION
New sniff to detect issues for the below:

> Prior to PHP 5.5, cases existed where the self, parent, and static keywords were treated in a case sensitive fashion. These have now been resolved, and these keywords are always handled case insensitively: SELF::CONSTANT is now treated identically to self::CONSTANT.

Ref: http://php.net/manual/en/migration55.incompatible.php#migration55.incompatible.self-parent-static