### PR TITLE
PHP 5.5: New sniff to detect array and string literal dereferencing

### DIFF
--- a/Sniffs/PHP/NewArrayStringDereferencingSniff.php
+++ b/Sniffs/PHP/NewArrayStringDereferencingSniff.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff.
+ *
+ * Array and string literals can now be dereferenced directly to access individual elements and characters.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_ARRAY,
+            T_OPEN_SHORT_ARRAY,
+            T_CONSTANT_ENCAPSED_STRING,
+        );
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        switch($tokens[$stackPtr]['code']) {
+            case T_CONSTANT_ENCAPSED_STRING:
+                $type = 'string literals';
+                $end  = $stackPtr;
+                break;
+
+            case T_ARRAY:
+                if (isset($tokens[$stackPtr]['parenthesis_closer']) === false) {
+                    // Live coding.
+                    return;
+                } else {
+                    $type = 'arrays';
+                    $end  = $tokens[$stackPtr]['parenthesis_closer'];
+                }
+                break;
+
+            case T_OPEN_SHORT_ARRAY:
+                if (isset($tokens[$stackPtr]['bracket_closer']) === false) {
+                    // Live coding.
+                    return;
+                } else {
+                    $type = 'arrays';
+                    $end  = $tokens[$stackPtr]['bracket_closer'];
+                }
+                break;
+        }
+
+        if (isset($type, $end) === false) {
+            // Shouldn't happen, but for some reason did.
+            return;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+
+        if ($nextNonEmpty !== false &&
+            ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET' ||
+                $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SHORT_ARRAY') // Work around bug #1381 in PHPCS 2.8.1 and lower.
+        ) {
+            $phpcsFile->addError(
+                'Direct array dereferencing of %s is not present in PHP version 5.4 or earlier',
+                $nextNonEmpty,
+                'Found',
+                array($type)
+            );
+        }
+
+    }//end process()
+
+}//end class

--- a/Tests/Sniffs/PHP/NewArrayStringDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewArrayStringDereferencingSniffTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * NewArrayStringDereferencingSniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New array and string literal dereferencing sniff test.
+ *
+ * @group newArrayStringDereferencing
+ * @group dereferencing
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewArrayStringDereferencingSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_array_string_dereferencing.php';
+
+    /**
+     * testArrayStringDereferencing
+     *
+     * @dataProvider dataArrayStringDereferencing
+     *
+     * @param int    $line The line number.
+     * @param string $type Whether this is an array or string dereferencing.
+     *
+     * @return void
+     */
+    public function testArrayStringDereferencing($line, $type)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, "Direct array dereferencing of {$type} is not present in PHP version 5.4 or earlier");
+    }
+
+    /**
+     * Data provider dataArrayStringDereferencing.
+     *
+     * @see testArrayStringDereferencing()
+     *
+     * @return array
+     */
+    public function dataArrayStringDereferencing()
+    {
+        return array(
+            array(4, 'arrays'),
+            array(5, 'arrays'),
+            array(6, 'arrays'),
+            array(7, 'string literals'),
+            array(8, 'string literals'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+            array(16),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -10,6 +10,7 @@
  * New function array dereferencing sniff tests
  *
  * @group newFunctionArrayDereferencing
+ * @group dereferencing
  *
  * @covers PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff
  *

--- a/Tests/sniff-examples/new_array_string_dereferencing.php
+++ b/Tests/sniff-examples/new_array_string_dereferencing.php
@@ -1,0 +1,16 @@
+<?php
+
+// Array and string literal dereferencing.
+echo array(1, 2, 3)[0];
+echo [1, 2, 3][0];
+echo [1, [20, 21, 22], 3][1][1]; // Multi-dimensional array - will give two errors in PHPCS < 2.8.2 / bug #1381.
+echo 'PHP'[0];
+echo "PHP"[0];
+
+// Check against false positives.
+echo [1, 2, 3];
+echo [1, [20, 21, 22], 3];
+echo 'PHP';
+echo "P{$H}P"[0]; // Parse error.
+echo $array[0];
+echo $string[0];


### PR DESCRIPTION
New sniff to detect issues for the below:

> Array and string literals can now be dereferenced directly to access individual elements and characters

Ref: http://php.net/manual/en/migration55.new-features.php#migration55.new-features.const-dereferencing