### PR TITLE
Fix file encoding

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
+++ b/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
@@ -347,7 +347,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
             array('dir_name', 'dir_name'), // No change.
             array('soap.wsdl_cache', 'soap_wsdl_cache'), // No dot.
             array('arbitrary-string with space', 'arbitrary_string_with_space'), // No dashes, no spaces.
-            array('^%*&%*€éáø', '__________'), // No non alpha-numeric characters.
+            array('^%*&%*â‚¬Ã ?', '____________'), // No non alpha-numeric characters.
         );
     }
 


### PR DESCRIPTION
The default file encoding changes in PHPCS 3.0 to utf-8. This test file was not correctly encoded to be compatible with that.