### PR TITLE
PHP7break:  Adjusted sniff to find numbers after break statements.

### DIFF
--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -83,6 +83,11 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
                 $errorType = 'zeroArgument';
                 break;
             }
+            } elseif ($tokens[$curToken]['type'] === 'T_LNUMBER') {
+                $errorType = 'variableArgument';
+                break;
+            }
+
         }
 
         if ($errorType !== '') {


### PR DESCRIPTION
Updated ForbiddenBreakContinueVariableArgumentsSniff to display a message if any line number is present after break statement.