### PR TITLE
Various small fixes

### DIFF
--- a/Sniff.php
+++ b/Sniff.php
@@ -509,7 +509,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         $nextComma  = $opener;
         $paramStart = $opener + 1;
         $cnt        = 1;
-        while ($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY), $nextComma + 1, $closer + 1)) {
+        while (($nextComma = $phpcsFile->findNext(array(T_COMMA, $tokens[$closer]['code'], T_OPEN_SHORT_ARRAY), $nextComma + 1, $closer + 1)) !== false) {
             // Ignore anything within short array definition brackets.
             if ($tokens[$nextComma]['type'] === 'T_OPEN_SHORT_ARRAY'
                 && (isset($tokens[$nextComma]['bracket_opener'])
@@ -836,11 +836,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
             T_WHITESPACE,
         );
 
-        $start = ($phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true) + 1);
-        if ($start === false) {
+        $start = $phpcsFile->findPrevious($find, $stackPtr - 1, null, true, null, true);
+        if ($start === false || isset($tokens[($start + 1)]) === false) {
             return '';
         }
 
+        $start     = ($start + 1);
         $className = $phpcsFile->getTokensAsString($start, ($stackPtr - $start));
         $className = trim($className);
 

--- a/Sniff.php
+++ b/Sniff.php
@@ -115,8 +115,8 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                         "Invalid range in testVersion setting: '" . $testVersion . "'",
                         E_USER_WARNING
                     );
-                }
-                else {
+
+                } else {
                     $arrTestVersions[$testVersion] = array($matches[1], $matches[2]);
                 }
 
@@ -578,8 +578,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
         if (isset($parameters[$paramOffset]) === false) {
             return false;
-        }
-        else {
+        } else {
             return $parameters[$paramOffset];
         }
     }
@@ -877,8 +876,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
         if ($namespace === '') {
             return '\\' . $name;
-        }
-        else {
+        } else {
             return '\\' . $namespace . '\\' . $name;
         }
     }
@@ -957,8 +955,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         // If we still haven't got a namespace, return an empty string.
         if ($namespace === false) {
             return '';
-        }
-        else {
+        } else {
             return $namespace;
         }
     }
@@ -1361,7 +1358,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                             break;
                         }
                     }
-    
+
                     if ($prevComma !== false) {
                         $nextEquals = false;
                         for ($t = $prevComma; $t < $i; $t++) {
@@ -1370,12 +1367,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                                 break;
                             }
                         }
-    
+
                         if ($nextEquals !== false) {
                             break;
                         }
                     }
-    
+
                     if ($defaultStart === null) {
                         $typeHint .= $tokens[$i]['content'];
                     }
@@ -1399,12 +1396,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                     if ($currVar === null) {
                         continue;
                     }
-    
+
                     $vars[$paramCount]            = array();
                     $vars[$paramCount]['token']   = $currVar;
                     $vars[$paramCount]['name']    = $tokens[$currVar]['content'];
                     $vars[$paramCount]['content'] = trim($phpcsFile->getTokensAsString($paramStart, ($i - $paramStart)));
-    
+
                     if ($defaultStart !== null) {
                         $vars[$paramCount]['default']
                             = trim($phpcsFile->getTokensAsString(
@@ -1412,12 +1409,12 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                                 ($i - $defaultStart)
                             ));
                     }
-    
+
                     $vars[$paramCount]['pass_by_reference'] = $passByReference;
                     $vars[$paramCount]['variable_length']   = $variableLength;
                     $vars[$paramCount]['type_hint']         = $typeHint;
                     $vars[$paramCount]['nullable_type']     = $nullableType;
-    
+
                     // Reset the vars, as we are about to process the next parameter.
                     $defaultStart    = null;
                     $paramStart      = ($i + 1);
@@ -1425,7 +1422,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                     $variableLength  = false;
                     $typeHint        = '';
                     $nullableType    = false;
-    
+
                     $paramCount++;
                     break;
                 case T_EQUAL:

--- a/Sniff.php
+++ b/Sniff.php
@@ -103,7 +103,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
 
         $testVersion = trim(PHP_CodeSniffer::getConfigData('testVersion'));
 
