### PR TITLE
Minor refactor of the `NewConstVisibility` sniff.

### DIFF
--- a/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -91,6 +91,8 @@ class NewConstVisibilitySniffTest extends BaseSniffTest
             array(7),
             array(17),
             array(30),
+            array(44),
+            array(48),
         );
     }
 

--- a/Tests/sniff-examples/new_const_visibility.php
+++ b/Tests/sniff-examples/new_const_visibility.php
@@ -34,3 +34,17 @@ $a = new class
     protected const PROTECTED_CONST = 3;
     private const PRIVATE_CONST = 4;
 }
+
+/*
+ * Test against some false positives.
+ *
+ * Constants defined in the global namespace can not have visibility indicators,
+ * but this is outside the scope of this library. Would cause a parse error anyway.
+ */
+public const GLOBAL_CONSTANT = 'not valid';
+
+class NotAClassConstant {
+    public function something() {
+        public const GLOBAL_CONSTANT = 'not valid';
+    }
+}


### PR DESCRIPTION
_Part of a review to see which sniffs would benefit from using the new `isClassProperty()`  and `isClassConstant()` methods as introduced in #391 and #393._

* Use the new `isClassConstant()` utility method as introduced in #391.
* Bow out early if not testing for PHP < 7.1 (was originally done later as some "debug" checks were slated to go in and didn't)

Includes additional unit tests.