### PR TITLE
Revert "NewMagicClassConstant: Add two additional checks…

### DIFF
--- a/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -45,6 +45,10 @@ class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatib
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
+        if ($this->supportsBelow('5.4') === false) {
+            return;
+        }
+
         $tokens = $phpcsFile->getTokens();
 
         if (strtolower($tokens[$stackPtr]['content']) !== 'class') {
@@ -56,64 +60,10 @@ class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatib
             return;
         }
 
-        if ($this->supportsBelow('5.4')) {
-            $phpcsFile->addError(
-                'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
-                $stackPtr,
-                'Found'
-            );
-        }
-
-        /*
-         * Check against invalid use of the magic `::class` constant.
-         */
-        if ($this->supportsAbove('5.5') === false) {
-            return;
-        }
-
-        $classNameToken = $phpcsFile->findPrevious(T_STRING, ($prevToken - 1), null, false, null, true);
-
-        // Useless if not in a namespace.
-        $hasNamespace = false;
-        if ($classNameToken !== false) {
-            $namespace = $this->determineNamespace($phpcsFile, $classNameToken);
-            if (empty($namespace) === false) {
-                $hasNamespace = true;
-            }
-        }
-
-        if ($hasNamespace === false) {
-            $phpcsFile->addWarning(
-                'Using the magic class constant ClassName::class is only useful in combination with a namespaced class',
-                $stackPtr,
-                'NotInNamespace'
-            );
-        }
-
-
-        // Is the magic constant used in a file which actually contains the referenced class ?
-        if ($classNameToken === false) {
-            return;
-        }
-
-        $targetClassName = $tokens[$classNameToken]['content'];
-        $classPtr        = $stackPtr;
-        while ($classPtr > 0) {
-            $classPtr = $phpcsFile->findPrevious(T_CLASS, ($classPtr - 1));
-
-            if ($classPtr !== false) {
-                $className = $phpcsFile->getDeclarationName($classPtr);
-                if (empty($className) === false && $className === $targetClassName) {
-                    return;
-                }
-            }
-        }
-
-        // Still here? In that case, the magic constant is used in a file which doesn't contain the target class.
-        $phpcsFile->addWarning(
-            'The magic class constant ClassName::class can only be used in the same file as where the class is defined',
+        $phpcsFile->addError(
+            'The magic class constant ClassName::class was not available in PHP 5.4 or earlier',
             $stackPtr,
-            'FileDoesNotContainClass'
+            'Found'
         );
     }
 }

--- a/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
+++ b/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
@@ -27,23 +27,14 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
      *
      * @dataProvider dataNewMagicClassConstant
      *
-     * @param int  $line            The line number.
-     * @param bool $testNoViolation Whether or not to run the noViolation test.
+     * @param int $line The line number.
      *
      * @return void
      */
-    public function testNewMagicClassConstant($line, $testNoViolation = true)
+    public function testNewMagicClassConstant($line)
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertError($file, $line, 'The magic class constant ClassName::class was not available in PHP 5.4 or earlier');
-
-        if ($testNoViolation === true) {
-            // Namespace detection does not work on PHP 5.2.
-            if (version_compare(phpversion(), '5.3.0', '>=')) {
-                $file = $this->sniffFile(self::TEST_FILE, '5.5');
-                $this->assertNoViolation($file, $line);
-            }
-        }
     }
 
     /**
@@ -58,7 +49,6 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
         return array(
             array(6),
             array(12),
-            array(24, false), // Line which also tests the incorrect use warnings.
         );
     }
 
@@ -97,57 +87,20 @@ class NewMagicClassConstantSniffTest extends BaseSniffTest
 
 
     /**
-     * testInvalidUse
+     * Verify no notices are thrown at all.
      *
      * @return void
      */
-    public function testInvalidUse()
+    public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertWarning($file, 24, 'Using the magic class constant ClassName::class is only useful in combination with a namespaced class');
-        $this->assertWarning($file, 24, 'The magic class constant ClassName::class can only be used in the same file as where the class is defined');
-    }
-
-
-    /**
-     * testNoFalsePositivesInvalidUse
-     *
-     * @dataProvider dataNoFalsePositivesInvalidUse
-     *
-     * @param int $line The line number.
-     *
-     * @return void
-     */
-    public function testNoFalsePositivesInvalidUse($line)
-    {
-        if (version_compare(phpversion(), '5.3.0', '<') === true) {
-            $this->markTestSkipped('PHP 5.2 does not recognize namespaces.');
+        // Namespace detection does not work on PHP 5.2.
+        if (version_compare(phpversion(), '5.3.0', '>=') === false) {
+            $this->markTestSkipped();
             return;
         }
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
-        $this->assertNoViolation($file, $line);
+        $this->assertNoViolation($file);
     }
-
-    /**
-     * Data provider.
-     *
-     * @see testNoFalsePositivesInvalidUse()
-     *
-     * @return array
-     */
-    public function dataNoFalsePositivesInvalidUse()
-    {
-        return array(
-            array(6),
-            array(12),
-        );
-    }
-
-
-    /*
-     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings
-     * on invalid use of the constant in PHP 5.5+ versions.
-     */
 
 }

--- a/Tests/sniff-examples/new_magic_class_constant.php
+++ b/Tests/sniff-examples/new_magic_class_constant.php
@@ -15,10 +15,5 @@ namespace MyNameSpace {
 /*
  * False positives check.
  */
-new class {} // Anonymous class, not the keyword.
 echo bar::classProp; // Not the keyword.
-
-/*
- * Invalid use check.
- */
-echo foobar::class; // Invalid: Used outside of a namespace + class foobar does not exist in this file.
+new class {} // Anonymous class, not the keyword.


### PR DESCRIPTION
... against invalid usage of the magic `::class` constant."

This reverts commit efe7a83f3c206c16a01924061a67a2e0abcc6468.

Fixes #436
Fixes https://github.com/wimg/PHPCompatibility/pull/403#issuecomment-299899902