### PR TITLE
:rocket: Travis: make it easier to see on which PHPCS version a build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,42 +12,42 @@ matrix:
       env: PHPCS_VERSION="master"
 
     - php: 5.3
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.3
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
 
     - php: 5.4
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.4
-      env: COVERALLS_VERSION="~1.0" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
 
     - php: 5.5
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 5.5
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
     - php: 5.5
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
 
     - php: 5.6
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 5.6
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
     - php: 5.6
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
 
     - php: 7.0
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 7.0
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
     - php: 7.0
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master" SNIFF=1
+      env: PHPCS_VERSION="dev-master" SNIFF=1 COVERALLS_VERSION="dev-master"
 
     - php: 7.1
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 7.1
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
     - php: 7.1
-      env: COVERALLS_VERSION="dev-master" PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
 
     - php: nightly
       env: PHPCS_VERSION=">=1.5.1,<2.0"


### PR DESCRIPTION
For the build failures, the coveralls version is irrelevant, while the PHPCS version gives you a clue on where to start debugging.
Previously the PHPCS version would - depending on screen size - often be hidden behind the run time. Now it won't anymore.

Before:
![travis build info](https://cloud.githubusercontent.com/assets/663378/25067797/89bf46c6-224e-11e7-88ea-d476d3d81080.png)

After:
![travis build info 2](https://cloud.githubusercontent.com/assets/663378/25067808/d31f375e-224e-11e7-822c-33aa9eb00d1f.png)
