### PR TITLE
PHP 5.3: Add new sniff to detect heredoc initialization

### DIFF
--- a/Sniffs/PHP/NewHeredocInitializeSniff.php
+++ b/Sniffs/PHP/NewHeredocInitializeSniff.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff.
+ *
+ * As of PHP 5.3.0, it's possible to initialize static variables and class
+ * properties/constants using the Heredoc syntax.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_START_HEREDOC);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.2') !== true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $equalSign = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        if ($equalSign === false || $tokens[$equalSign]['code'] !== T_EQUAL) {
+            // Not an assignment.
+            return;
+        }
+
+        $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($equalSign - 1), null, true, null, true);
+        if ($prevNonEmpty === false ||
+            ($tokens[$prevNonEmpty]['code'] !== T_VARIABLE && $tokens[$prevNonEmpty]['code'] !== T_STRING)
+        ) {
+            // Not a variable or constant assignment.
+            return;
+        }
+
+
+        switch ($tokens[$prevNonEmpty]['type']) {
+            /*
+             * Check class constant assignments.
+             */
+            case 'T_STRING':
+                // Walk back to check for the const keyword.
+                $constPtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
+                if ($constPtr === false || $tokens[$constPtr]['code'] !== T_CONST) {
+                    // Not a constant assignment.
+                    return;
+                }
+
+                if ($this->isClassConstant($phpcsFile, $constPtr) === true) {
+                    $this->throwError($phpcsFile, $stackPtr, 'const');
+                }
+                return;
+
+            case 'T_VARIABLE':
+                /*
+                 * Check class property assignments.
+                 */
+                if ($this->isClassProperty($phpcsFile, $prevNonEmpty) === true) {
+                    $this->throwError($phpcsFile, $stackPtr, 'property');
+                }
+
+                /*
+                 * Check static variable assignments.
+                 */
+                else {
+                    // Walk back to check this is a static variable `static $var =`.
+                    $staticPtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
+                    if ($staticPtr === false || $tokens[$staticPtr]['code'] !== T_STATIC) {
+                        // Not a static variable assignment.
+                        return;
+                    }
+
+                    // Still here ? Then we have a static variable assignment
+                    $this->throwError($phpcsFile, $stackPtr, 'staticvar');
+                }
+                return;
+        }
+    }
+
+
+    /**
+     * Throw an error if a non-static value is found.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the token to link the error to.
+     * @param string               $type      Type of usage found.
+     *
+     * @return void
+     */
+    protected function throwError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $type)
+    {
+        switch($type) {
+            case 'const':
+                $phrase = 'class constants';
+                break;
+
+            case 'property':
+                $phrase = 'class properties';
+                break;
+
+            case 'staticvar':
+                $phrase = 'static variables';
+                break;
+
+            default:
+                $phrase = '';
+                break;
+        }
+
+        $errorCode = $this->stringToErrorCode($type) . 'Found';
+
+        $phpcsFile->addError(
+            'Initializing %s using the Heredoc syntax was not supported in PHP 5.2 or earlier',
+            $stackPtr,
+            $errorCode,
+            array($phrase)
+        );
+    }
+
+}

