### PR TITLE
NewClasses sniff: Detect new Exception classes

### DIFF
--- a/Sniffs/PHP/NewClassesSniff.php
+++ b/Sniffs/PHP/NewClassesSniff.php
@@ -69,10 +69,6 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
                                             '5.2' => false,
                                             '5.3' => true
                                         ),
-                                        'PharException' => array(
-                                            '5.2' => false,
-                                            '5.3' => true
-                                        ),
                                         'PharFileInfo' => array(
                                             '5.2' => false,
                                             '5.3' => true
@@ -190,6 +186,155 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
 
                                     );
 
+    /**
+     * A list of new Exception classes, not present in older versions.
+     *
+     * The array lists : version number with false (not present) or true (present).
+     * If's sufficient to list the first version where the class appears.
+     *
+     * {@internal Classes listed here do not need to be added to the $newClasses
+     *            property as well.
+     *            This list is automatically added to the $newClasses property
+     *            in the `register()` method.}}
+     *
+     * @var array(string => array(string => bool))
+     */
+    protected $newExceptions = array(
+        'Exception' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'ErrorException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'BadFunctionCallException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'BadMethodCallException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'DomainException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'InvalidArgumentException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'LengthException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'LogicException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'OutOfBoundsException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'OutOfRangeException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'OverflowException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'RangeException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'RuntimeException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'UnderflowException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'UnexpectedValueException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'DOMException' => array(
+            // According to the docs introduced in PHP 5.0, but Exception was only introduced in 5.1.
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'mysqli_sql_exception' => array(
+            // According to the docs introduced in PHP 5.0, but Exception was only introduced in 5.1.
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'PDOException' => array(
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'ReflectionException' => array(
+            // According to the docs introduced in PHP 5.0, but Exception was only introduced in 5.1.
+            '5.0' => false,
+            '5.1' => true
+        ),
+        'SoapFault' => array(
+            // According to the docs introduced in PHP 5.0.1, but Exception was only introduced in 5.1.
+            '5.0' => false,
+            '5.1' => true
+        ),
+
+        'PharException' => array(
+            '5.2' => false,
+            '5.3' => true
+        ),
+
+        'SNMPException' => array(
+            '5.3' => false,
+            '5.4' => true
+        ),
+
+        'IntlException' => array(
+            '5.5.0' => false,
+            '5.5.1' => true
+        ),
+
+        'Error' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'ArithmeticError' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'AssertionError' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'DivisionByZeroError' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'ParseError' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'TypeError' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'UI\Exception\InvalidArgumentException' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+        'UI\Exception\RuntimeException' => array(
+            '5.6' => false,
+            '7.0' => true
+        ),
+
+    );
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -200,6 +345,10 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
     {
         // Handle case-insensitivity of class names.
         $this->newClasses = $this->arrayKeysToLowercase($this->newClasses);
+        $this->newExceptions = $this->arrayKeysToLowercase($this->newExceptions);
+
+        // Add the Exception classes to the Classes list.
+        $this->newClasses = array_merge($this->newClasses, $this->newExceptions);
 
         $targets = array(
             T_NEW,
@@ -207,6 +356,7 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
             T_DOUBLE_COLON,
             T_FUNCTION,
             T_CLOSURE,
+            T_CATCH,
         );
 
         if (defined('T_ANON_CLASS')) {
@@ -235,6 +385,10 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
             case 'T_FUNCTION':
             case 'T_CLOSURE':
                 $this->processFunctionToken($phpcsFile, $stackPtr);
+                break;
+
+            case 'T_CATCH':
+                $this->processCatchToken($phpcsFile, $stackPtr);
                 break;
 
             default:
@@ -270,10 +424,6 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
         }
 
         if ($FQClassName === '') {
-            return;
-        }
-
-        if ($this->isNamespaced($FQClassName) === true) {
             return;
         }
 
@@ -322,6 +472,72 @@ class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_Abstr
                     'nameLc' => $typeHintLc,
                 );
                 $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+            }
+        }
+    }
+
+
+    /**
+     * Processes this test for when a catch token is encountered.
+     *
+     * - Detect exceptions when used in a catch statement.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    private function processCatchToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Bow out during live coding.
+        if (isset($tokens[$stackPtr]['parenthesis_opener'], $tokens[$stackPtr]['parenthesis_closer']) === false) {
+            return;
+        }
+
+        $opener = $tokens[$stackPtr]['parenthesis_opener'];
+        $closer = ($tokens[$stackPtr]['parenthesis_closer'] + 1);
+        $name   = '';
+        $listen = array(
+            // Parts of a (namespaced) class name.
+            T_STRING              => true,
+            T_NS_SEPARATOR        => true,
+            // End/split tokens.
+            T_VARIABLE            => false,
+            T_BITWISE_OR          => false,
+            T_CLOSE_CURLY_BRACKET => false, // Shouldn't be needed as we expect a var before this.
+        );
+
+        for ($i = ($opener + 1); $i < $closer; $i++ ) {
+            if (isset($listen[$tokens[$i]['code']]) === false) {
+                continue;
+            }
+
+            if ($listen[$tokens[$i]['code']] === true) {
+                $name .= $tokens[$i]['content'];
+                continue;
+            } else {
+                if (empty($name) === true) {
+                    // Weird, we should have a name by the time we encounter a variable or |.
+                    // So this may be the closer.
+                    continue;
+                }
+
+                $name   = ltrim($name, '\\');
+                $nameLC = strtolower($name);
+
+                if (isset($this->newExceptions[$nameLC]) === true) {
+                    $itemInfo = array(
+                        'name'   => $name,
+                        'nameLc' => $nameLC,
+                    );
+                    $this->handleFeature($phpcsFile, $i, $itemInfo);
+                }
+
+                // Reset for a potential multi-catch.
+                $name = '';
             }
         }
     }

--- a/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -32,12 +32,24 @@ class NewClassesSniffTest extends BaseSniffTest
      * @param string $lastVersionBefore The PHP version just *before* the class was introduced.
      * @param array  $lines             The line numbers in the test file which apply to this class.
      * @param string $okVersion         A PHP version in which the class was ok to be used.
+     * @param string $testVersion       Optional. A PHP version in which to test for the error if different
+     *                                  from the $lastVersionBefore.
      *
      * @return void
      */
