### PR TITLE
Add user-notice about the upcoming breaking changes in the 7.1.6 release

### DIFF
--- a/phpcs-bootstrap.php
+++ b/phpcs-bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * PHPCompatibility: Adds a (temporary) warning about the breaking changes
+ * in the upcoming 7.1.6 release of the PHPCompatibility standard.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+echo '
+
+===============================================================================
+IMPORTANT NOTICE: Please be advised that the upcoming 7.1.6 version of the
+                  PHPCompatibility standard will contain a breaking change.
+                  Please read the changelog carefully when you upgrade and
+                  follow the instructions contained therein to retain
+                  uninterupted service.
+                  Thank you for using PHPCompatibility!
+===============================================================================
+
+
+';

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -3,6 +3,8 @@
 <ruleset name="PHPCompatibility">
     <description>Coding Standard that checks for PHP version compatibility.</description>
 
+    <arg name="bootstrap" value="./phpcs-bootstrap.php"/>
+
     <!-- This rule covers checking for non-magic methods using __ prefix. -->
     <!-- Covers part 2 of issue 64: https://github.com/wimg/PHPCompatibility/issues/64 -->
     <rule ref="Generic.NamingConventions.CamelCapsFunctionName">


### PR DESCRIPTION
As discussed off GH, this would allow us to notify users about the upcoming 7.1.6 release and the breaking changes it contains.
It is not a perfect solution, but it's the most elegant I can think off.

The alternative would be to add a temporary sniff which will add this notification as a warning to the sniff results for the first file the sniff is run on. See #470.

The current PR will break the PHPCS run for anyone who runs the PHPCompatibility standard on PHPCS < 2.6.0.
The alternative would break the build for anyone who does not ignore warnings when using PHPCS in an automated build check, but also would not be seen by anyone who by default ignores warnings.

Not sure what is better....


Tested in PHP 5.3 - 7.1.
Tested on PHPCS 1.5.6-2.9.1 with varying results. Found working for PHPCS 2.6.0 and up. See screenshots below for the results.

### PHPCS 2.6.0 - 2.9.1
![phpcs-bootstrap-output-2 6](https://user-images.githubusercontent.com/663378/27614117-e58c1c7e-5b9f-11e7-93b3-8e232cb1a92f.png)

### PHPCS 2.5.x
![phpcs-bootstrap-output-2 5 x](https://user-images.githubusercontent.com/663378/27614120-eb586748-5b9f-11e7-8666-e0624792e844.png)

### PHPCS 2.0.0-2.4.0
![phpcs-bootstrap-output-2 4](https://user-images.githubusercontent.com/663378/27614124-f179bec4-5b9f-11e7-8743-7a353967dfcc.png)

### PHPCS 1.5.6: silently ignores the argument.
