### PR TITLE
NewClasses sniff: Improve support for anonymous classes.

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -785,7 +785,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             return '';
         }
 
-        $extends = $phpcsFile->findExtendedClassName($stackPtr);
+        $extends = $this->findExtendedClassName($phpcsFile, $stackPtr);
         if (empty($extends) || is_string($extends) === false) {
             return '';
         }
@@ -1444,6 +1444,76 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         return $vars;
 
     }//end getMethodParameters()
+
+
+    /**
+     * Returns the name of the class that the specified class extends.
+     *
+     * Returns FALSE on error or if there is no extended class name.
+     *
+     * {@internal Duplicate of same method as contained in the `PHP_CodeSniffer_File`
+     * class, but with some improvements which have been introduced in
+     * PHPCS 2.8.0.
+     * {@link https://github.com/squizlabs/PHP_CodeSniffer/commit/0011d448119d4c568e3ac1f825ae78815bf2cc34}.
+     *
+     * Once the minimum supported PHPCS version for this standard goes beyond
+     * that, this method can be removed and calls to it replaced with
+     * `$phpcsFile->findExtendedClassName($stackPtr)` calls.
+     *
+     * Last synced with PHPCS version: PHPCS 2.9.0 at commit b940fb7dca8c2a37f0514161b495363e5b36d879}}
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                  $stackPtr  The position in the stack of the
+     *                                        class token.
+     *
+     * @return string|false
+     */
+    public function findExtendedClassName(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if (version_compare(PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+            return $phpcsFile->findExtendedClassName($stackPtr);
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        // Check for the existence of the token.
+        if (isset($tokens[$stackPtr]) === false) {
+            return false;
+        }
+
+        if ($tokens[$stackPtr]['code'] !== T_CLASS
+            && $tokens[$stackPtr]['code'] !== T_ANON_CLASS
+        ) {
+            return false;
+        }
+
+        if (isset($tokens[$stackPtr]['scope_closer']) === false) {
+            return false;
+        }
+
+        $classCloserIndex = $tokens[$stackPtr]['scope_closer'];
+        $extendsIndex     = $phpcsFile->findNext(T_EXTENDS, $stackPtr, $classCloserIndex);
+        if (false === $extendsIndex) {
+            return false;
+        }
+
+        $find = array(
+                 T_NS_SEPARATOR,
+                 T_STRING,
+                 T_WHITESPACE,
+                );
+
+        $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), $classCloserIndex, true);
+        $name = $phpcsFile->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));
+        $name = trim($name);
+
+        if ($name === '') {
+            return false;
+        }
+
+        return $name;
+
+    }//end findExtendedClassName()
 
 
     /**


### PR DESCRIPTION
Anonymous classes which extend a "new" class would not be recognized correctly in combination with PHPCS < 2.8.0 and > 2.4.0.

To fix this we need to emulate the upstream `findExtendedClassName()` method.

Fixes #334