### PR TITLE
PHP 5.6: New sniff to detect constant arrays defined using the `const` keyword

### DIFF
--- a/Sniffs/PHP/ConstantArraysUsingConstSniff.php
+++ b/Sniffs/PHP/ConstantArraysUsingConstSniff.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff.
+ *
+ * PHP version 5.6
+ *
+ * @category  PHP
+ * @package   PHPCompatibility
+ * @author    Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff.
+ *
+ * Constant arrays using the constant keyword in PHP 5.6
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_CONST);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.5') !== true) {
+            return;
+        }
+
+        $find = array(
+            T_ARRAY             => T_ARRAY,
+            T_OPEN_SHORT_ARRAY  => T_OPEN_SHORT_ARRAY,
+            T_CLOSE_SHORT_ARRAY => T_CLOSE_SHORT_ARRAY,
+        );
+
+        $hasArray = $phpcsFile->findNext($find, ($stackPtr + 1), null, false, null, true);
+        if ($hasArray !== false) {
+            $phpcsFile->addError(
+                'Constant arrays using the "const" keyword are not allowed in PHP 5.5 or earlier',
+                $hasArray,
+                'Found'
+            );
+        }
+    }
+}

--- a/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
+++ b/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Constant arrays using the const keyword in PHP 5.6 sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Constant arrays using the const keyword in PHP 5.6 sniff test file
+ *
+ * @group constantArraysUsingConst
+ * @group constants
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ConstantArraysUsingConstSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/constant_arrays_using_const.php';
+
+    /**
+     * testConstantArraysUsingConst
+     *
+     * @dataProvider dataConstantArraysUsingConst
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testConstantArraysUsingConst($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertError($file, $line, 'Constant arrays using the "const" keyword are not allowed in PHP 5.5 or earlier');
+    }
+
+    /**
+     * Data provider dataConstantArraysUsingConst.
+     *
+     * @see testConstantArraysUsingConst()
+     *
+     * @return array
+     */
+    public function dataConstantArraysUsingConst()
+    {
+        return array(
+            array(3),
+            array(4),
+            array(6),
+            array(12),
+            array(19),
+            array(25),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(31),
+            array(33),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/constant_arrays_using_const.php
+++ b/Tests/sniff-examples/constant_arrays_using_const.php
@@ -1,0 +1,33 @@
+<?php
+
+const ABC = ['a', 'b'];
+const AB = array('a', 'b');
+
+const ANIMALS = [
+    'dog',
+    'cat',
+    'bird'
+];
+
+const MORE_ANIMALS = array(
+    'dog',
+    'cat',
+    'bird'
+);
+
+class MyClass {
+    const ANIMALS = [
+        'dog',
+        'cat',
+        'bird'
+    ];
+
+    const MORE_ANIMALS = array( 'dog', 'cat', 'bird' );
+}
+
+/*
+ * Minimal tests against false positives.
+ */
+const ANIMALS = 'array';
+
+const ABC; // Not an assignment. Useless, but what the heck ;-)


### PR DESCRIPTION
> It is also now possible to define a constant array using the const keyword:

Ref: http://php.net/manual/en/migration56.new-features.php#migration56.new-features.const-scalar-exprs

Includes unit tests