### PR TITLE
NewClassesSniff: Detect anonymous classes extending new classes.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -708,15 +708,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return '';
         }
 
-        $find = array(
-                 T_NS_SEPARATOR,
-                 T_STRING,
-                 T_NAMESPACE,
-                 T_WHITESPACE,
-                );
-
         $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
-
         if ($start === false) {
             return '';
         }
@@ -725,6 +717,18 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         if ($tokens[$start]['code'] === T_VARIABLE) {
             return '';
         }
+
+        // Bow out if the next token is the class keyword.
+        if ($tokens[$start]['type'] === 'T_ANON_CLASS' || $tokens[$start]['code'] === T_CLASS) {
+            return '';
+        }
+
+        $find = array(
+                 T_NS_SEPARATOR,
+                 T_STRING,
+                 T_NAMESPACE,
+                 T_WHITESPACE,
+                );
 
         $end       = $phpcsFile->findNext($find, ($start + 1), null, true, null, true);
         $className = $phpcsFile->getTokensAsString($start, ($end - $start));
@@ -754,7 +758,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return '';
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS) {
+        if ($tokens[$stackPtr]['code'] !== T_CLASS && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS') {
             return '';
         }
 
@@ -818,7 +822,11 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                  T_WHITESPACE,
                 );
 
-        $start     = ($phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true) + 1);
+        $start = ($phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true) + 1);
+        if ($start === false) {
+            return '';
+        }
+
         $className = $phpcsFile->getTokensAsString($start, ($stackPtr - $start));
         $className = trim($className);
 

--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -196,11 +196,17 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
         // Handle case-insensitivity of class names.
         $this->newClasses = $this->arrayKeysToLowercase($this->newClasses);
 
-        return array(
-                T_NEW,
-                T_CLASS,
-                T_DOUBLE_COLON,
-               );
+        $targets = array(
+            T_NEW,
+            T_CLASS,
+            T_DOUBLE_COLON,
+        );
+
+        if (defined('T_ANON_CLASS')) {
+            $targets[] = constant('T_ANON_CLASS');
+        }
+
+        return $targets;
 
     }//end register()
 
@@ -222,7 +228,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
         if ($tokens[$stackPtr]['type'] === 'T_NEW') {
             $FQClassName = $this->getFQClassNameFromNewToken($phpcsFile, $stackPtr);
         }
-        else if ($tokens[$stackPtr]['type'] === 'T_CLASS') {
+        else if ($tokens[$stackPtr]['type'] === 'T_CLASS' || $tokens[$stackPtr]['type'] === 'T_ANON_CLASS') {
             $FQClassName = $this->getFQExtendedClassName($phpcsFile, $stackPtr);
         }
         else if ($tokens[$stackPtr]['type'] === 'T_DOUBLE_COLON') {

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -59,13 +59,13 @@ class NewClassesSniffTest extends BaseSniffTest
     public function dataNewClass()
     {
         return array(
-            array('DateTime', '5.1', array(25, 65, 105), '5.2'),
+            array('DateTime', '5.1', array(25, 65, 105, 151), '5.2'),
             array('DateTimeZone', '5.1', array(26, 66, 106), '5.2'),
             array('RegexIterator', '5.1', array(27, 67, 107), '5.2'),
             array('RecursiveRegexIterator', '5.1', array(28, 68, 108), '5.2'),
             array('DateInterval', '5.2', array(17, 18, 19, 20, 29, 69, 109), '5.3'),
             array('DatePeriod', '5.2', array(30, 70, 110), '5.3'),
-            array('Phar', '5.2', array(31, 71, 111), '5.3'),
+            array('Phar', '5.2', array(31, 71, 111, 152), '5.3'),
             array('PharData', '5.2', array(32, 72, 112), '5.3'),
             array('PharException', '5.2', array(33, 73, 113), '5.3'),
             array('PharFileInfo', '5.2', array(34, 74, 114), '5.3'),
@@ -77,7 +77,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('SplFixedArray', '5.2', array(40, 80, 120), '5.3'),
             array('SplHeap', '5.2', array(41, 81, 121), '5.3'),
             array('SplMaxHeap', '5.2', array(42, 82, 122), '5.3'),
-            array('SplMinHeap', '5.2', array(43, 83, 123), '5.3'),
+            array('SplMinHeap', '5.2', array(43, 83, 123, 153), '5.3'),
             array('SplPriorityQueue', '5.2', array(44, 84, 124), '5.3'),
             array('SplQueue', '5.2', array(45, 85, 125), '5.3'),
             array('SplStack', '5.2', array(46, 86, 126), '5.3'),
@@ -86,7 +86,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('ReflectionZendExtension', '5.3', array(49, 89, 129), '5.4'),
             array('SessionHandler', '5.3', array(50, 90, 130), '5.4'),
             array('SNMP', '5.3', array(51, 91, 131), '5.4'),
-            array('Transliterator', '5.3', array(52, 92, 132), '5.4'),
+            array('Transliterator', '5.3', array(52, 92, 132, 154), '5.4'),
             array('CURLFile', '5.4', array(53, 93, 133), '5.5'),
             array('DateTimeImmutable', '5.4', array(54, 94, 134), '5.5'),
             array('IntlCalendar', '5.4', array(55, 95, 135), '5.5'),
@@ -95,7 +95,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('IntlBreakIterator', '5.4', array(58, 98, 138), '5.5'),
             array('IntlRuleBasedBreakIterator', '5.4', array(59, 99, 139), '5.5'),
             array('IntlCodePointBreakIterator', '5.4', array(60, 100, 140), '5.5'),
-            
+
             array('DATETIME', '5.1', array(146), '5.2'),
             array('datetime', '5.1', array(147), '5.2'),
             array('dATeTiMe', '5.1', array(148), '5.2'),
@@ -132,6 +132,8 @@ class NewClassesSniffTest extends BaseSniffTest
             array(7),
             array(8),
             array(9),
+            array(157),
+            array(158),
         );
     }
 

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -140,9 +140,19 @@ IntlRuleBasedBreakIterator::$static_property;
 IntlCodePointBreakIterator::$static_property;
 
 
-/**
+/*
  * These should all be flagged too as classnames are case-insensitive.
  */
 $test = new DATETIME(); // Uppercase.
 class MyDateTime extends datetime {} // Lowercase.
 dATeTiMe::static_method(); // Mixed case.
+
+// Test anonymous classes extending a new class.
+new class extends DateTime {}
+new class extends \Phar {}
+new class extends SplMinHeap {}
+new class extends \Transliterator {}
+
+// Check against false positives.
+new class extends \My\IntlRuleBasedBreakIterator {}
+new class extends My\IntlRuleBasedBreakIterator {}


### PR DESCRIPTION
This issue does not come into play (yet) as no new classes were added since the introduction of anonymous classes, but would start playing up once they will be.

One of several PRs to fix #351