### PR TITLE
ForbiddenClosureUseVariable Tests: prevent infinite loop with PHPCS 2.5.1

### DIFF
--- a/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
@@ -22,6 +22,8 @@ class ForbiddenClosureUseVariableNamesSniffTest extends BaseSniffTest
 {
     const TEST_FILE = 'sniff-examples/forbidden_closure_use_variable_names.php';
 
+    const TEST_FILE_LIVE_CODING = 'sniff-examples/forbidden_closure_use_variable_names.2.php';
+
     /**
      * testForbiddenClosureUseVariableNames
      *
@@ -96,8 +98,42 @@ class ForbiddenClosureUseVariableNamesSniffTest extends BaseSniffTest
             array(32),
             array(33),
             array(36),
-            array(41), // Live coding.
-            array(44), // Live coding.
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesLiveCoding
+     *
+     * @dataProvider dataNoFalsePositivesLiveCoding
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesLiveCoding($line)
+    {
+        if (strpos(PHP_CodeSniffer::VERSION, '2.5.1') !== false) {
+            $this->markTestSkipped('PHPCS 2.5.1 has a bug in the tokenizer which affects this test.');
+            return;
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE_LIVE_CODING, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesLiveCoding()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesLiveCoding()
+    {
+        return array(
+            array(41),
+            array(44),
         );
     }
 

--- a/Tests/sniff-examples/forbidden_closure_use_variable_names.2.php
+++ b/Tests/sniff-examples/forbidden_closure_use_variable_names.2.php
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * Test these two cases separately as they trigger a bug in PHPCS 2.5.1.
+ * Ref: https://github.com/squizlabs/PHP_CodeSniffer/commit/9a70ae2d4c0a0bd0f48b965202158defb828cadd
+ */
+
+// Live coding.
+$f = function ($param) use
+
+// Live coding.
+$f = function ($param) use ($param

--- a/Tests/sniff-examples/forbidden_closure_use_variable_names.php
+++ b/Tests/sniff-examples/forbidden_closure_use_variable_names.php
@@ -36,9 +36,3 @@ class ezcReflectionMethod extends ReflectionMethod {
     use ezcReflectionReturnInfo { sayHello as private myPrivateHello; };
     /* ... */
 }
-
-// Live coding
-$f = function ($param) use
-
-// Live coding
-$f = function ($param) use ($param


### PR DESCRIPTION
The PHPCS Tokenizer has a bug in version 2.5.1 which causes an infinite loop with undefined index notices.
This fix skips the two tests which are affected by this bug when the tests are run on PHPCS 2.5.1 to prevent this.

Commit https://github.com/squizlabs/PHP_CodeSniffer/commit/9a70ae2d4c0a0bd0f48b965202158defb828cadd fixed the issue. The bug only exists in PHPCS 2.5.1.

The bug seems to only affect this sniff when the sniff is run from an IDE during live coding and/or when the file has parse errors.

The `README` for PHPCompatibility already commends using PHPCS 2.6+, so hopefully this bug will rarely rear its head for end-users.