### PR TITLE
Issue #333: add cross-version support for anonymous classes to the RemovedGlobalVariable sniff

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -1046,6 +1046,58 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
 
     /**
+     * Check whether a T_VARIABLE token is a class property declaration.
+     *
+     * Compatibility layer for PHPCS cross-version compatibility
+     * as PHPCS 2.4.0 - 2.7.1 does not have good enough support for
+     * anonymous classes. Along the same lines, the`getMemberProperties()`
+     * method does not support the `var` prefix.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                  $stackPtr  The position in the stack of the
+     *                                        T_VARIABLE token to verify.
+     *
+     * @return bool
+     */
+    public function isClassProperty(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]) === false || $tokens[$stackPtr]['code'] !== T_VARIABLE) {
+            return false;
+        }
+
+        if (empty($tokens[$stackPtr]['conditions']) === true) {
+            return false;
+        }
+
+        /*
+         * Check to see if the variable is a property by checking if the
+         * direct wrapping scope is a class like structure.
+         */
+        $conditions = array_keys($tokens[$stackPtr]['conditions']);
+        $ptr        = array_pop($conditions);
+
+        if (isset($tokens[$ptr]) === false) {
+            return false;
+        }
+
+        // Note: interfaces can not declare properties.
+        if ($tokens[$ptr]['type'] === 'T_CLASS'
+            || $tokens[$ptr]['type'] === 'T_ANON_CLASS'
+            || $tokens[$ptr]['type'] === 'T_TRAIT'
+        ) {
+            // Make sure it's not a method parameter.
+            if (empty($tokens[$stackPtr]['nested_parenthesis']) === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
      * Returns the method parameters for the specified function token.
      *
      * Each parameter is in the following format:

--- a/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -71,6 +71,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
         ),
     );
 
