### PR TITLE
Fix the build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,52 +9,52 @@ matrix:
     - php: 5.2
       env: PHPCS_VERSION="1.5.6"
     - php: 5.2
-      env: PHPCS_VERSION="master"
+      env: PHPCS_VERSION="2.9"
 
     - php: 5.3
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.3
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
 
     - php: 5.4
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.4
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
 
     - php: 5.5
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 5.5
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
     - php: 5.5
-      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
 
     - php: 5.6
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 5.6
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
     - php: 5.6
-      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
 
     - php: 7.0
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 7.0
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
     - php: 7.0
-      env: PHPCS_VERSION="dev-master" SNIFF=1 COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.9.x-dev" SNIFF=1 COVERALLS_VERSION="dev-master"
 
     - php: 7.1
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 7.1
-      env: PHPCS_VERSION=">=2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
     - php: 7.1
-      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
 
     - php: nightly
       env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: nightly
-      env: PHPCS_VERSION=">=2.0"
+      env: PHPCS_VERSION=">=2.0,<3.0"
     - php: nightly
-      env: PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.9.x-dev"
 
   allow_failures:
     # Allow failures for unstable builds.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The sniffs are designed to give the same results regardless of which PHP version
 
 PHP CodeSniffer 1.5.1 is required for 90% of the sniffs, PHPCS 2.6 or later is required for full support, notices may be thrown on older versions.
 
+The PHPCompatibility standard is currently not compatible with PHPCS 3.0, though the [intention is to fix this](https://github.com/wimg/PHPCompatibility/issues/367) in the near future.
+
 Thank you
 ---------
 Thanks to all contributors for their valuable contributions.


### PR DESCRIPTION
As PHPCS 3.0 has been released and become the `master` branch, the builds will fail.

This PR changes the "high" branch to build against to `2.9.x-dev`/`2.9` which is the patch branch for the 2.x series and limits the "last stable" build to the 2.x series.

It also adds a note to the Readme annotating that PHPCS 3.x is currently not (yet) supported.