-    public function testNewClass($className, $lastVersionBefore, $lines, $okVersion)
+    public function testNewClass($className, $lastVersionBefore, $lines, $okVersion, $testVersion = null)
     {
-        $file  = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        if (version_compare(phpversion(), '5.3', '<') === true && strpos($className, '\\') !== false) {
+            $this->markTestSkipped('PHP 5.2 does not recognize namespaces.');
+            return;
+        }
+
+        if (isset($testVersion)){
+            $file = $this->sniffFile(self::TEST_FILE, $testVersion);
+        }
+        else {
+            $file = $this->sniffFile(self::TEST_FILE, $lastVersionBefore);
+        }
         $error = "The built-in class {$className} is not present in PHP version {$lastVersionBefore} or earlier";
         foreach ($lines as $line) {
             $this->assertError($file, $line, $error);
@@ -100,6 +112,38 @@ class NewClassesSniffTest extends BaseSniffTest
             array('DATETIME', '5.1', array(146), '5.2'),
             array('datetime', '5.1', array(147), '5.2'),
             array('dATeTiMe', '5.1', array(148), '5.2'),
+
+            array('Exception', '5.0', array(190, 217), '5.1'),
+            array('ErrorException', '5.0', array(194, 218), '5.1'),
+            array('BadFunctionCallException', '5.0', array(201, 219), '5.1'),
+            array('BadMethodCallException', '5.0', array(207, 220), '5.1'),
+            array('DomainException', '5.0', array(186, 221), '5.1'),
+            array('InvalidArgumentException', '5.0', array(222, 255), '5.1'),
+            array('LengthException', '5.0', array(195, 223), '5.1'),
+            array('LogicException', '5.0', array(224, 255), '5.1'),
+            array('OutOfBoundsException', '5.0', array(225, 255), '5.1'),
+            array('OutOfRangeException', '5.0', array(226, 255), '5.1'),
+            array('OverflowException', '5.0', array(196, 227), '5.1'),
+            array('RangeException', '5.0', array(208, 228), '5.1'),
+            array('RuntimeException', '5.0', array(229, 255), '5.1'),
+            array('UnderflowException', '5.0', array(197, 230), '5.1'),
+            array('UnexpectedValueException', '5.0', array(191, 231), '5.1'),
+            array('DOMException', '5.0', array(232, 260), '5.1'),
+            array('mysqli_sql_exception', '5.0', array(202, 233), '5.1'),
+            array('PDOException', '5.0', array(198, 234), '5.1'),
+            array('ReflectionException', '5.0', array(187, 235), '5.1'),
+            array('SoapFault', '5.0', array(236), '5.1'),
+            array('PharException', '5.2', array(237), '5.3'),
+            array('SNMPException', '5.3', array(238), '5.4'),
+            array('IntlException', '5.5.0', array(239), '5.6', '5.5'),
+            array('Error', '5.6', array(214, 240), '7.0'),
+            array('ArithmeticError', '5.6', array(209, 241), '7.0'),
+            array('AssertionError', '5.6', array(242), '7.0'),
+            array('DivisionByZeroError', '5.6', array(203, 243), '7.0'),
+            array('ParseError', '5.6', array(244), '7.0'),
+            array('TypeError', '5.6', array(245), '7.0'),
+            array('UI\Exception\InvalidArgumentException', '5.6', array(192, 210, 246), '7.0'),
+            array('UI\Exception\RuntimeException', '5.6', array(188, 199, 247), '7.0'),
         );
     }
 
