### PR TITLE
DeprecatedNewReference sniff: minor improvement for accuracy

### DIFF
--- a/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -47,22 +47,27 @@ class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompati
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.3')) {
-            $tokens = $phpcsFile->getTokens();
-            if ($tokens[$stackPtr - 1]['type'] == 'T_BITWISE_AND' || $tokens[$stackPtr - 2]['type'] == 'T_BITWISE_AND') {
-                $error     = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
-                $isError   = false;
-                $errorCode = 'Deprecated';
-
-                if ($this->supportsAbove('7.0') === true) {
-                    $error    .= ' and forbidden in PHP 7.0';
-                    $isError   = true;
-                    $errorCode = 'Forbidden';
-                }
-
-                $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
-            }
+        if ($this->supportsAbove('5.3') === false) {
+            return;
         }
+
+        $tokens = $phpcsFile->getTokens();
+        $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['type'] !== 'T_BITWISE_AND') {
+            return;
+        }
+
+        $error     = 'Assigning the return value of new by reference is deprecated in PHP 5.3';
+        $isError   = false;
+        $errorCode = 'Deprecated';
+
+        if ($this->supportsAbove('7.0') === true) {
+            $error    .= ' and forbidden in PHP 7.0';
+            $isError   = true;
+            $errorCode = 'Forbidden';
+        }
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);
 
     }//end process()
 

--- a/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -53,6 +53,8 @@ class DeprecatedNewReferenceSniffTest extends BaseSniffTest
         return array(
             array(9),
             array(10),
+            array(11),
+            array(12),
         );
     }
 

--- a/Tests/sniff-examples/deprecated_new_reference.php
+++ b/Tests/sniff-examples/deprecated_new_reference.php
@@ -8,3 +8,5 @@ class Foobar
 $foobar = new Foobar();
 $foobar2 = &new Foobar();
 $foobar3 = & new Foobar();
+$foobar4 =& /* reference */ new Foobar();
+$foobar5 = &                new Foobar();


### PR DESCRIPTION
The sniff was presuming a certain code style, while an assignment might be aligned differently depending on the project code style.

This fixes that.