--- a/Tests/BaseClass/IsClassConstantTest.php
+++ b/Tests/BaseClass/IsClassConstantTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Is class constant ? test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * isClassConstant() function tests
+ *
+ * @group utilityIsClassConstant
+ * @group utilityFunctions
+ *
+ * @uses    BaseClass_MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class BaseClass_isClassConstantTest extends BaseClass_MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'is_class_constant.php';
+
+    /**
+     * testIsClassConstant
+     *
+     * @dataProvider dataIsClassConstant
+     *
+     * @covers PHPCompatibility_Sniff::isClassConstant
+     *
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param string $expected      The expected boolean return value.
+     */
+    public function testIsClassConstant($commentString, $expected)
+    {
+        $stackPtr = $this->getTargetToken($commentString, T_CONST);
+        $result   = $this->helperClass->isClassConstant($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataIsClassConstant
+     *
+     * @see testIsClassConstant()
+     *
+     * @return array
+     */
+    public function dataIsClassConstant()
+    {
+        return array(
+            array('/* Case 1 */', false),
+            array('/* Case 2 */', false),
+            array('/* Case 3 */', true),
+            array('/* Case 4 */', false),
+            array('/* Case 5 */', true),
+            array('/* Case 6 */', false),
+            array('/* Case 7 */', true),
+            array('/* Case 8 */', false),
+            array('/* Case 9 */', false),
+        );
+    }
+}

--- a/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * New initialize with heredoc sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New initialize with heredoc in PHP 5.3 sniff test file
+ *
+ * @group newHeredocInitialize
+ * @group constants
+ * @group variables
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewHeredocInitializeSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_heredoc_initialize.php';
+
+    /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+            self::$recognizesTraits = false;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
+     * testHeredocInitialize
+     *
+     * @dataProvider dataHeredocInitialize
+     *
+     * @param int    $line    The line number.
+     * @param string $type    Error type.
+     * @param bool   $isTrait Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testHeredocInitialize($line, $type, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped('Traits are not recognized on PHPCS 1.5.x in combination with PHP < 5.4');
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertError($file, $line, "Initializing {$type} using the Heredoc syntax was not supported in PHP 5.2 or earlier");
+    }
+
+    /**
+     * Data provider dataHeredocInitialize.
+     *
+     * @see testHeredocInitialize()
+     *
+     * @return array
+     */
+    public function dataHeredocInitialize()
+    {
+        $data = array(
+            array(5, 'static variables'),
+            array(13, 'class constants'),
+            array(27, 'class constants'),
+            array(31, 'class properties'),
+            array(39, 'class constants'),
+            array(47, 'class properties', true),
+        );
+
+        // Quoted heredoc identifier is not recognized in PHP 5.2.
+        if (version_compare(phpversion(), '5.3', '>=')) {
+            $data[] = array(19, 'class properties');
+        }
+
+        return $data;
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(57),
+            array(63),
+            array(70),
+            array(75),
+            array(79),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/new_heredoc_initialize.php
+++ b/Tests/sniff-examples/new_heredoc_initialize.php
@@ -1,0 +1,82 @@
+<?php
+
+// Static variables.
+function foo() {
+    static $bar = <<<LABEL
+Nothing in here...
+LABEL;
+}
+
+// Class properties/constants.
+class foo
+{
+    const BAR = <<<FOOBAR
+Constant example
+FOOBAR;
+
+    // Double quoted heredoc only introduced in PHP 5.3 and will be caught by another sniff.
+    // Will still throw an error here too if the sniff is run on PHP >= 5.3.
+    private $baz = <<<"FOOBAR"
+Property example
+FOOBAR;
+}
+
+// Anonymous class properties/constants.
+$class = new class
+{
+    const BAR = <<<FOOBAR
+Constant example
+FOOBAR;
+
+    protected static $baz = <<<FOOBAR
+Property example
+FOOBAR;
+}
+
+// Interface constants - interfaces cannot declare properties.
+interface FooBar
+{
+    const BAR = <<<FOOBAR
+Constant example
+FOOBAR;
+}
+
+// Trait properties - traits cannot declare constants.
+trait FooBar
+{
+    public $baz = <<<FOOBAR
+Property example
+FOOBAR;
+}
+
+
+/*
+ * Test against false positives.
+ */
+// Not a class constant.
+const ONE = <<<FOOBAR
+Property example
+FOOBAR;
+
+class SomeThing {
+    function scoped {
+        const ONE = <<<FOOBAR
+Property example
+FOOBAR;
+    }
+}
+
+// Pre-PHP 5.3 ordinary variable initialization with heredoc was already ok.
+$var = <<<FOOBAR
+Constant example
+FOOBAR;
+
+// Nowdoc was only introduced in PHP 5.3 and is sniffed for in a separate sniff.
+$var = <<<'FOOBAR'
+Constant example
+FOOBAR;
+
+$array = array( 'key' => <<<FOOBAR
+Constant example
+FOOBAR
+);

--- a/Tests/sniff-examples/utility-functions/is_class_constant.php
+++ b/Tests/sniff-examples/utility-functions/is_class_constant.php
@@ -1,0 +1,49 @@
+<?php
+
+/* Case 1 */
+const BAR = false;
+
+function something()
+{
+    /* Case 2 */
+    const BAR = false;
+}
+
+class MyClass {
+    /* Case 3 */
+    const FOO = true;
+
+    public function something()
+    {
+        /* Case 4 */
+        const BAR = false;
+    }
+}
+
+$a = new class {
+    /* Case 5 */
+    const FOO = true;
+
+    public function something()
+    {
+        /* Case 6 */
+        const BAR = false;
+    }
+}
+
+interface MyInterface {
+    /* Case 7 */
+    const FOO = true;
+}
+
+trait MyTrait {
+    // Constants are not allowed in traits.
+    /* Case 8 */
+    const BAR = false;
+
+    public function something()
+    {
+        /* Case 9 */
+        const BAR = false;
+    }
+}


### PR DESCRIPTION
> As of PHP 5.3.0, it's possible to initialize static variables and class properties/constants using the Heredoc syntax

Ref:
* http://php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc
* http://php.net/manual/en/migration53.new-features.php

This PR adds a new sniff to detect this.
Includes unit tests.

Fixes #51 

-----
[Edit]:
I have updated this PR since #393 was merged to use the new `PHPCompatibility_Sniff::isClassProperty()` method.

This PR now includes addition of two more new utility functions `PHPCompatibility_Sniff::isClassConstant()` and `PHPCompatibility_Sniff::validDirectScope()`.

The `PHPCompatibility_Sniff::isClassConstant()` is also needed by some other PRs which is why it was turned into a utility method.

The `PHPCompatibility_Sniff::validDirectScope()` method is to avoid code duplication between the `isClassConstant()` and `isClassProperty()` methods.

The PR includes unit tests for the new utility `PHPCompatibility_Sniff::isClassConstant()` method.
The `PHPCompatibility_Sniff::validDirectScope()` is tested indirectly by both the `PHPCompatibility_Sniff::isClassConstant()` and the `PHPCompatibility_Sniff::isClassProperty()` unit tests.