@@ -138,6 +182,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array(169),
             array(170),
             array(181),
+            array(265),
         );
     }
 

--- a/Tests/sniff-examples/new_classes.php
+++ b/Tests/sniff-examples/new_classes.php
@@ -179,3 +179,88 @@ function ( MultipleIterator $a ) {}
 function(\RecursiveCallbackFilterIterator $a) {}
 function ( ?SNMP $a ) {}
 function(myNameSpace\IntlTimeZone $a) {} // Ok.
+
+/*
+ * Exception classes should be caught too.
+ */
+throw new DomainException($msg);
+throw new ReflectionException($msg);
+throw new UI\Exception\RuntimeException($msg);
+
+class MyException extends Exception {}
+class MyException extends UnexpectedValueException {}
+class MyException extends UI\Exception\InvalidArgumentException {}
+
+ErrorException::static_method();
+LengthException::static_method();
+OverflowException::CLASS_CONSTANT;
+UnderflowException::CLASS_CONSTANT;
+PDOException::$static_property;
+UI\Exception\RuntimeException::$static_property;
+
+new class extends BadFunctionCallException {}
+new class extends mysqli_sql_exception {}
+new class extends DivisionByZeroError {}
+
+class MyExceptionHandler {
+    // New Exceptions as typehints.
+    function ExceptionTypeHint( BadMethodCallException $e ) {}
+    function ExceptionTypeHint( RangeException $e ) {}
+    function ExceptionTypeHint( ArithmeticError $e ) {}
+    function ExceptionTypeHint( UI\Exception\InvalidArgumentException $e ) {}
+}
+
+// New exceptions as type hints in anonymous functions.
+function ( Error $e ) {}
+
+try {
+} catch (Exception $e) {
+} catch (ErrorException $e) {
+} catch (BadFunctionCallException $e) {
+} catch (BadMethodCallException $e) {
+} catch (DomainException $e) {
+} catch (InvalidArgumentException $e) {
+} catch (LengthException $e) {
+} catch (LogicException $e) {
+} catch (OutOfBoundsException $e) {
+} catch (OutOfRangeException $e) {
+} catch (OverflowException $e) {
+} catch (RangeException $e) {
+} catch (RuntimeException $e) {
+} catch (UnderflowException $e) {
+} catch (UnexpectedValueException $e) {
+} catch (DOMException $e) {
+} catch (mysqli_sql_exception $e) {
+} catch (PDOException $e) {
+} catch (ReflectionException $e) {
+} catch (SoapFault $e) {
+} catch (PharException $e) {
+} catch (SNMPException $e) {
+} catch (IntlException $e) {
+} catch (Error $e) {
+} catch (ArithmeticError $e) {
+} catch (AssertionError $e) {
+} catch (DivisionByZeroError $e) {
+} catch (ParseError $e) {
+} catch (TypeError $e) {
+} catch (UI\Exception\InvalidArgumentException $e) {
+} catch (UI\Exception\RuntimeException $e) {
+}
+
+
+
+
+// Multi-catch.
+try {
+} catch (InvalidArgumentException | \LogicException | OutOfBoundsException | \OutOfRangeException | RuntimeException $e) {
+}
+
+// Global namespace, should throw error.
+try {
+} catch (\DOMException $e) {
+}
+
+// Namespaced, should be ignored.
+try {
+} catch (\My\Except\DOMException $e) {
+}


### PR DESCRIPTION
* Add Exception classes to the new classes sniff to be sniffed for using all the existing checks
* Add checking for use of new Exception classes in catch statements. Includes support for multi-catch statements (PHP 7.1)

Includes extensive unit tests.