### PR TITLE
Add anonymous class support in the InternalInterfaces and NewInterfaces sniffs.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -282,8 +282,10 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      * Returns FALSE on error or if there are no implemented interface names.
      *
      * {@internal Duplicate of same method as introduced in PHPCS 2.7.
+     * This method also includes an improvement we use which was only introduced
+     * in PHPCS 2.8.0, so only defer to upstream for higher versions.
      * Once the minimum supported PHPCS version for this sniff library goes beyond
-     * that, this method can be removed and call to it replaced with
+     * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findImplementedInterfaceNames($stackPtr)` calls.}}
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
@@ -293,7 +295,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      */
     public function findImplementedInterfaceNames(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (method_exists($phpcsFile, 'findImplementedInterfaceNames')) {
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
             return $phpcsFile->findImplementedInterfaceNames($stackPtr);
         }
 
@@ -304,7 +306,9 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return false;
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS) {
+        if ($tokens[$stackPtr]['code'] !== T_CLASS
+            && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
+        ) {
             return false;
         }
 

--- a/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/Sniffs/PHP/InternalInterfacesSniff.php
@@ -43,7 +43,13 @@ class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibili
         // Handle case-insensitivity of interface names.
         $this->internalInterfaces = $this->arrayKeysToLowercase($this->internalInterfaces);
 
-        return array(T_CLASS);
+        $targets = array(T_CLASS);
+
+        if (defined('T_ANON_CLASS')) {
+            $targets[] = constant('T_ANON_CLASS');
+        }
+
+        return $targets;
 
     }//end register()
 

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -91,7 +91,13 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Ab
         $this->newInterfaces      = $this->arrayKeysToLowercase($this->newInterfaces);
         $this->unsupportedMethods = $this->arrayKeysToLowercase($this->unsupportedMethods);
 
-        return array(T_CLASS);
+        $targets = array(T_CLASS);
+
+        if (defined('T_ANON_CLASS')) {
+            $targets[] = constant('T_ANON_CLASS');
+        }
+
+        return $targets;
 
     }//end register()
 

--- a/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -30,6 +30,17 @@ class InternalInterfacesSniffTest extends BaseSniffTest
     protected $_sniffFile;
 
     /**
+     * Interface error messages.
+     *
+     * @var array
+     */
+    protected $messages = array(
+        'Traversable'       => 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.',
+        'DateTimeInterface' => 'The interface DateTimeInterface is intended for type hints only and is not implementable.',
+        'Throwable'         => 'The interface Throwable cannot be implemented directly, extend the Exception class instead.',
+    );
+
+    /**
      * Set up the test file for this unit test.
      *
      * @return void
@@ -43,44 +54,43 @@ class InternalInterfacesSniffTest extends BaseSniffTest
     }
 
     /**
-     * Test Traversable interface
+     * Test InternalInterfaces
+     *
+     * @dataProvider dataInternalInterfaces
+     *
+     * @param string $interface Interface name.
+     * @param array  $line      The line number in the test file.
      *
      * @return void
      */
-    public function testTraversable()
+    public function testInternalInterfaces($type, $line)
     {
-        $this->assertError($this->_sniffFile, 3, 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.');
+        $this->assertError($this->_sniffFile, $line, $this->messages[$type]);
     }
 
     /**
-     * Test DateTimeInterface interface
+     * Data provider.
      *
-     * @return void
+     * @see testInternalInterfaces()
+     *
+     * @return array
      */
-    public function testDateTimeInterface()
+    public function dataInternalInterfaces()
     {
-        $this->assertError($this->_sniffFile, 4, 'The interface DateTimeInterface is intended for type hints only and is not implementable.');
-    }
+        return array(
+            array('Traversable', 3),
+            array('DateTimeInterface', 4),
+            array('Throwable', 5),
+            array('Traversable', 7),
+            array('Throwable', 7),
 
-    /**
-     * Test Throwable interface
-     *
-     * @return void
-     */
-    public function testThrowable()
-    {
-        $this->assertError($this->_sniffFile, 5, 'The interface Throwable cannot be implemented directly, extend the Exception class instead.');
-    }
-
-    /**
-     * Test multiple interfaces
-     *
-     * @return void
-     */
-    public function testMultipleInterfaces()
-    {
-        $this->assertError($this->_sniffFile, 7, 'The interface Traversable shouldn\'t be implemented directly, implement the Iterator or IteratorAggregate interface instead.');
-        $this->assertError($this->_sniffFile, 7, 'The interface Throwable cannot be implemented directly, extend the Exception class instead.');
+            // Anonymous classes.
+            array('Traversable', 17),
+            array('DateTimeInterface', 18),
+            array('Throwable', 19),
+            array('Traversable', 20),
+            array('Throwable', 20),
+        );
     }
 
     /**

--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -62,8 +62,8 @@ class NewInterfacesSniffTest extends BaseSniffTest
             array('Countable', '5.0', array(3, 17), '5.1'),
             array('OuterIterator', '5.0', array(4), '5.1'),
             array('RecursiveIterator', '5.0', array(5), '5.1'),
-            array('SeekableIterator', '5.0', array(6, 17), '5.1'),
-            array('Serializable', '5.0', array(7), '5.1'),
+            array('SeekableIterator', '5.0', array(6, 17, 28), '5.1'),
+            array('Serializable', '5.0', array(7, 29), '5.1'),
             array('SplObserver', '5.0', array(11), '5.1'),
             array('SplSubject', '5.0', array(12, 17), '5.1'),
             array('JsonSerializable', '5.3', array(13), '5.4'),
@@ -74,14 +74,36 @@ class NewInterfacesSniffTest extends BaseSniffTest
     /**
      * Test unsupported methods
      *
+     * @dataProvider dataUnsupportedMethods
+     *
+     * @param array  $line       The line number.
+     * @param string $methodName The name of the unsupported method which should be detected.
+     *
      * @return void
      */
-    public function testUnsupportedMethods()
+    public function testUnsupportedMethods($line, $methodName)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.1'); // Version in which the Serializable interface was introduced.
-        $this->assertError($file, 8, 'Classes that implement interface Serializable do not support the method __sleep(). See http://php.net/serializable');
-        $this->assertError($file, 9, 'Classes that implement interface Serializable do not support the method __wakeup(). See http://php.net/serializable');
+        $this->assertError($file, $line, "Classes that implement interface Serializable do not support the method {$methodName}(). See http://php.net/serializable");
     }
+
+    /**
+     * Data provider.
+     *
+     * @see testUnsupportedMethods()
+     *
+     * @return array
+     */
+    public function dataUnsupportedMethods()
+    {
+        return array(
+            array(8, '__sleep'),
+            array(9, '__wakeup'),
+            array(30, '__sleep'),
+            array(31, '__wakeup'),
+        );
+    }
+
 
     /**
      * Test interfaces in different cases.

--- a/Tests/sniff-examples/internal_interfaces.php
+++ b/Tests/sniff-examples/internal_interfaces.php
@@ -12,3 +12,9 @@ class MyLowercase implements datetimeinterface {} // Test case-insensitivity.
 // These shouldn't throw errors.
 class MyTraversable implements TraversableSomething {}
 class MyTraversable implements myNameSpace\Traversable {}
+
+// Internal interfaces with anonymous classes.
+$a = new class implements Traversable {}
+$b = new class implements DateTimeInterface {}
+$c = new class implements Throwable {}
+$d = new class implements SomeInterface, Throwable, AnotherInterface, Traversable {} // Test multiple interfaces.

--- a/Tests/sniff-examples/new_interfaces.php
+++ b/Tests/sniff-examples/new_interfaces.php
@@ -5,8 +5,8 @@ class MyOuterIterator implements OuterIterator {}
 class MyRecursiveIterator implements RecursiveIterator {}
 class MySeekableIterator implements SeekableIterator {}
 class MySerializable implements Serializable {
-	public function __sleep() {}
-	public function __wakeup() {}
+    public function __sleep() {}
+    public function __wakeup() {}
 }
 class MySplObserver implements SplObserver {}
 class MySplSubject implements SplSubject {}
@@ -23,3 +23,10 @@ class MyLowercase implements countable {}
 // These shouldn't throw errors.
 class MyJsonSerializable implements JsonSerializableSomething {}
 class MyJsonSerializable implements myNameSpace\JsonSerializable {}
+
+// Test anonymous class support.
+$a = new class implements SeekableIterator {}
+$b = new class implements Serializable {
+    public function __sleep() {}
+    public function __wakeup() {}
+}


### PR DESCRIPTION
While there have no new interfaces been introduced since the introduction of anonymous classes, this will make the sniff forward compatible for when those are introduced.
For InternalInterfaces, the change is already relevant.

Includes unit tests.

As there are now more tests, largely reworked the InternalInterfaces unit tests to data providers.
In a similar vain, reworked the `testUnsupportedMethods` test in the `NewInterfaces` unit test file to use a data provider.

One of several PRs to fix #351