### PR TITLE
NewClosures sniff: add checking for new features added in PHP 5.4

### DIFF
--- a/Sniffs/PHP/NewClosureSniff.php
+++ b/Sniffs/PHP/NewClosureSniff.php
@@ -44,6 +44,8 @@ class PHPCompatibility_Sniffs_PHP_NewClosureSniff extends PHPCompatibility_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        $tokens = $phpcsFile->getTokens();
+
         if ($this->supportsBelow('5.2')) {
             $phpcsFile->addError(
                 'Closures / anonymous functions are not available in PHP 5.2 or earlier',
@@ -51,6 +53,96 @@ class PHPCompatibility_Sniffs_PHP_NewClosureSniff extends PHPCompatibility_Sniff
                 'Found'
             );
         }
+
+
+        if ($this->supportsBelow('5.3')) {
+
+            /*
+             * Closures can only be declared as static since PHP 5.4.
+             */
+            if ($this->isClosureStatic($phpcsFile, $stackPtr) === true) {
+                $phpcsFile->addError(
+                    'Closures / anonymous functions could not be declared as static in PHP 5.3 or earlier',
+                    $stackPtr,
+                    'StaticFound'
+                );
+            }
+
+            /*
+             * Closures declared within classes only have access to $this since PHP 5.4.
+             */
+            $thisFound = $this->findThisUsageInClosure($phpcsFile, $stackPtr);
+            if ($thisFound !== false) {
+                do {
+                    $phpcsFile->addError(
+                        'Closures / anonymous functions did not have access to $this in PHP 5.3 or earlier',
+                        $thisFound,
+                        'ThisFound'
+                    );
+
+                    $thisFound = $this->findThisUsageInClosure($phpcsFile, $stackPtr, ($thisFound + 1));
+
+                } while($thisFound !== false);
+            }
+        }
+
     }//end process()
+
+
+    /**
+     * Check whether the closure is declared as static.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return bool
+     */
+    protected function isClosureStatic(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+
+        return ($prevToken !== false && $tokens[$prevToken]['code'] === T_STATIC);
+    }
+
+
+    /**
+     * Check if the code within a closure uses the $this variable.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile  The file being scanned.
+     * @param int                  $stackPtr   The position of the closure token.
+     * @param int                  $startToken Optional. The position within the closure to continue searching from.
+     *
+     * @return int|false The stackPtr to the first $this usage if found or false if
+     *                   $this is not used or usage of $this could not reliably be determined.
+     */
+    protected function findThisUsageInClosure(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $startToken = null)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['scope_opener'], $tokens[$stackPtr]['scope_closer']) === false) {
+            // Live coding or parse error.
+            return false;
+        }
+
+        // Make sure the optional $startToken is valid.
+        if (isset($startToken) === true && (isset($tokens[$startToken]) === false || $startToken >= $tokens[$stackPtr]['scope_closer'])) {
+            return false;
+        }
+
+        $start = ($tokens[$stackPtr]['scope_opener'] + 1);
+        if (isset($startToken) === true) {
+            $start = $startToken;
+        }
+
+        return $phpcsFile->findNext(
+            T_VARIABLE,
+            $start,
+            $tokens[$stackPtr]['scope_closer'],
+            false,
+            '$this'
+        );
+    }
 
 }//end class

--- a/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -25,12 +25,33 @@ class NewClosureSniffTest extends BaseSniffTest
     /**
      * Test closures
      *
+     * @dataProvider dataClosure
+     *
+     * @param int $line The line number.
+     *
      * @return void
      */
-    public function testClosure()
+    public function testClosure($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.2');
-        $this->assertError($file, 3, 'Closures / anonymous functions are not available in PHP 5.2 or earlier');
+        $this->assertError($file, $line, 'Closures / anonymous functions are not available in PHP 5.2 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testClosure()
+     *
+     * @return array
+     */
+    public function dataClosure()
+    {
+        return array(
+            array(3),
+            array(14),
+            array(22),
+            array(30),
+        );
     }
 
 
@@ -47,13 +68,76 @@ class NewClosureSniffTest extends BaseSniffTest
 
 
     /**
+     * Test static closures
+     *
+     * @dataProvider dataStaticClosure
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testStaticClosure($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Closures / anonymous functions could not be declared as static in PHP 5.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testStaticClosure()
+     *
+     * @return array
+     */
+    public function dataStaticClosure()
+    {
+        return array(
+            array(14),
+            array(30),
+        );
+    }
+
+
+    /**
+     * Test using $this in closures
+     *
+     * @dataProvider dataThisInClosure
+     *
+     * @param int  $line            The line number.
+     * @param bool $testNoViolation Whether or not to run the noViolation test.
+     *
+     * @return void
+     */
+    public function testThisInClosure($line, $testNoViolation = true)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Closures / anonymous functions did not have access to $this in PHP 5.3 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testThisInClosure()
+     *
+     * @return array
+     */
+    public function dataThisInClosure()
+    {
+        return array(
+            array(23),
+            array(24),
+        );
+    }
+
+
+    /**
      * Verify no notices are thrown at all.
      *
      * @return void
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file);
     }
 

--- a/Tests/sniff-examples/new_closure.php
+++ b/Tests/sniff-examples/new_closure.php
@@ -24,9 +24,36 @@ class Test
             var_dump($this); // Let's make sure we get an error for each line using $this.
         };
     }
+
+    // $this is not available if the closure is declared as static.
+    public function testThisStatic()
+    {
+        return static function() {
+            var_dump($this);
+            var_dump($this); // Let's make sure we get an error for each line using $this.
+        };
+    }
+
+    // Valid: using a variable - not $this - in a static closure.
+    public function testVarStatic()
+    {
+        return static function() {
+            var_dump($var);
+        };
+    }
 }
 
 // PHP 5.4+: Static closures.
 static function() {
     var_dump($something);
+}
+
+// Invalid: Using $this outside of a class context.
+function() {
+   var_dump($this);
+}
+
+// Valid: using a variable - not $this - in a closure.
+function() {
+   var_dump($something);
 }

--- a/Tests/sniff-examples/new_closure.php
+++ b/Tests/sniff-examples/new_closure.php
@@ -4,3 +4,29 @@ spl_autoload_register( function ( $class ) {
 } );
 
 function something() {}
+
+// PHP 5.4+,
+class Test
+{
+    // PHP 5.4+: Static closures.
+    public function testStatic()
+    {
+        return static function() {
+            echo 'static closure';
+        };
+    }
+
+    // PHP 5.4+: Using this in a class context.
+    public function testThis()
+    {
+        return function() {
+            var_dump($this);
+            var_dump($this); // Let's make sure we get an error for each line using $this.
+        };
+    }
+}
+
+// PHP 5.4+: Static closures.
+static function() {
+    var_dump($something);
+}


### PR DESCRIPTION
Closures were introduced in PHP 5.3.
However, until PHP 5.4, they could not be declared as `static`, nor could they use the `$this` variable when declared within a class context.
Ref: http://php.net/manual/en/functions.anonymous.php

This will now be sniffed for.

Additionally this PR contains two extra checks for incorrect/unsupported usage of the `$this` variable in closures for PHP 5.4 and higher:
* usage of `$this` in static closures is not supported by PHP
* usage of `$this` in closures outside of a class context is not supported by PHP

Includes unit tests.

Related #24