### PR TITLE
Tests: Skip tests involving traits in combi with the right PHPCS version

### DIFF
--- a/Tests/BaseClass/IsClassPropertyTest.php
+++ b/Tests/BaseClass/IsClassPropertyTest.php
@@ -42,8 +42,8 @@ class BaseClass_isClassPropertyTest extends BaseClass_MethodTestFrame
      */
     public static function setUpBeforeClass()
     {
-        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -65,7 +65,7 @@ class BaseClass_isClassPropertyTest extends BaseClass_MethodTestFrame
     public function testIsClassProperty($commentString, $expected, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 

--- a/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
+++ b/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
@@ -38,8 +38,8 @@ class NewHeredocInitializeSniffTest extends BaseSniffTest
      */
     public static function setUpBeforeClass()
     {
-        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -61,7 +61,7 @@ class NewHeredocInitializeSniffTest extends BaseSniffTest
     public function testHeredocInitialize($line, $type, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped('Traits are not recognized on PHPCS 1.5.x in combination with PHP < 5.4');
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 

--- a/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -35,8 +35,8 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
      */
     public static function setUpBeforeClass()
     {
-        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -89,7 +89,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
     public function testNewMagicMethod($methodName, $lastVersionBefore, $lines, $okVersion, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 
@@ -149,7 +149,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
     public function testChangedToStringMethod($line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 

--- a/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -35,8 +35,8 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
      */
     public static function setUpBeforeClass()
     {
-        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -89,7 +89,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public function testWrongMethodVisibility($methodName, $desiredVisibility, $testVisibility, $line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 
@@ -176,7 +176,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public function testWrongStaticMethod($methodName, $line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 
@@ -252,7 +252,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public function testWrongNonStaticMethod($methodName, $line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 
@@ -309,7 +309,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public function testNoFalsePositives($line, $isTrait = false)
     {
         if ($isTrait === true && self::$recognizesTraits === false) {
-            $this->markTestSkipped();
+            $this->markTestSkipped('Traits are not recognized on PHPCS < 2.4.0 in combination with PHP < 5.4');
             return;
         }
 


### PR DESCRIPTION
Traits are only recognized when either PHP > 5.3 or PHPCS > 2.3.4.

Skip the tests for the correct version and add proper skip annotation.