### PR TITLE
Fix break/continue variable argument bug with closing tag after break/continue

### DIFF
--- a/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -63,7 +63,7 @@ class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff e
         }
 
         $tokens             = $phpcsFile->getTokens();
-        $nextSemicolonToken = $phpcsFile->findNext(T_SEMICOLON, ($stackPtr), null, false);
+        $nextSemicolonToken = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr), null, false);
         $errorType          = '';
         for ($curToken = $stackPtr + 1; $curToken < $nextSemicolonToken; $curToken++) {
             if ($tokens[$curToken]['type'] === 'T_STRING') {

--- a/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -69,6 +69,8 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
             array(102, self::ERROR_TYPE_VARIABLE),
             array(107, self::ERROR_TYPE_ZERO),
             array(111, self::ERROR_TYPE_ZERO),
+            array(118, self::ERROR_TYPE_ZERO),
+            array(122, self::ERROR_TYPE_VARIABLE),
         );
     }
 
@@ -108,6 +110,7 @@ class ForbiddenBreakContinueVariableArgumentsSniffTest extends BaseSniffTest
             array(39),
             array(44),
             array(48),
+            array(126),
         );
     }
 

--- a/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
+++ b/Tests/sniff-examples/forbidden_break_continue_variable_argument.php
@@ -112,3 +112,17 @@ for ($i = 0; $i < 20; $i++) {
         }
     }
 }
+
+// Issue #460 and some variations.
+for ($x=0;$x<5;$x++):
+    continue 0 ?> <?php
+endfor;
+
+for ($x=0;$x<5;$x++):
+    continue $x ?> <?php
+endfor;
+
+for ($x=0;$x<5;$x++):
+    continue ?> <?php
+    print 0;
+endfor;


### PR DESCRIPTION
Fixes #460 (at least it should).

Even though I have not been able to reproduce the issue, even with the code sample in the test file, this minor change should fix the issue even so.

----

~~NOTE: DO NOT MERGE AT THIS MOMENT! Rebased against the composer fix branch for testing.~~ Re-rebased on `master`, should be ok to merge now.