### PR TITLE
PHP 7.1: New sniff to check for forbidden variable names in closure use statements

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -25,6 +25,25 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
 
     /**
+     * List of superglobals as an array of strings.
+     *
+     * Used by the ParameterShadowSuperGlobals and ForbiddenClosureUseVariableNames sniffs.
+     *
+     * @var array
+     */
+    protected $superglobals = array(
+        '$GLOBALS',
+        '$_SERVER',
+        '$_GET',
+        '$_POST',
+        '$_FILES',
+        '$_COOKIE',
+        '$_SESSION',
+        '$_REQUEST',
+        '$_ENV'
+    );
+
+    /**
      * List of functions using hash algorithm as parameter (always the first parameter).
      *
      * Used by the new/removed hash algorithm sniffs.

--- a/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * PHP 7.1 Forbidden variable names in closure use statements.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHP 7.1 Forbidden variable names in closure use statements.
+ *
+ * Variables bound to a closure via the use construct cannot use the same name
+ * as any superglobals, $this, or any parameter since PHP 7.1.
+ *
+ * PHP version 7.1
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_ForbiddenClosureUseVariableNamesSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_USE);
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.1') === false) {
+			return;
+		}
+
+		$tokens = $phpcsFile->getTokens();
+
+		// Verify this use statement is used with a closure - if so, it has to have parenthesis before it.
+		$previousNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+		if ($previousNonEmpty === false || $tokens[$previousNonEmpty]['code'] !== T_CLOSE_PARENTHESIS
+			|| isset($tokens[$previousNonEmpty]['parenthesis_opener']) === false
+		) {
+			return;
+		}
+
+		// ... and (a variable within) parenthesis after it.
+		$nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+		if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+			return;
+		}
+
+		if (isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false) {
+			// Live coding.
+			return;
+		}
+
+		$closurePtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true );
+		if ($tokens[$closurePtr]['code'] !== T_CLOSURE) {
+			return;
+		}
+
+		// Get the parameters declared by the closure.
+		$closureParams = $this->getMethodParameters($phpcsFile, $closurePtr);
+
+		$errorMsg = 'Variables bound to a closure via the use construct cannot use the same name as superglobals, $this, or a declared parameter since PHP 7.1. Found: %s';
+
+		for ($i = ($nextNonEmpty + 1); $i < $tokens[$nextNonEmpty]['parenthesis_closer']; $i++) {
+			if ($tokens[$i]['code'] !== T_VARIABLE) {
+				continue;
+			}
+			
+			$variableName = $tokens[$i]['content'];
+
+			if ($variableName === '$this') {
+				$phpcsFile->addError($errorMsg, $i, 'FoundThis', array($variableName));
+				continue;
+			}
+
+			if (in_array($variableName, $this->superglobals, true) === true) {
+				$phpcsFile->addError($errorMsg, $i, 'FoundSuperglobal', array($variableName));
+				continue;
+			}
+
+			// Check whether it is one of the parameters declared by the closure.
+			if (empty($closureParams) === false) {
+				foreach ($closureParams as $param) {
+					if ($param['name'] === $variableName) {
+						$phpcsFile->addError($errorMsg, $i, 'FoundShadowParam', array($variableName));
+						continue 2;
+					}
+				}
+			}
+		}
+
+    }//end process()
+
+}//end class

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -4,6 +4,8 @@
  *
  * Discourages use of superglobals as parameters for functions.
  *
+ * {@internal List of superglobals is maintained in the parent class.}}
+ *
  * PHP version 5.4
  *
  * @category   PHP
@@ -13,22 +15,6 @@
  */
 class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCompatibility_Sniff
 {
-    /**
-     * List of superglobals as an array of strings.
-     *
-     * @var array
-     */
-    protected $superglobals = array(
-        '$GLOBALS',
-        '$_SERVER',
-        '$_GET',
-        '$_POST',
-        '$_FILES',
-        '$_COOKIE',
-        '$_SESSION',
-        '$_REQUEST',
-        '$_ENV'
-    );
 
     /**
      * Register the tokens to listen for.

--- a/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * PHP 7.1 Forbidden variable names in closure use statements tests.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * PHP 7.1 Forbidden variable names in closure use statements tests.
+ *
+ * @group forbiddenClosureUseVariableNames
+ * @group closures
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_ForbiddenClosureUseVariableNamesSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ForbiddenClosureUseVariableNamesSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/forbidden_closure_use_variable_names.php';
+
+    /**
+     * testForbiddenClosureUseVariableNames
+     *
+     * @dataProvider dataForbiddenClosureUseVariableNames
+     *
+     * @param int    $line    The line number.
+     * @param string $varName Variable name which should be found.
+     *
+     * @return void
+     */
+    public function testForbiddenClosureUseVariableNames($line, $varName)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertError($file, $line, 'Variables bound to a closure via the use construct cannot use the same name as superglobals, $this, or a declared parameter since PHP 7.1. Found: ' . $varName);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testForbiddenClosureUseVariableNames()
+     *
+     * @return array
+     */
+    public function dataForbiddenClosureUseVariableNames()
+    {
+        return array(
+            array(4, '$_SERVER'),
+            array(5, '$_REQUEST'),
+            array(6, '$GLOBALS'),
+            array(7, '$this'),
+            array(8, '$param'),
+            array(9, '$param'),
+            array(10, '$c'),
+            array(11, '$b'),
+            array(11, '$d'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(18),
+            array(19),
+            array(22),
+            array(23),
+            array(24),
+            array(27),
+            array(31),
+            array(32),
+            array(33),
+            array(36),
+            array(41), // Live coding.
+            array(44), // Live coding.
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/forbidden_closure_use_variable_names.php
+++ b/Tests/sniff-examples/forbidden_closure_use_variable_names.php
@@ -1,0 +1,44 @@
+<?php
+
+// PHP 7.1 Forbidden variable names in closure use statements.
+$f = function () use ($_SERVER) {};
+$f = function () use ($_REQUEST) {};
+$f = function () use ($GLOBALS) {};
+$f = function () use ($this) {};
+$f = function ($param) use ($param) {};
+$f = function ($param) use (&$param) {};
+$f = function ($a, $b, $c, $d, $e) use ($c) {};
+$f = function ($a, $b, $c, $d, $e) use ($b, $d) {};
+
+/*
+ * Check against false positives.
+ */
+
+// Empty use statement.
+$f = function () use () {};
+$f = function () use ( /*nothing here*/ ) {};
+
+// Variable names are case-sensitive.
+$f = function () use ($_server) {};
+$f = function () use ($THIS) {};
+$f = function ($param) use ($Param) {};
+
+// Not the same variable name.
+$f = function ($par, $parameter) use ($param) {};
+
+// Use statements not used with a closure.
+namespace Something;
+use function some\namespace\fn_a as fn_a;
+use const some\namespace\ConstA;
+use some\namespace\{ClassA, ClassB, ClassC as C};
+
+class ezcReflectionMethod extends ReflectionMethod {
+    use ezcReflectionReturnInfo { sayHello as private myPrivateHello; };
+    /* ... */
+}
+
+// Live coding
+$f = function ($param) use
+
+// Live coding
+$f = function ($param) use ($param


### PR DESCRIPTION
> Lexically bound variables cannot reuse names
>
> Variables bound to a closure via the use construct cannot use the same name as any superglobals, $this, or any parameter. For example, all of these function definition will result in a fatal error: ...

Ref: http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.lexical-names

To sniff for this a new sniff has been added.

Notes:
    * The `$superglobals` array which previously was defined as a property of the `ParameterShadowSuperGlobalsSniff` has been moved up to the parent class `PHPCompatibility_Sniff` so it can be used by this sniff as well without duplicating code.

Sniff includes extensive unit tests.

Closes #374