### PR TITLE
PHP 5.5: add new sniff to detect `::class` magic constant

### DIFF
--- a/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff.
+ *
+ * The special ClassName::class constant is available as of PHP 5.5.0, and allows for
+ * fully qualified class name resolution at compile.
+ *
+ * PHP version 5.5
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatibility_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STRING);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if (strtolower($tokens[$stackPtr]['content']) !== 'class') {
+            return;
+        }
+
+        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        if ($prevToken === false || $tokens[$prevToken]['code'] !== T_DOUBLE_COLON) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -45,10 +45,6 @@ class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatib
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.4') === false) {
-            return;
-        }
-
         $tokens = $phpcsFile->getTokens();
 
         if (strtolower($tokens[$stackPtr]['content']) !== 'class') {
@@ -60,10 +56,64 @@ class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatib
             return;
         }
 
-        $phpcsFile->addError(
-            'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
+        if ($this->supportsBelow('5.4')) {
+            $phpcsFile->addError(
+                'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
+                $stackPtr,
+                'Found'
+            );
+        }
+
+        /*
+         * Check against invalid use of the magic `::class` constant.
+         */
+        if ($this->supportsAbove('5.5') === false) {
+            return;
+        }
+
+        $classNameToken = $phpcsFile->findPrevious(T_STRING, ($prevToken - 1), null, false, null, true);
+
+        // Useless if not in a namespace.
+        $hasNamespace = false;
+        if ($classNameToken !== false) {
+            $namespace = $this->determineNamespace($phpcsFile, $classNameToken);
+            if (empty($namespace) === false) {
+                $hasNamespace = true;
+            }
+        }
+
+        if ($hasNamespace === false) {
+            $phpcsFile->addWarning(
+                'Using the magic class constant ClassName::class is only useful in combination with a namespaced class',
+                $stackPtr,
+                'NotInNamespace'
+            );
+        }
+
+
+        // Is the magic constant used in a file which actually contains the referenced class ?
+        if ($classNameToken === false) {
+            return;
+        }
+
+        $targetClassName = $tokens[$classNameToken]['content'];
+        $classPtr        = $stackPtr;
+        while ($classPtr > 0) {
+            $classPtr = $phpcsFile->findPrevious(T_CLASS, ($classPtr - 1));
+
+            if ($classPtr !== false) {
+                $className = $phpcsFile->getDeclarationName($classPtr);
+                if (empty($className) === false && $className === $targetClassName) {
+                    return;
+                }
+            }
+        }
+
+        // Still here? In that case, the magic constant is used in a file which doesn't contain the target class.
+        $phpcsFile->addWarning(
+            'The magic class constant ClassName::class can only be used in the same file as where the class is defined',
             $stackPtr,
-            'Found'
+            'FileDoesNotContainClass'
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
@@ -27,14 +27,23 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
      *
      * @dataProvider dataNewMagicClassConstant
      *
-     * @param int $line The line number.
+     * @param int  $line            The line number.
+     * @param bool $testNoViolation Whether or not to run the noViolation test.
      *
      * @return void
      */
-    public function testNewMagicClassConstant($line)
+    public function testNewMagicClassConstant($line, $testNoViolation = true)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertError($file, $line, 'The magic class constant ClassName::class was not available in PHP 5.4 or earlier');
+
+        if ($testNoViolation === true) {
+            // Namespace detection does not work on PHP 5.2.
+            if (version_compare(phpversion(), '5.3.0', '>=')) {
+                $file = $this->sniffFile(self::TEST_FILE, '5.5');
+                $this->assertNoViolation($file, $line);
+            }
+        }
     }
 
     /**
@@ -49,6 +58,7 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
         return array(
             array(6),
             array(12),
+            array(24, false), // Line which also tests the incorrect use warnings.
         );
     }
 
@@ -87,20 +97,57 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
 
 
     /**
-     * Verify no notices are thrown at all.
+     * testInvalidUse
      *
      * @return void
      */
-    public function testNoViolationsInFileOnValidVersion()
+    public function testInvalidUse()
     {
-		// Namespace detection does not work on PHP 5.2.
-        if (version_compare(phpversion(), '5.3.0', '>=') === false) {
-            $this->markTestSkipped();
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertWarning($file, 24, 'Using the magic class constant ClassName::class is only useful in combination with a namespaced class');
+        $this->assertWarning($file, 24, 'The magic class constant ClassName::class can only be used in the same file as where the class is defined');
+    }
+
+
+    /**
+     * testNoFalsePositivesInvalidUse
+     *
+     * @dataProvider dataNoFalsePositivesInvalidUse
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesInvalidUse($line)
+    {
+        if (version_compare(phpversion(), '5.3.0', '<') === true) {
+            $this->markTestSkipped('PHP 5.2 does not recognize namespaces.');
             return;
         }
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertNoViolation($file);
+        $this->assertNoViolation($file, $line);
     }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesInvalidUse()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesInvalidUse()
+    {
+        return array(
+            array(6),
+            array(12),
+        );
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings
+     * on invalid use of the constant in PHP 5.5+ versions.
+     */
 
 }

--- a/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * New magic ::class constant sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * New magic ::class constant sniff test file.
+ *
+ * @group newMagicClassConstant
+ * @group constants
+ *
+ * @covers PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewMagicClassConstantSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_magic_class_constant.php';
+
+    /**
+     * testNewMagicClassConstant
+     *
+     * @dataProvider dataNewMagicClassConstant
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewMagicClassConstant($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertError($file, $line, 'The magic class constant ClassName::class was not available in PHP 5.4 or earlier');
+    }
+
+    /**
+     * Data provider dataNewMagicClassConstant.
+     *
+     * @see testNewMagicClassConstant()
+     *
+     * @return array
+     */
+    public function dataNewMagicClassConstant()
+    {
+        return array(
+            array(6),
+            array(12),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(10),
+            array(18),
+            array(19),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+		// Namespace detection does not work on PHP 5.2.
+        if (version_compare(phpversion(), '5.3.0', '>=') === false) {
+            $this->markTestSkipped();
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/Tests/sniff-examples/new_magic_class_constant.php
+++ b/Tests/sniff-examples/new_magic_class_constant.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace foo {
+    class bar {}
+
+    echo bar::class; // foo\bar
+}
+
+namespace MyNameSpace {
+	class xyz {}
+
+	remove_filter('theme_filter', [\namespace\xyz::class, 'methodName'], 30);
+}
+
+/*
+ * False positives check.
+ */
+echo bar::classProp; // Not the keyword.
+new class {} // Anonymous class, not the keyword.

--- a/Tests/sniff-examples/new_magic_class_constant.php
+++ b/Tests/sniff-examples/new_magic_class_constant.php
@@ -15,5 +15,10 @@ namespace MyNameSpace {
 /*
  * False positives check.
  */
-echo bar::classProp; // Not the keyword.
 new class {} // Anonymous class, not the keyword.
+echo bar::classProp; // Not the keyword.
+
+/*
+ * Invalid use check.
+ */
+echo foobar::class; // Invalid: Used outside of a namespace + class foobar does not exist in this file.


### PR DESCRIPTION
Includes unit tests + two additional checks against invalid use of the magic `::class` constant.

Ref: http://php.net/manual/en/migration55.new-features.php#migration55.new-features.class-name
Ref: example #3 http://php.net/manual/en/language.oop5.constants.php

Fixes #364