### PR TITLE
Move Forbidden names test file generator script to `/bin` directory

### DIFF
--- a/bin/generate-forbidden-names-test-files
+++ b/bin/generate-forbidden-names-test-files
@@ -1,13 +1,12 @@
 #!/usr/bin/env php
 <?php
 /**
- * This script is used to generate the test specimens for the forbidden-names 
- * test case.
+ * This script is used to generate the test case specimens for the forbidden-names Sniff.
  *
  * @package PHPCompatibility
  */
 
-// This array is pulled from the ForbiddenNamesSniff.php
+// This array is pulled from PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
 $invalidNames = array(
     'abstract' => '5.0',
     'and' => 'all',
@@ -96,7 +95,11 @@ $tests = array(
     'interface-extends' => function($name) { return "interface Foobar extends $name {}\n"; },
 );
 
-$path = realpath(__DIR__) . DIRECTORY_SEPARATOR . 'forbidden-names';
+$path = realpath(dirname(__DIR__))
+    . DIRECTORY_SEPARATOR . 'PHPCompatibility'
+    . DIRECTORY_SEPARATOR . 'Tests'
+    . DIRECTORY_SEPARATOR . 'sniff-examples'
+    . DIRECTORY_SEPARATOR . 'forbidden-names';
 
 foreach ($tests as $name => $callback) {
     $filename = $path . DIRECTORY_SEPARATOR . $name . ".php";


### PR DESCRIPTION
It always seemed kind of hidden and misplaced in the `sniff-examples` directory.