### PR TITLE
:bug: Fix issue 436 - remove incorrect check for class being defined in the same file

### DIFF
--- a/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -71,49 +71,23 @@ class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatib
             return;
         }
 
-        $classNameToken = $phpcsFile->findPrevious(T_STRING, ($prevToken - 1), null, false, null, true);
 
         // Useless if not in a namespace.
-        $hasNamespace = false;
-        if ($classNameToken !== false) {
-            $namespace = $this->determineNamespace($phpcsFile, $classNameToken);
-            if (empty($namespace) === false) {
-                $hasNamespace = true;
-            }
-        }
-
-        if ($hasNamespace === false) {
-            $phpcsFile->addWarning(
-                'Using the magic class constant ClassName::class is only useful in combination with a namespaced class',
-                $stackPtr,
-                'NotInNamespace'
-            );
-        }
-
-
-        // Is the magic constant used in a file which actually contains the referenced class ?
+        $classNameToken = $phpcsFile->findPrevious(T_STRING, ($prevToken - 1), null, false, null, true);
         if ($classNameToken === false) {
             return;
         }
 
-        $targetClassName = $tokens[$classNameToken]['content'];
-        $classPtr        = $stackPtr;
-        while ($classPtr > 0) {
-            $classPtr = $phpcsFile->findPrevious(T_CLASS, ($classPtr - 1));
-
-            if ($classPtr !== false) {
-                $className = $phpcsFile->getDeclarationName($classPtr);
-                if (empty($className) === false && $className === $targetClassName) {
-                    return;
-                }
-            }
+        $namespace = $this->determineNamespace($phpcsFile, $classNameToken);
+        if (empty($namespace) === false) {
+            return;
         }
 
-        // Still here? In that case, the magic constant is used in a file which doesn't contain the target class.
         $phpcsFile->addWarning(
-            'The magic class constant ClassName::class can only be used in the same file as where the class is defined',
+            'Using the magic class constant ClassName::class is only useful in combination with a namespaced class',
             $stackPtr,
-            'FileDoesNotContainClass'
+            'NotInNamespace'
         );
     }
+
 }

--- a/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
@@ -105,7 +105,6 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
         $this->assertWarning($file, 24, 'Using the magic class constant ClassName::class is only useful in combination with a namespaced class');
-        $this->assertWarning($file, 24, 'The magic class constant ClassName::class can only be used in the same file as where the class is defined');
     }
 
 

--- a/Tests/sniff-examples/new_magic_class_constant.php
+++ b/Tests/sniff-examples/new_magic_class_constant.php
@@ -21,4 +21,4 @@ echo bar::classProp; // Not the keyword.
 /*
  * Invalid use check.
  */
-echo foobar::class; // Invalid: Used outside of a namespace + class foobar does not exist in this file.
+echo foobar::class; // Invalid: Used outside of a namespace.


### PR DESCRIPTION
One of the additional "debug" type warnings was incorrect. I've chosen to remove it completely from the sniff and the unit tests and have simplified the code of the remaining "debug" check.

Fixes #436 

@wimg Not sure which release this should go into as I believe the next release is intended to be one which only fixes the Composer issue ?