-        if (!isset($arrTestVersions[$testVersion]) && !empty($testVersion)) {
+        if (isset($arrTestVersions[$testVersion]) === false && empty($testVersion) === false) {
 
             $arrTestVersions[$testVersion] = array(null, null);
             if (preg_match('/^\d+\.\d+$/', $testVersion)) {
@@ -133,7 +133,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
                 // different language).
                 $arrTestVersions[$testVersion] = array('4.0', substr($testVersion, 1));
 
-            } elseif (!$testVersion == '') {
+            } elseif ($testVersion !== '') {
                 trigger_error(
                     "Invalid testVersion setting: '" . $testVersion . "'",
                     E_USER_WARNING
@@ -193,7 +193,7 @@ abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
         $testVersion = $this->getTestVersion();
         $testVersion = $testVersion[0];
 
-        if (!is_null($testVersion)
+        if (is_null($testVersion) === false
             && version_compare($testVersion, $phpVersion) <= 0
         ) {
             return true;

--- a/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -92,7 +92,7 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends P
 
             if ($funcNameLc === $classNameLc) {
                 $oldConstructorFound = true;
-                $oldConstructorPos   = $phpcsFile->findNext(T_STRING, $nextFunc);
+                $oldConstructorPos   = $nextFunc;
             }
 
             // If both have been found, no need to continue looping through the functions.

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -83,7 +83,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
         );
 
         if ($openBracket === false || $tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS
-           || isset($tokens[$openBracket]['parenthesis_closer']) === false
+            || isset($tokens[$openBracket]['parenthesis_closer']) === false
         ) {
             return;
         }
@@ -144,8 +144,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
 
             // Make sure the variable belongs directly to this function call
             // and is not inside a nested function call or array.
-            if (isset($tokens[$nextVariable]['nested_parenthesis']) === false ||
-               (count($tokens[$nextVariable]['nested_parenthesis']) !== $nestingLevel)
+            if (isset($tokens[$nextVariable]['nested_parenthesis']) === false
+                || (count($tokens[$nextVariable]['nested_parenthesis']) !== $nestingLevel)
             ) {
                 continue;
             }
@@ -216,8 +216,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
                         $searchStartToken,
                         true
                     );
-                    if ($tokens[$tokenBeforePlus]['code'] === T_DOUBLE_COLON ||
-                        $tokens[$tokenBeforePlus]['code'] === T_OBJECT_OPERATOR
+                    if ($tokens[$tokenBeforePlus]['code'] === T_DOUBLE_COLON
+                        || $tokens[$tokenBeforePlus]['code'] === T_OBJECT_OPERATOR
                     ) {
                         break;
                     }

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -123,7 +123,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
      * Determine whether a parameter is passed by reference.
      *
      * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param array                $parameter    Function parameter infor array.
+     * @param array                $parameter    Information on the current parameter
+     *                                           to be examined.
      * @param int                  $nestingLevel Target nesting level.
      *
      * @return bool

--- a/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -59,10 +59,8 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends 
         // within their definitions. For example: function myFunction...
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
-        $findTokens = array_merge(
-            PHP_CodeSniffer_Tokens::$emptyTokens,
-            array(T_BITWISE_AND)
-        );
+        $findTokens   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $findTokens[] = T_BITWISE_AND;
 
         $prevNonEmpty = $phpcsFile->findPrevious(
             $findTokens,

--- a/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
+++ b/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
@@ -72,7 +72,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenClosureUseVariableNamesSniff extends 
         }
 
         $closurePtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
-        if ($tokens[$closurePtr]['code'] !== T_CLOSURE) {
+        if ($closurePtr === false || $tokens[$closurePtr]['code'] !== T_CLOSURE) {
             return;
         }
 

--- a/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -76,6 +76,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPC
                 for ($cnt = $open + 1; $cnt < $close; $cnt++) {
                     if (isset($this->ignoreTokens[$tokens[$cnt]['code']]) === false) {
                         $error = false;
+                        break;
                     }
                 }
             }

--- a/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -71,7 +71,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff e
             $paramNames[] = strtolower($param['name']);
         }
 
-        if (count($paramNames) != count(array_unique($paramNames))) {
+        if (count($paramNames) !== count(array_unique($paramNames))) {
             $phpcsFile->addError(
                 'Functions can not have multiple parameters with the same name since PHP 7.0',
                 $stackPtr,

--- a/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -178,6 +178,9 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompa
                 $nameLc = strtolower($tokens[$nextNonEmpty]['content']);
             } elseif ($nextNonEmptyCode === T_STRING) {
                 $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_OPEN_CURLY_BRACKET), ($stackPtr + 1));
+                if ($endOfStatement === false) {
+                    return;
+                }
 
                 do {
                     $nextNonEmptyLc = strtolower($tokens[$nextNonEmpty]['content']);

--- a/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -126,7 +126,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends 
             }
         }
 
-        if ($isString) {
+        if ($isString === true) {
             $version = $this->targetedStringTokens[$tokenContentLc];
         } else {
             $version = $this->targetedTokens[$tokenCode];

--- a/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -57,7 +57,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff 
         $defaultToken = $stackPtr;
         $defaultCount = 0;
         $targetLevel  = $tokens[$stackPtr]['level'] + 1;
-        while ($defaultCount < 2 && $defaultToken = $phpcsFile->findNext(array(T_DEFAULT), $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) {
+        while ($defaultCount < 2 && ($defaultToken = $phpcsFile->findNext(array(T_DEFAULT), $defaultToken + 1, $tokens[$stackPtr]['scope_closer'])) !== false) {
             // Same level or one below (= two default cases after each other).
             if ($tokens[$defaultToken]['level'] === $targetLevel || $tokens[$defaultToken]['level'] === ($targetLevel + 1)) {
                 $defaultCount++;

--- a/Sniffs/PHP/NewClosureSniff.php
+++ b/Sniffs/PHP/NewClosureSniff.php
@@ -44,8 +44,6 @@ class PHPCompatibility_Sniffs_PHP_NewClosureSniff extends PHPCompatibility_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $tokens = $phpcsFile->getTokens();
-
         if ($this->supportsBelow('5.2')) {
             $phpcsFile->addError(
                 'Closures / anonymous functions are not available in PHP 5.2 or earlier',

--- a/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -285,7 +285,7 @@ class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompati
 
             $phpcsFile->addWarning($error, $stackPtr, $errorCode, $data);
         }
-    }// addErrorOnInvalidValue()
+    }// addWarningOnInvalidValue()
 
 
     /**

--- a/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -70,7 +70,7 @@ class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHP
                 T_INTERFACE,
             );
 
-            if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+            if (in_array($tokens[$prevToken]['code'], $ignore, true) === true) {
                 // Not a call to a PHP function or method.
                 return;
             }

--- a/Sniffs/PHP/NewHeredocInitializeSniff.php
+++ b/Sniffs/PHP/NewHeredocInitializeSniff.php
@@ -58,13 +58,13 @@ class PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff extends PHPCompatibi
         }
 
         $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($equalSign - 1), null, true, null, true);
-        if ($prevNonEmpty === false ||
-            ($tokens[$prevNonEmpty]['code'] !== T_VARIABLE && $tokens[$prevNonEmpty]['code'] !== T_STRING)
+        if ($prevNonEmpty === false
+            || ($tokens[$prevNonEmpty]['code'] !== T_VARIABLE
+                && $tokens[$prevNonEmpty]['code'] !== T_STRING)
         ) {
             // Not a variable or constant assignment.
             return;
         }
-
 
         switch ($tokens[$prevNonEmpty]['type']) {
             /*

--- a/Sniffs/PHP/NewInterfacesSniff.php
+++ b/Sniffs/PHP/NewInterfacesSniff.php
@@ -176,7 +176,7 @@ class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_Ab
 
         if (isset($tokens[$stackPtr]['scope_closer'])) {
             $checkMethods = true;
-            $scopeCloser = $tokens[$stackPtr]['scope_closer'];
+            $scopeCloser  = $tokens[$stackPtr]['scope_closer'];
         }
 
         foreach ($interfaces as $interface) {

--- a/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -157,7 +157,7 @@ class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatib
         // Translate older PHPCS token combis for new constructs to the actual construct.
         if (isset($this->newConstructs[$tokenType]) === false) {
             if (isset($this->PHPCSCompatTranslate[$tokenType])
-                && ((isset($this->PHPCSCompatTranslate[$tokenType]['before']) === true
+                && ((isset($this->PHPCSCompatTranslate[$tokenType]['before'], $tokens[$stackPtr - 1]) === true
                     && $tokens[$stackPtr - 1]['type'] === $this->PHPCSCompatTranslate[$tokenType]['before'])
                 || (isset($this->PHPCSCompatTranslate[$tokenType]['callback']) === true
                     && call_user_func(array($this, $this->PHPCSCompatTranslate[$tokenType]['callback']), $tokens, $stackPtr) === true))

--- a/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -98,7 +98,7 @@ class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPComp
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         // Get all parameters from method signature.
-        $paramNames   = $this->getMethodParameters($phpcsFile, $stackPtr);
+        $paramNames = $this->getMethodParameters($phpcsFile, $stackPtr);
         if (empty($paramNames)) {
             return;
         }

--- a/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -119,7 +119,7 @@ class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatib
         $functionPtr      = $stackPtr;
 
         // Find all the functions in this class or interface.
-        while ($functionToken = $phpcsFile->findNext(T_FUNCTION, $functionPtr, $classScopeCloser)) {
+        while (($functionToken = $phpcsFile->findNext(T_FUNCTION, $functionPtr, $classScopeCloser)) !== false) {
             /*
              * Get the scope closer for this function in order to know how
              * to advance to the next function.

--- a/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -166,7 +166,7 @@ class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibi
             $regexEndPos = strrpos($regex, $regexFirstChar);
         }
 
-        if ($regexEndPos) {
+        if ($regexEndPos !== false) {
             $modifiers = substr($regex, $regexEndPos + 1);
 
             if (strpos($modifiers, 'e') !== false) {

--- a/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -107,7 +107,7 @@ class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPComp
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis      = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {


### PR DESCRIPTION
* minor strict checking improvements
* minor code simplifications
* make sure that the output of `findNext()`/`findPrevious()` is always checked against `false` before use
* one `break` for efficiency
* remove one unused variable
* minor whitespace fixes
* minor documentation fixes

Partially based on Scrutinizer feedback, partially little things collected along the way which didn't fit into any other PR.