### PR TITLE
ForbiddenNames: always report on `use` statements using `const` or `function`

### DIFF
--- a/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -214,7 +214,6 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_S
          */
         else if ($tokens[$stackPtr]['type'] === 'T_USE'
             && isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === true
-            && $this->supportsAbove('5.6')
         ) {
             $maybeUseNext = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext !== false && $this->isEndOfUseStatement($tokens[$maybeUseNext]) === false) {

--- a/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -44,8 +44,8 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
 
         // Set the testVersion to the highest PHP version encountered in the
         // PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff::$invalidNames list
-        // to catch all errors + beyond `use function/const` exception.
-        $file = $this->sniffFile($filename, '5.6');
+        // to catch all errors.
+        $file = $this->sniffFile($filename, '5.5');
 
         $this->assertNoViolation($file, 2);
 
@@ -104,16 +104,6 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
         $this->assertNoViolation($file);
     }
 
-    /**
-     * testCorrectUsageUseFunctionConst
-     *
-     * @return void
-     */
-    public function testCorrectUsageUseFunctionConst()
-    {
-        $file = $this->sniffFile('sniff-examples/forbidden_names_correct_usage_use.php', '5.6');
-        $this->assertNoViolation($file);
-    }
 
     /**
      * testNotForbiddenInPHP7

--- a/Tests/sniff-examples/forbidden_names_correct_usage.php
+++ b/Tests/sniff-examples/forbidden_names_correct_usage.php
@@ -161,3 +161,10 @@ $a = new class {}
 // Nested namespace declarations.
 namespace Foo\Bar\Baz;
 namespace Foo\Bar\Baz {}
+
+/**
+ * Issue #124/#126: Valid use statements with function or const (PHP 5.6+).
+ */
+use function MyFunctionName;
+use function MyFunctionName as func;
+use const MyCONSTANT;

--- a/Tests/sniff-examples/forbidden_names_correct_usage_use.php
+++ b/Tests/sniff-examples/forbidden_names_correct_usage_use.php
@@ -1,8 +1,0 @@
-<?php
-
-/**
- * Issue #24/#126: Valid use statements with function or const (PHP 5.6+).
- */
-use function MyFunctionName;
-use function MyFunctionName as func;
-use const MyCONSTANT;


### PR DESCRIPTION
The `ForbiddenNames` sniff should report on use of reserved keywords in `use const ...` and `use function ..` statements independently of the `testVersion` which was set.

Reporting on the use of those constructs for PHP versions in which they are not available is covered by the separate `NewUseConstFunction` sniff.