### PR TITLE
`getMethodParameters()`: Sync in upstream changes.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -1052,9 +1052,11 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      *
      * <code>
      *   0 => array(
+     *         'token'             => int,     // The position of the var in the token stack.
      *         'name'              => '$var',  // The variable name.
      *         'content'           => string,  // The full content of the variable definition.
      *         'pass_by_reference' => boolean, // Is the variable passed by reference?
+     *         'variable_length'   => boolean, // Is the param of variable length through use of `...` ?
      *         'type_hint'         => string,  // The type hint for the variable.
      *         'nullable_type'     => boolean, // Is the variable using a nullable type?
      *        )
@@ -1075,10 +1077,10 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
      * `$phpcsFile->getMethodParameters($stackPtr)` calls.
      *
      * NOTE: This version does not deal with the new T_NULLABLE token type.
-     * This token is included upstream only in 2.7.2+ and as we defer to upstream
+     * This token is included upstream only in 2.8.0+ and as we defer to upstream
      * in that case, no need to deal with it here.
      *
-     * Last synced with PHPCS version: PHPCS 2.7.2-alpha.}}
+     * Last synced with PHPCS version: PHPCS 2.9.0-alpha at commit f1511adad043edfd6d2e595e77385c32577eb2bc}}
      *
      * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
      * @param int                  $stackPtr  The position in the stack of the
@@ -1210,15 +1212,16 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 }
 
                 $vars[$paramCount]            = array();
+                $vars[$paramCount]['token']   = $currVar;
                 $vars[$paramCount]['name']    = $tokens[$currVar]['content'];
                 $vars[$paramCount]['content'] = trim($phpcsFile->getTokensAsString($paramStart, ($i - $paramStart)));
 
                 if ($defaultStart !== null) {
                     $vars[$paramCount]['default']
-                        = $phpcsFile->getTokensAsString(
+                        = trim($phpcsFile->getTokensAsString(
                             $defaultStart,
                             ($i - $defaultStart)
-                        );
+                        ));
                 }
 
                 $vars[$paramCount]['pass_by_reference'] = $passByReference;

--- a/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/Sniffs/PHP/NewNullableTypesSniff.php
@@ -98,7 +98,7 @@ class PHPCompatibility_Sniffs_PHP_NewNullableTypesSniff extends PHPCompatibility
                 if ($param['nullable_type'] === true) {
                     $phpcsFile->addError(
                         'Nullable type declarations are not supported in PHP 7.0 or earlier. Found: %s',
-                        $stackPtr,
+                        $param['token'],
                         'typeDeclarationFound',
                         array($param['type_hint'])
                     );

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -113,7 +113,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(
                     'Type hints were not present in PHP 4.4 or earlier.',
-                    $stackPtr,
+                    $param['token'],
                     'TypeHintFound'
                 );
             }
@@ -121,7 +121,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                 $itemInfo = array(
                     'name'   => $param['type_hint'],
                 );
-                $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+                $this->handleFeature($phpcsFile, $param['token'], $itemInfo);
             }
             else if (isset($this->invalidTypes[$param['type_hint']])) {
                 $error = "'%s' is not a valid type declaration. Did you mean %s ?";
@@ -130,13 +130,13 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
                     $this->invalidTypes[$param['type_hint']],
                 );
 
-                $phpcsFile->addError($error, $stackPtr, 'InvalidTypeHintFound', $data);
+                $phpcsFile->addError($error, $param['token'], 'InvalidTypeHintFound', $data);
             }
             else if ($param['type_hint'] === 'self') {
                 if ($this->inClassScope($phpcsFile, $stackPtr) === false) {
                     $phpcsFile->addError(
                         "'self' type cannot be used outside of class scope",
-                        $stackPtr,
+                        $param['token'],
                         'SelfOutsideClassScopeFound'
                     );
                 }

--- a/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -67,7 +67,7 @@ class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCo
                 $errorCode = $this->stringToErrorCode(substr($param['name'], 1)).'Found';
                 $data      = array($param['name']);
 
-                $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+                $phpcsFile->addError($error, $param['token'], $errorCode, $data);
             }
         }
     }


### PR DESCRIPTION
And start using the new `token` index for more precise error line indication in the case of multi-line function declarations.