### PR TITLE
:fire: Hot fix: using unbounded ranges in `testVersion` only showed first error

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -124,19 +124,17 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 }
             }
             elseif (preg_match('/^\d+\.\d+-$/', $testVersion)) {
-                $testVersion = substr($testVersion, 0, -1);
                 // If no upper-limit is set, we set the max version to 99.9.
                 // This is *probably* safe... :-)
-                $arrTestVersions[$testVersion] = array($testVersion, '99.9');
+                $arrTestVersions[$testVersion] = array(substr($testVersion, 0, -1), '99.9');
             }
             elseif (preg_match('/^-\d+\.\d+$/', $testVersion)) {
-                $testVersion = substr($testVersion, 1);
                 // If no lower-limit is set, we set the min version to 4.0.
                 // Whilst development focuses on PHP 5 and above, we also accept
                 // sniffs for PHP 4, so we include that as the minimum.
                 // (It makes no sense to support PHP 3 as this was effectively a
                 // different language).
-                $arrTestVersions[$testVersion] = array('4.0', $testVersion);
+                $arrTestVersions[$testVersion] = array('4.0', substr($testVersion, 1));
             }
             elseif (!$testVersion == '') {
                 trigger_error("Invalid testVersion setting: '" . $testVersion

--- a/Tests/BaseClass/FunctionsTest.php
+++ b/Tests/BaseClass/FunctionsTest.php
@@ -74,6 +74,9 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
 
+		// Verify that the caching of the function results is working correctly.
+        $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
+
         // Clean up / reset the value.
         PHP_CodeSniffer::setConfigData('testVersion', null, true);
     }


### PR DESCRIPTION
The overwriting of `$testVersion` within the function created a second entry with `array(null,null)` as value. This in effect broke the function result caching.

This resulted in the very first sniff calling the `supportsBelow()` method to report an error, but any subsequent calls to `supportBelow()` - even from the same sniff - would fail causing errors not to be reported.

Includes unit test to safeguard against this in the future.

Related to #371 and #142. /cc @MarkMaldaba 