### PR TITLE
PHP 5.6: Add new sniff to detect importing const and function via a use statement

### DIFF
--- a/Sniffs/PHP/NewUseConstFunctionSniff.php
+++ b/Sniffs/PHP/NewUseConstFunctionSniff.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff.
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff.
+ *
+ * The use operator has been extended to support importing functions and
+ * constants in addition to classes. This is achieved via the use function
+ * and use const constructs, respectively.
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * A list of keywords that can follow use statements.
+     *
+     * @var array(string => string)
+     */
+    protected $validUseNames = array(
+        'const'    => true,
+        'function' => true,
+    );
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_USE);
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.5') !== true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($nextNonEmpty === false) {
+            // Live coding.
+            return;
+        }
+
+        if (isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === false) {
+            // Not a `use const` or `use function` statement.
+            return;
+        }
+
+        // `use const` and `use function` have to be followed by the function/constant name.
+        $functionOrConstName = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        if ($functionOrConstName === false
+            // Identifies as T_AS or T_STRING, this covers both.
+            || ($tokens[$functionOrConstName]['content'] === 'as'
+            || $tokens[$functionOrConstName]['code'] === T_COMMA)
+        ) {
+            // Live coding or incorrect use of reserved keyword, but that is
+            // covered by the ForbiddenNames sniff.
+            return;
+        }
+
+        // Still here ? In that case we have encountered a `use const` or `use function` statement.
+        $phpcsFile->addError(
+            'Importing functions and constants through a "use" statement is not supported in PHP 5.5 or lower.',
+            $nextNonEmpty,
+            'Found'
+        );
+    }
+
+}

--- a/Tests/Sniffs/PHP/NewUseConstFunctionSniffTest.php
+++ b/Tests/Sniffs/PHP/NewUseConstFunctionSniffTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * New use const function sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New use const function in PHP 5.6 sniff test file
+ *
+ * @group newUseConstFunction
+ * @group use
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewUseConstFunctionSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_use_const_function.php';
+
+
+    /**
+     * testNewUseConstFunction
+     *
+     * @dataProvider dataNewUseConstFunction
+     *
+     * @param int    $line    The line number.
+     * @param bool   $isTrait Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testNewUseConstFunction($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertError($file, $line, 'Importing functions and constants through a "use" statement is not supported in PHP 5.5 or lower.');
+    }
+
+    /**
+     * Data provider dataNewUseConstFunction.
+     *
+     * @see testNewUseConstFunction()
+     *
+     * @return array
+     */
+    public function dataNewUseConstFunction()
+    {
+        return array(
+            array(48),
+            array(49),
+            array(50),
+            array(51),
+            array(54),
+            array(58),
+            array(62),
+            array(66),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(7),
+            array(8),
+            array(9),
+            array(12),
+            array(16),
+            array(22),
+            array(28),
+            array(34),
+            array(40),
+            array(72),
+            array(73),
+            array(74),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/new_use_const_function.php
+++ b/Tests/sniff-examples/new_use_const_function.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Use statements which are ok pre-PHP 5.6.
+ */
+namespace FooBar;
+    use Foo\Bar;
+    use Foobar as Baz;
+    use Foobar as Baz, Bay as BarFoo;
+
+class Foobar {
+    use Baz;
+}
+
+class Foobar {
+    use BazTrait {
+        oldfunction as Baz
+    }
+}
+
+class Foobar {
+    use BazTrait {
+        oldfunction as public Baz
+    }
+}
+
+class Foobar {
+    use BazTrait {
+        oldfunction as protected Baz
+    }
+}
+
+class Foobar {
+    use BazTrait {
+        oldfunction as private Baz
+    }
+}
+
+class Foobar {
+    use BazTrait {
+        oldfunction as final Baz
+    }
+}
+
+/*
+ * PHP 5.6: Use statements using `const` and `function`
+ */
+use const Baz;
+use const FOOBAR as Baz;
+use function Baz;
+use function FooBar as Baz;
+
+class Foobar {
+    use const Baz;
+}
+
+class Foobar {
+    use function Baz;
+}
+
+trait Foobar {
+    use const Baz;
+}
+
+trait Foobar {
+    use function Baz;
+}
+
+/*
+ * Incorrect use, but covered by ForbiddenNames sniff, should not be reported here.
+ */
+use const as Baz;
+use function as Baz;
+use const, function, somethingElse;


### PR DESCRIPTION
> The use operator has been extended to support importing functions and constants in addition to classes. This is achieved via the use function and use const constructs, respectively.

Refs:
* http://php.net/manual/en/migration56.new-features.php#migration56.new-features.use
* https://wiki.php.net/rfc/use_function

Includes unit tests.

#### Not covered, multiple statements separated by comma's:
.. as I'm not sure if it is a valid syntax in the first place:
```php
use const Baz, function Foo\Bar as bar;
```