+
     /**
      * Returns an array of tokens this test wants to listen for.
      *
@@ -81,6 +82,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
         return array(T_VARIABLE);
 
     }//end register()
+
 
     /**
      * Processes this test, when one of its tokens is encountered.
@@ -104,28 +106,13 @@ class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompati
             return;
         }
 
+        if ($this->isClassProperty($phpcsFile, $stackPtr) === true) {
+            // Ok, so this was a class property declaration, not our concern.
+            return;
+        }
+
+        // Check for static usage of class properties shadowing the removed global variables.
         if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
-            /*
-             * Check for class property definitions.
-             */
-            $properties = array();
-            try {
-                $properties = $phpcsFile->getMemberProperties($stackPtr);
-            } catch ( PHP_CodeSniffer_Exception $e) {
-                // If it's not an expected exception, throw it.
-                if ($e->getMessage() !== '$stackPtr is not a class member var') {
-                    throw $e;
-                }
-            }
-
-            if (isset($properties['scope'])) {
-                // Ok, so this was a class property declaration, not our concern.
-                return;
-            }
-
-            /*
-             * Check for static usage of class properties shadowing the removed global variables.
-             */
             $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
             if ($prevToken !== false && $tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
                 return;

--- a/Tests/BaseClass/IsClassPropertyTest.php
+++ b/Tests/BaseClass/IsClassPropertyTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Is class property ? test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * isClassProperty() function tests
+ *
+ * @group utilityIsClassProperty
+ * @group utilityFunctions
+ *
+ * @uses    BaseClass_MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class BaseClass_isClassPropertyTest extends BaseClass_MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'is_class_property.php';
+
+    /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+            self::$recognizesTraits = false;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
+     * testIsClassProperty
+     *
+     * @dataProvider dataIsClassProperty
+     *
+     * @covers PHPCompatibility_Sniff::isClassProperty
+     *
+     * @param string $commentString The comment which prefaces the target token in the test file.
+     * @param string $expected      The expected boolean return value.
+     * @param bool   $isTrait       Whether the test relates to a variable in a trait.
+     */
+    public function testIsClassProperty($commentString, $expected, $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $stackPtr = $this->getTargetToken($commentString, T_VARIABLE);
+        $result   = $this->helperClass->isClassProperty($this->_phpcsFile, $stackPtr);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataIsClassProperty
+     *
+     * @see testIsClassProperty()
+     *
+     * @return array
+     */
+    public function dataIsClassProperty()
+    {
+        return array(
+            array('/* Case 1 */', false),
+            array('/* Case 2 */', false),
+            array('/* Case 3 */', false),
+            array('/* Case 4 */', true),
+            array('/* Case 5 */', true),
+            array('/* Case 6 */', true),
+            array('/* Case 7 */', true),
+            array('/* Case 8 */', false),
+            array('/* Case 9 */', false),
+            array('/* Case 10 */', true),
+            array('/* Case 11 */', true),
+            array('/* Case 12 */', true),
+            array('/* Case 13 */', true),
+            array('/* Case 14 */', false),
+            array('/* Case 15 */', false),
+            array('/* Case 16 */', false),
+            array('/* Case 17 */', false),
+            array('/* Case 18 */', false),
+            array('/* Case 19 */', false),
+            array('/* Case 20 */', false),
+            array('/* Case 21 */', false),
+            array('/* Case 22 */', true, true),
+            array('/* Case 23 */', true, true),
+            array('/* Case 24 */', true, true),
+            array('/* Case 25 */', true, true),
+            array('/* Case 26 */', false, true),
+            array('/* Case 27 */', false, true),
+        );
+    }
+}

--- a/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -66,15 +66,15 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
     public function dataRemovedGlobalVariables()
     {
         return array(
-            array('HTTP_POST_VARS', '5.3', '5.4', array(9, 31), '$_POST', '5.2'),
-            array('HTTP_GET_VARS', '5.3', '5.4', array(10, 32, 51), '$_GET', '5.2'),
-            array('HTTP_ENV_VARS', '5.3', '5.4', array(11, 33, 52), '$_ENV', '5.2'),
-            array('HTTP_SERVER_VARS', '5.3', '5.4', array(12, 34), '$_SERVER', '5.2'),
-            array('HTTP_COOKIE_VARS', '5.3', '5.4', array(13, 35), '$_COOKIE', '5.2'),
-            array('HTTP_SESSION_VARS', '5.3', '5.4', array(14, 36), '$_SESSION', '5.2'),
-            array('HTTP_POST_FILES', '5.3', '5.4', array(15, 37), '$_FILES', '5.2'),
+            array('HTTP_POST_VARS', '5.3', '5.4', array(9, 31, 71, 91), '$_POST', '5.2'),
+            array('HTTP_GET_VARS', '5.3', '5.4', array(10, 32, 51, 72), '$_GET', '5.2'),
+            array('HTTP_ENV_VARS', '5.3', '5.4', array(11, 33, 52, 73), '$_ENV', '5.2'),
+            array('HTTP_SERVER_VARS', '5.3', '5.4', array(12, 34, 74, 92), '$_SERVER', '5.2'),
+            array('HTTP_COOKIE_VARS', '5.3', '5.4', array(13, 35, 75), '$_COOKIE', '5.2'),
+            array('HTTP_SESSION_VARS', '5.3', '5.4', array(14, 36, 76, 93), '$_SESSION', '5.2'),
+            array('HTTP_POST_FILES', '5.3', '5.4', array(15, 37, 77), '$_FILES', '5.2'),
 
-            array('HTTP_RAW_POST_DATA', '5.6', '7.0', array(3, 38, 53), 'php://input', '5.5'),
+            array('HTTP_RAW_POST_DATA', '5.6', '7.0', array(3, 38, 53, 78), 'php://input', '5.5'),
         );
     }
 
@@ -126,6 +126,25 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
             array(46),
             array(47),
             array(48),
+
+            // Issue #333 - class properties named after long array variables in anonymous classes.
+            array(60),
+            array(61),
+            array(62),
+            array(63),
+            array(64),
+            array(65),
+            array(66),
+            array(67),
+
+            array(81),
+            array(82),
+            array(83),
+            array(84),
+            array(85),
+            array(86),
+            array(87),
+            array(88),
         );
     }
 

--- a/Tests/sniff-examples/removed_global_variables.php
+++ b/Tests/sniff-examples/removed_global_variables.php
@@ -53,3 +53,43 @@ class TestClass {
         self::{$HTTP_RAW_POST_DATA};
     }
 }
