### PR TITLE
PHP 7.2: Add detection for ext/gd deprecated functions

### DIFF
--- a/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -755,6 +755,14 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibil
                                             '7.1' => false,
                                             'alternative' => 'OpenSSL'
                                         ),
+                                        'jpeg2wbmp' => array(
+                                            '7.2' => false,
+                                            'alternative' => 'imagecreatefromjpeg() and imagewbmp()'
+                                        ),
+                                        'png2wbmp' => array(
+                                            '7.2' => false,
+                                            'alternative' => 'imagecreatefrompng() or imagewbmp()'
+                                        ),
                                     );
 
 

--- a/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -200,6 +200,8 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('mcrypt_module_self_test', '7.1', 'OpenSSL', array(130), '7.0'),
             array('mdecrypt_generic', '7.1', 'OpenSSL', array(131), '7.0'),
 
+            array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(143), '7.1'),
+            array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(144), '7.1'),
         );
     }
 

--- a/Tests/sniff-examples/deprecated_functions.php
+++ b/Tests/sniff-examples/deprecated_functions.php
@@ -138,3 +138,7 @@ echo PHP_CHECK_SYNTAX; // Constant.
 const php_check_syntax;
 use php_check_syntax;
 function php_check_syntax() {}
+
+// More deprecated functions, PHP 7.2
+jpeg2wbmp();
+png2wbmp();


### PR DESCRIPTION
Refs:
* https://wiki.php.net/rfc/deprecate-png-jpeg-2wbmp
* https://github.com/php/php-src/pull/2164 (merged)