### PR TITLE
NewInterfacesSniff: Detect new interfaces when used as type hints.

### DIFF
--- a/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -59,18 +59,18 @@ class NewInterfacesSniffTest extends BaseSniffTest
     public function dataNewInterface()
     {
         return array(
-            array('Countable', '5.0', array(3, 17), '5.1'),
-            array('OuterIterator', '5.0', array(4), '5.1'),
-            array('RecursiveIterator', '5.0', array(5), '5.1'),
-            array('SeekableIterator', '5.0', array(6, 17, 28), '5.1'),
-            array('Serializable', '5.0', array(7, 29), '5.1'),
-            array('SplObserver', '5.0', array(11), '5.1'),
-            array('SplSubject', '5.0', array(12, 17), '5.1'),
-            array('JsonSerializable', '5.3', array(13), '5.4'),
-            array('SessionHandlerInterface', '5.3', array(14), '5.4'),
-            array('Traversable', '4.4', array(35), '5.0'),
-            array('DateTimeInterface', '5.4', array(36), '5.5'),
-            array('Throwable', '5.6', array(37), '7.0'),
+            array('Countable', '5.0', array(3, 17, 41), '5.1'),
+            array('OuterIterator', '5.0', array(4, 42, 65), '5.1'),
+            array('RecursiveIterator', '5.0', array(5, 43, 65), '5.1'),
+            array('SeekableIterator', '5.0', array(6, 17, 28, 44), '5.1'),
+            array('Serializable', '5.0', array(7, 29, 45, 55, 70), '5.1'),
+            array('SplObserver', '5.0', array(11, 46, 65), '5.1'),
+            array('SplSubject', '5.0', array(12, 17, 47, 69), '5.1'),
+            array('JsonSerializable', '5.3', array(13, 48), '5.4'),
+            array('SessionHandlerInterface', '5.3', array(14, 49), '5.4'),
+            array('Traversable', '4.4', array(35, 50, 60, 71), '5.0'),
+            array('DateTimeInterface', '5.4', array(36, 51, 61), '5.5'),
+            array('Throwable', '5.6', array(37, 52, 62), '7.0'),
         );
     }
 
@@ -148,6 +148,9 @@ class NewInterfacesSniffTest extends BaseSniffTest
         return array(
             array(24),
             array(25),
+            array(56),
+            array(57),
+            array(72),
         );
     }
 

--- a/Tests/sniff-examples/new_interfaces.php
+++ b/Tests/sniff-examples/new_interfaces.php
@@ -35,3 +35,38 @@ $b = new class implements Serializable {
 class MyTraversable implements Traversable {}
 class MyDateTimeInterface implements DateTimeInterface {}
 class MyThrowable implements Throwable {}
+
+class MyClass {
+	// Interfaces as typehints.
+	function CountableTypeHint( Countable $a ) {}
+	function OuterIteratorTypeHint( OuterIterator $a ) {}
+	function RecursiveIteratorTypeHint( RecursiveIterator $a ) {}
+	function SeekableIteratorTypeHint( SeekableIterator $a ) {}
+	function SerializableTypeHint( Serializable $a ) {}
+	function SplObserverTypeHint( SplObserver $a ) {}
+	function SplSubjectTypeHint( SplSubject $a ) {}
+	function JsonSerializableTypeHint( JsonSerializable $a ) {}
+	function SessionHandlerInterfaceTypeHint( SessionHandlerInterface $a ) {}
+	function TraversableTypeHint( Traversable $a ) {}
+	function DateTimeInterfaceTypeHint( DateTimeInterface $a ) {}
+	function ThrowableTypeHint( Throwable $a ) {}
+
+	// Namespaced interfaces as typehints
+	function SerializableTypeHint( \Serializable $a ) {} // Error: global namespace.
+	function SplObserverTypeHint( myNameSpace\SplObserver $a ) {} // Ok.
+	function SplSubjectTypeHint( \some\other\SplSubject $a ) {} // Ok.
+
+	// Interfaces as nullable typehints (PHP 7.1+).
+	function TraversableTypeHint( ?Traversable $a ) {}
+	function DateTimeInterfaceTypeHint( ?\DateTimeInterface $a ) {}
+	function ThrowableTypeHint( ?Throwable $a ) {}
+	
+	// Function with multiple typehinted parameters.
+	function MultipleTypeHints (OuterIterator $a, ?int $b, SplObserver $c, ?\RecursiveIterator $d) {}
+}
+
+// Interfaces in type hints in anonymous functions.
+function ( SplSubject $a ) {}
+function(\Serializable $a) {}
+function ( ?Traversable $a ) {}
+function(myNameSpace\SplObserver $a) {} // Ok.


### PR DESCRIPTION
Notes:
* Adds a new method to the `PHPCompatibility_Sniff` class to retrieve just the typehints from a function declaration.
* Adds the logic to the sniff to detect usage of new interfaces as type hints.

Includes unit tests.