+
+// Anonymous classes: Issue #333
+$a = new class {
+	// OK.
+    private $HTTP_POST_VARS;
+    protected $HTTP_GET_VARS;
+    public static $HTTP_ENV_VARS;
+    var $HTTP_SERVER_VARS;
+    private $HTTP_COOKIE_VARS;
+    protected static $HTTP_SESSION_VARS;
+    public $HTTP_POST_FILES;
+    var static $HTTP_RAW_POST_DATA;
+
+    function testing() {
+		 // Bad.
+        $HTTP_POST_VARS;
+        $HTTP_GET_VARS;
+        $HTTP_ENV_VARS;
+        $HTTP_SERVER_VARS;
+        $HTTP_COOKIE_VARS;
+        $HTTP_SESSION_VARS;
+        $HTTP_POST_FILES;
+        echo $HTTP_RAW_POST_DATA;
+
+		// Ok.
+        self::$HTTP_POST_VARS;
+        self::$HTTP_GET_VARS;
+        static::$HTTP_ENV_VARS;
+        static::$HTTP_SERVER_VARS;
+        $this->HTTP_COOKIE_VARS;
+        $this->HTTP_SESSION_VARS;
+        $this->HTTP_POST_FILES;
+        static::$HTTP_RAW_POST_DATA;
+
+		// Bad.
+        self::{$HTTP_POST_VARS};
+        self::{$HTTP_SERVER_VARS};
+        self::{$HTTP_SESSION_VARS};
+    }
+}

--- a/Tests/sniff-examples/utility-functions/is_class_property.php
+++ b/Tests/sniff-examples/utility-functions/is_class_property.php
@@ -1,0 +1,80 @@
+<?php
+
+/* Case 1 */
+$var = false;
+
+/* Case 2 */
+function something($var = false)
+{
+	/* Case 3 */
+	$var = false;
+}
+
+class MyClass {
+	/* Case 4 */
+	public $var = true;
+	/* Case 5 */
+	protected $var = true;
+	/* Case 6 */
+	private $var = true;
+	/* Case 7 */
+	var $var = true;
+
+	/* Case 8 */
+	public function something($var = false)
+	{
+		/* Case 9 */
+		$var = false;
+	}
+}
+
+$a = new class {
+	/* Case 10 */
+	public $var = true;
+	/* Case 11 */
+	protected $var = true;
+	/* Case 12 */
+	private $var = true;
+	/* Case 13 */
+	var $var = true;
+
+	/* Case 14 */
+	public function something($var = false)
+	{
+		/* Case 15 */
+		$var = false;
+	}
+}
+
+interface MyInterface {
+	// Properties are not allowed in interfaces.
+	/* Case 16 */
+	public $var = false;
+	/* Case 17 */
+	protected $var = false;
+	/* Case 18 */
+	private $var = false;
+	/* Case 19 */
+	var $var = false;
+
+	/* Case 20 */
+	public function something($var = false);
+}
+
+trait MyTrait {
+	/* Case 22 */
+	public $var = true;
+	/* Case 23 */
+	protected $var = true;
+	/* Case 24 */
+	private $var = true;
+	/* Case 25 */
+	var $var = true;
+
+	/* Case 26 */
+	function something($var = false)
+	{
+		/* Case 27 */
+		$var = false;
+	}
+}


### PR DESCRIPTION
Prevent false positives for class properties named after removed PHP superglobals in PHPCS 2.4.0-2.7.1.

* Pre-PHPCS 2.4.0, the `T_ANON_CLASS` token was recognized as T_CLASS and supported as such which works perfectly for our purposes.
* PHPCS 2.4.0 - 2.7.1 supported the T_ANON_CLASS *token*, but did not consistently take it into account in all the relevant methods, like `getMemberProperties()`.
* This was finally fixed in PHPCS 2.8.0.

As there is another upcoming sniff which will run into the same issue, I've abstracted the code to determine whether a variable is a class property to a method in the `PHPCompatibility_Sniff`.

Includes unit tests both for anonymous class support in the RemovedGlobalVariable sniff, as well as for the new utility method.

Fixes #333 

One of several PRs to fix #351