### PR TITLE
Alternative: Add user-notice about upcoming breaking changes..

### DIFF
--- a/Sniffs/Upgrade/Release716Sniff.php
+++ b/Sniffs/Upgrade/Release716Sniff.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * PHPCompatibility_Sniffs_Upgrade_Release716Sniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+/**
+ * PHPCompatibility_Sniffs_Upgrade_Release716Sniff.
+ *
+ * Adds a temporary warning about the breaking changes in the upcoming 7.1.6
+ * release of the PHPCompatibility standard.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCompatibility_Sniffs_Upgrade_Release716Sniff extends PHPCompatibility_Sniff
+{
+    /**
+     * Keep track of whether the warning has been thrown yet.
+     *
+     * This warning should only be thrown once per run.
+     *
+     * @var bool
+     */
+    protected $thrown = false;
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_OPEN_TAG,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in the
+     *                                        stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        // Don't do anything if the warning has already been thrown once.
+        if ($this->thrown === true) {
+            return ($phpcsFile->numTokens + 1);
+        }
+
+        $phpcsFile->addWarning(
+            "IMPORTANT NOTICE:\nPlease be advised that the upcoming 7.1.6 version of the PHPCompatibility standard will contain a breaking change.\n\nPlease read the changelog carefully when you upgrade and follow the instructions contained therein to retain uninterupted service.\n\nThank you for using PHPCompatibility!",
+            0,
+            'BreakingChange'
+        );
+
+        $this->thrown = true;
+    }
+}

--- a/Sniffs/Upgrade/Release716Sniff.php
+++ b/Sniffs/Upgrade/Release716Sniff.php
@@ -57,7 +57,7 @@ class PHPCompatibility_Sniffs_Upgrade_Release716Sniff extends PHPCompatibility_S
         }
 
         $phpcsFile->addWarning(
-            "IMPORTANT NOTICE:\nPlease be advised that the upcoming 7.1.6 version of the PHPCompatibility standard will contain a breaking change.\n\nPlease read the changelog carefully when you upgrade and follow the instructions contained therein to retain uninterupted service.\n\nThank you for using PHPCompatibility!",
+            "IMPORTANT NOTICE:\nPlease be advised that the upcoming 7.1.6 version of the PHPCompatibility standard will contain a breaking change.\n\nPlease read the changelog carefully when you upgrade and follow the instructions contained therein to retain uninterupted service.\n\nTo disable this notice, add `--exclude=PHPCompatibility.Upgrade.Release716` to your command.\n\nThank you for using PHPCompatibility!",
             0,
             'BreakingChange'
         );

--- a/Tests/Sniffs/Upgrade/Release716SniffTest.php
+++ b/Tests/Sniffs/Upgrade/Release716SniffTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Temporary warning about the upcoming 7.1.6 release.
+ *
+ * @package PHPCompatibility
+ */
+
+
+/**
+ * Temporary warning about the upcoming 7.1.6 release.
+ *
+ * @group upgrade
+ *
+ * @covers PHPCompatibility_Sniffs_Upgrade_Release716Sniff
+ *
+ * @uses    BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class Release716SniffTest extends BaseSniffTest
+{
+    /**
+     * testUpgradeNotice
+     *
+     * Ensures that the upgrade notice is only thrown for the first file.
+     *
+     * @return void
+     */
+    public function testUpgradeNotice()
+    {
+        $file = $this->sniffFile('sniff-examples/forbidden_closure_use_variable_names.php');
+        $this->assertWarning($file, 1, 'IMPORTANT NOTICE:');
+
+        $file = $this->sniffFile('sniff-examples/empty_non_variable.php');
+        $this->assertNoViolation($file, 1);
+    }
+
+    /**
+     * Get the sniff code for the current sniff being tested.
+     *
+     * @return string
+     */
+    protected function getSniffCode()
+    {
+        return self::STANDARD_NAME . '.Upgrade.' . str_replace('SniffTest', '', get_class($this));
+    }
+}


### PR DESCRIPTION
.. in the 7.1.6 release

The "warning on first file" alternative for PR #469.

A choice should be made between these solutions. Only one of the two should be accepted (if at all).