### PR TITLE
PHPCS 3.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,66 +2,59 @@ sudo: false
 
 language: php
 
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+env:
+  # `master`, i.e PHPCS 3.x.
+  - PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
+  # PHPCS 1.5.x
+  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+
 matrix:
   fast_finish: true
   include:
-
-    - php: 5.2
-      env: PHPCS_VERSION="1.5.6"
-    - php: 5.2
-      env: PHPCS_VERSION="2.9"
-
+    # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.3
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
 
+    # PHP 5.4 needs a different Coveralls version.
     - php: 5.4
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.4
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
+    - php: 5.4
+      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="~1.0"
 
-    - php: 5.5
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+    # These will be changed to set variations of PHPCS 2.x in a next PR.
     - php: 5.5
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
-    - php: 5.5
-      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
-
-    - php: 5.6
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
     - php: 5.6
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
-    - php: 5.6
-      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
-
     - php: 7.0
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
-    - php: 7.0
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
-    - php: 7.0
-      env: PHPCS_VERSION="2.9.x-dev" SNIFF=1 COVERALLS_VERSION="dev-master"
-
-    - php: 7.1
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=2.0,<3.0" SNIFF=1  COVERALLS_VERSION="dev-master"
     - php: 7.1
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
-    - php: 7.1
-      env: PHPCS_VERSION="2.9.x-dev" COVERALLS_VERSION="dev-master"
 
+    # Coverage is not checked on nightly and HHVM.
     - php: nightly
       env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
     - php: nightly
-      env: PHPCS_VERSION="2.9.x-dev"
+      env: PHPCS_VERSION="dev-master"
 
     - php: hhvm
       dist: trusty
       env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: hhvm
       dist: trusty
-      env: PHPCS_VERSION="2.9.x-dev"
+      env: PHPCS_VERSION="dev-master"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -71,16 +64,11 @@ matrix:
 before_install:
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
-  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer self-update; fi
-  - if [[ $TRAVIS_PHP_VERSION > "5.2" && $COVERALLS_VERSION ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION};fi
-  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer require squizlabs/php_codesniffer:${PHPCS_VERSION}; fi
+  - composer self-update
+  - if [[ $COVERALLS_VERSION ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
+  - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
-  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then composer install; fi
-  # PHP 5.2: set up test environment using git cloning.
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_DIR=/tmp/phpcs; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then export PHPCS_BIN=$PHPCS_DIR/scripts/phpcs; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then mkdir -p $PHPCS_DIR && git clone --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git -b $PHPCS_VERSION $PHPCS_DIR; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then $PHPCS_BIN --config-set installed_paths "$(pwd)"; fi
+  - composer install
 
 before_script:
   - if [[ $COVERALLS_VERSION ]]; then mkdir -p build/logs; fi
@@ -88,13 +76,12 @@ before_script:
 
 script:
   # Lint all PHP files against parse errors.
-  - if [[ $TRAVIS_PHP_VERSION > "5.2" ]]; then find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
-  - if [[ $TRAVIS_PHP_VERSION < "5.3" ]]; then find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./PHPCompatibility/Tests/PHPUnit6Compat.php -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+  - find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
   # Check the code style of the code base.
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --runtime-set ignore_warnings_on_exit 1; fi
   # Run the unit tests.
   - if [[ $COVERALLS_VERSION ]]; then phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
-  - if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "nightly" ]]; then phpunit --configuration phpunit.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then phpunit --configuration phpunit.xml; fi
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit --configuration phpunit.xml; fi
   # Validate the xml file.
   # @link http://xmlsoft.org/xmllint.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ To start contributing, fork the repository, create a new branch in your fork, ma
 
 Please make sure that your pull request contains unit tests covering what's being addressed by it.
 
-All code should be compatible with PHPCS 1.5.6 and PHPCS 2.x.
-All code should be compatible with PHP 5.1 to PHP nightly.
-All code should comply with the PHPCompatibility coding standards. The ruleset used by PHPCompatibility is largely based on PSR2 with minor variations and some additional checks for documentation and such.
+* All code should be compatible with PHPCS 1.5.6, PHPCS 2.x and PHPCS 3.x.
+* All code should be compatible with PHP 5.3 to PHP nightly.
+* All code should comply with the PHPCompatibility coding standards. The ruleset used by PHPCompatibility is largely based on PSR2 with minor variations and some additional checks for documentation and such.
 
 
 Running the Sniff Tests
@@ -34,18 +34,18 @@ Running the Sniff Tests
 All the sniffs are fully tested with PHPUnit tests. In order to run the tests
 on the sniffs, the following installation steps are required.
 
-1. Install the latest release from the `2.x` branch of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer.git).
+1. Install the latest release or the `master` branch of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer.git).
 
     This can be done with composer using the following command:
 
-        $ composer require "squizlabs/php_codesniffer=^2.0"
+        $ composer require "squizlabs/php_codesniffer=^2.0 || ^3.0.1"
 
     or by adding the following into `~/.composer/composer.json`:
     ```json
         {
             "require": {
                 "phpunit/phpunit": ">=4.0",
-                "squizlabs/php_codesniffer": "^2.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0.1"
             }
         }
     ```

--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -39,3 +39,28 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
 
     define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);
 }
+
+
+/*
+ * Register an autoloader.
+ *
+ * {@internal This autoloader is not needed for running the sniffs, however, it *is*
+ * needed for running the unit tests as the PHPCS native autoloader runs into trouble there.
+ * This issue will be fixed in PHPCS 3.1, so the below code can be removed once the
+ * minimum PHPCS 3.x requirement for PHPCompatibility has gone up to 3.1.
+ * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564} }}
+ */
+if (defined('PHP_CODESNIFFER_IN_TESTS')) {
+    spl_autoload_register(function ($class) {
+        // Only try & load our own classes.
+        if (strpos($class, 'PHPCompatibility') !== 0) {
+            return;
+        }
+
+        $file = realpath(__DIR__) . DIRECTORY_SEPARATOR . strtr($class, '\\', DIRECTORY_SEPARATOR) . '.php';
+
+        if (file_exists($file)) {
+            include_once($file);
+        }
+    });
+}

--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+
+/*
+ * Alias a number of PHPCS 3.x classes to their PHPCS 2.x equivalents.
+ *
+ * This file is auto-loaded by PHPCS 3.x before any sniffs are loaded
+ * through the PHPCS 3.x `<autoload>` ruleset directive.
+ *
+ * {@internal The PHPCS file have been reorganized in PHPCS 3.x, quite
+ * a few "old" classes have been split and spread out over several "new"
+ * classes. In other words, this will only work for a limited number
+ * of classes.}}
+ *
+ * {@internal The `class_exists` wrappers are needed to play nice with other
+ * external PHPCS standards creating cross-version compatibility in the same
+ * manner.}}
+ */
+if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
+    if (class_exists('\PHP_CodeSniffer_Sniff') === false) {
+        class_alias('PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff');
+    }
+    if (class_exists('\PHP_CodeSniffer_File') === false) {
+        class_alias('PHP_CodeSniffer\Files\File', '\PHP_CodeSniffer_File');
+    }
+    if (class_exists('\PHP_CodeSniffer_Tokens') === false) {
+        class_alias('PHP_CodeSniffer\Util\Tokens', '\PHP_CodeSniffer_Tokens');
+    }
+    if (class_exists('\PHP_CodeSniffer_Exception') === false) {
+        class_alias('PHP_CodeSniffer\Exceptions\RuntimeException', '\PHP_CodeSniffer_Exception');
+    }
+
+    define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);
+}

--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -24,14 +24,14 @@ abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersi
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error/warning for an item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
      *
      * @return void
      */
-    public function handleFeature(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo)
+    public function handleFeature(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo)
     {
         $itemArray = $this->getItemArray($itemInfo);
         $errorInfo = $this->getErrorInfo($itemArray, $itemInfo);

--- a/PHPCompatibility/AbstractComplexVersionSniff.php
+++ b/PHPCompatibility/AbstractComplexVersionSniff.php
@@ -1,20 +1,22 @@
 <?php
 /**
- * PHPCompatibility_AbstractComplexVersionSniff.
+ * \PHPCompatibility\AbstractComplexVersionSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility;
+
 /**
- * PHPCompatibility_AbstractComplexVersionSniff.
+ * \PHPCompatibility\AbstractComplexVersionSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractComplexVersionSniff extends PHPCompatibility_Sniff implements PHPCompatibility_ComplexVersionInterface
+abstract class AbstractComplexVersionSniff extends Sniff implements ComplexVersionInterface
 {
 
 

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -78,16 +78,16 @@ abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Generates the error or warning for this item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
-     * @param array                $errorInfo Array with detail (version) information
-     *                                        relevant to the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
      *
      * @return void
      */
-    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();

--- a/PHPCompatibility/AbstractNewFeatureSniff.php
+++ b/PHPCompatibility/AbstractNewFeatureSniff.php
@@ -1,20 +1,22 @@
 <?php
 /**
- * PHPCompatibility_AbstractNewFeatureSniff.
+ * \PHPCompatibility\AbstractNewFeatureSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility;
+
 /**
- * PPHPCompatibility_AbstractNewFeatureSniff.
+ * \PHPCompatibility\AbstractNewFeatureSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractNewFeatureSniff extends PHPCompatibility_AbstractComplexVersionSniff
+abstract class AbstractNewFeatureSniff extends AbstractComplexVersionSniff
 {
 
 

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -1,20 +1,22 @@
 <?php
 /**
- * PHPCompatibility_AbstractRemovedFeatureSniff.
+ * \PHPCompatibility\AbstractRemovedFeatureSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility;
+
 /**
- * PHPCompatibility_AbstractRemovedFeatureSniff.
+ * \PHPCompatibility\AbstractRemovedFeatureSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class PHPCompatibility_AbstractRemovedFeatureSniff extends PHPCompatibility_AbstractComplexVersionSniff
+abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
 {
 
 

--- a/PHPCompatibility/AbstractRemovedFeatureSniff.php
+++ b/PHPCompatibility/AbstractRemovedFeatureSniff.php
@@ -100,16 +100,16 @@ abstract class AbstractRemovedFeatureSniff extends AbstractComplexVersionSniff
     /**
      * Generates the error or warning for this item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
-     * @param array                $errorInfo Array with detail (version) information
-     *                                        relevant to the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
      *
      * @return void
      */
-    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $itemName = $this->getItemName($itemInfo, $errorInfo);
         $error    = $this->getErrorMsgTemplate();

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -1,14 +1,16 @@
 <?php
 /**
- * PHPCompatibility_ComplexVersionInterface.
+ * \PHPCompatibility\ComplexVersionInterface.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility;
+
 /**
- * PHPCompatibility_ComplexVersionInterface.
+ * \PHPCompatibility\ComplexVersionInterface.
  *
  * Interface to be implemented by sniffs using a multi-dimensional array of
  * PHP features (functions, classes etc) being sniffed for with version
@@ -18,7 +20,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-interface PHPCompatibility_ComplexVersionInterface
+interface ComplexVersionInterface
 {
 
 

--- a/PHPCompatibility/ComplexVersionInterface.php
+++ b/PHPCompatibility/ComplexVersionInterface.php
@@ -28,14 +28,14 @@ interface ComplexVersionInterface
      * Handle the retrieval of relevant information and - if necessary - throwing of an
      * error/warning for an item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
      *
      * @return void
      */
-    public function handleFeature(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo);
+    public function handleFeature(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo);
 
 
     /**
@@ -62,16 +62,16 @@ interface ComplexVersionInterface
     /**
      * Generates the error or warning for this item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
-     * @param array                $errorInfo Array with detail (version) information
-     *                                        relevant to the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
      *
      * @return void
      */
-    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo);
 
 
 }//end interface

--- a/PHPCompatibility/PHPCSHelper.php
+++ b/PHPCompatibility/PHPCSHelper.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * PHPCS cross-version compatibility helper class.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility;
+
+/**
+ * \PHPCompatibility\PHPCSHelper
+ *
+ * PHPCS cross-version compatibility helper class.
+ *
+ * A number of PHPCS classes were split up into several classes in PHPCS 3.x
+ * Those classes cannot be aliased as they don't represent the same object.
+ * This class provides helper methods for functions which were contained in
+ * one of these classes and which are used within the PHPCompatibility library.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PHPCSHelper
+{
+
+    /**
+     * Get the PHPCS version number.
+     *
+     * @return string
+     */
+    public static function getVersion()
+    {
+        if (defined('\PHP_CodeSniffer\Config::VERSION')) {
+            // PHPCS 3.x.
+            return \PHP_CodeSniffer\Config::VERSION;
+        } else {
+            // PHPCS 1.x & 2.x.
+            return \PHP_CodeSniffer::VERSION;
+        }
+    }
+
+
+    /**
+     * Pass config data to PHPCS.
+     *
+     * PHPCS cross-version compatibility helper.
+     *
+     * @param string      $key   The name of the config value.
+     * @param string|null $value The value to set. If null, the config entry
+     *                           is deleted, reverting it to the default value.
+     * @param boolean     $temp  Set this config data temporarily for this script run.
+     *                           This will not write the config data to the config file.
+     *
+     * @return void
+     */
+    public static function setConfigData($key, $value, $temp = false)
+    {
+        if (method_exists('\PHP_CodeSniffer\Config', 'setConfigData')) {
+            // PHPCS 3.x.
+            \PHP_CodeSniffer\Config::setConfigData($key, $value, $temp);
+        } else {
+            // PHPCS 1.x & 2.x.
+            \PHP_CodeSniffer::setConfigData($key, $value, $temp);
+        }
+    }
+
+
+    /**
+     * Get the value of a single PHPCS config key.
+     *
+     * @param string $key The name of the config value.
+     *
+     * @return string|null
+     */
+    public static function getConfigData($key)
+    {
+        if (method_exists('\PHP_CodeSniffer\Config', 'getConfigData')) {
+            // PHPCS 3.x.
+            return \PHP_CodeSniffer\Config::getConfigData($key);
+        } else {
+            // PHPCS 1.x & 2.x.
+            return \PHP_CodeSniffer::getConfigData($key);
+        }
+    }
+
+}

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -10,6 +10,8 @@
 
 namespace PHPCompatibility;
 
+use PHPCompatibility\PHPCSHelper;
+
 /**
  * \PHPCompatibility\Sniff.
  *
@@ -103,7 +105,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
     {
         static $arrTestVersions = array();
 
-        $testVersion = trim(\PHP_CodeSniffer::getConfigData('testVersion'));
+        $testVersion = trim(PHPCSHelper::getConfigData('testVersion'));
 
         if (isset($arrTestVersions[$testVersion]) === false && empty($testVersion) === false) {
 
@@ -314,7 +316,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      */
     public function findImplementedInterfaceNames(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.7.1', '>') === true) {
             return $phpcsFile->findImplementedInterfaceNames($stackPtr);
         }
 
@@ -672,7 +674,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         static $isLowPHPCS, $ignoreTokens;
 
         if (isset($isLowPHPCS) === false) {
-            $isLowPHPCS = version_compare(\PHP_CodeSniffer::VERSION, '2.3.0', '<');
+            $isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.3.0', '<');
         }
         if (isset($ignoreTokens) === false) {
             $ignoreTokens              = \PHP_CodeSniffer_Tokens::$emptyTokens;
@@ -1282,7 +1284,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      */
     public function getMethodParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.7.1', '>') === true) {
             return $phpcsFile->getMethodParameters($stackPtr);
         }
 
@@ -1463,7 +1465,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      */
     public function findExtendedClassName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.7.1', '>') === true) {
             return $phpcsFile->findExtendedClassName($stackPtr);
         }
 

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniff.
+ * \PHPCompatibility\Sniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,15 +8,17 @@
  * @copyright 2014 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility;
+
 /**
- * PHPCompatibility_Sniff.
+ * \PHPCompatibility\Sniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2014 Cu.be Solutions bvba
  */
-abstract class PHPCompatibility_Sniff implements PHP_CodeSniffer_Sniff
+abstract class Sniff implements PHP_CodeSniffer_Sniff
 {
 
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -18,7 +18,7 @@ namespace PHPCompatibility;
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2014 Cu.be Solutions bvba
  */
-abstract class Sniff implements PHP_CodeSniffer_Sniff
+abstract class Sniff implements \PHP_CodeSniffer_Sniff
 {
 
     const REGEX_COMPLEX_VARS = '`(?:(\{)?(?<!\\\\)\$)?(\{)?(?<!\\\\)\$(\{)?(?P<varname>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(?:->\$?(?P>varname)|\[[^\]]+\]|::\$?(?P>varname)|\([^\)]*\))*(?(3)\}|)(?(2)\}|)(?(1)\}|)`';
@@ -97,13 +97,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *               single version number is specified, then this is used as
      *               both the min and max.
      *
-     * @throws PHP_CodeSniffer_Exception If testVersion is invalid.
+     * @throws \PHP_CodeSniffer_Exception If testVersion is invalid.
      */
     private function getTestVersion()
     {
         static $arrTestVersions = array();
 
-        $testVersion = trim(PHP_CodeSniffer::getConfigData('testVersion'));
+        $testVersion = trim(\PHP_CodeSniffer::getConfigData('testVersion'));
 
         if (isset($arrTestVersions[$testVersion]) === false && empty($testVersion) === false) {
 
@@ -208,20 +208,20 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Add a PHPCS message to the output stack as either a warning or an error.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file the message applies to.
-     * @param string               $message   The message.
-     * @param int                  $stackPtr  The position of the token
-     *                                        the message relates to.
-     * @param bool                 $isError   Whether to report the message as an
-     *                                        'error' or 'warning'.
-     *                                        Defaults to true (error).
-     * @param string               $code      The error code for the message.
-     *                                        Defaults to 'Found'.
-     * @param array                $data      Optional input for the data replacements.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file the message applies to.
+     * @param string                $message   The message.
+     * @param int                   $stackPtr  The position of the token
+     *                                         the message relates to.
+     * @param bool                  $isError   Whether to report the message as an
+     *                                         'error' or 'warning'.
+     *                                         Defaults to true (error).
+     * @param string                $code      The error code for the message.
+     *                                         Defaults to 'Found'.
+     * @param array                 $data      Optional input for the data replacements.
      *
      * @return void
      */
-    public function addMessage($phpcsFile, $message, $stackPtr, $isError, $code = 'Found', $data = array())
+    public function addMessage(\PHP_CodeSniffer_File $phpcsFile, $message, $stackPtr, $isError, $code = 'Found', $data = array())
     {
         if ($isError === true) {
             $phpcsFile->addError($message, $stackPtr, $code, $data);
@@ -307,14 +307,14 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findImplementedInterfaceNames($stackPtr)` calls.}}
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the class token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the class token.
      *
      * @return array|false
      */
-    public function findImplementedInterfaceNames(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function findImplementedInterfaceNames(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
             return $phpcsFile->findImplementedInterfaceNames($stackPtr);
         }
 
@@ -375,12 +375,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * @link https://github.com/wimg/PHPCompatibility/issues/120
      * @link https://github.com/wimg/PHPCompatibility/issues/152
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function call token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the function call token.
      *
      * @return bool
      */
-    public function doesFunctionCallHaveParameters(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function doesFunctionCallHaveParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -394,7 +394,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
             return false;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
 
         // Deal with short array syntax.
         if ($tokens[$stackPtr]['code'] === T_OPEN_SHORT_ARRAY) {
@@ -421,7 +421,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
         }
 
         $closeParenthesis = $tokens[$nextNonEmpty]['parenthesis_closer'];
-        $nextNextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextNonEmpty + 1, $closeParenthesis + 1, true);
+        $nextNextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $nextNonEmpty + 1, $closeParenthesis + 1, true);
 
         if ($nextNextNonEmpty === $closeParenthesis) {
             // No parameters.
@@ -445,12 +445,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * @link https://github.com/wimg/PHPCompatibility/issues/114
      * @link https://github.com/wimg/PHPCompatibility/issues/151
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function call token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the function call token.
      *
      * @return int
      */
-    public function getFunctionCallParameterCount(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getFunctionCallParameterCount(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->doesFunctionCallHaveParameters($phpcsFile, $stackPtr) === false) {
             return 0;
@@ -473,12 +473,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * Extra feature: If passed an T_ARRAY or T_OPEN_SHORT_ARRAY stack pointer,
      * it will tokenize the values / key/value pairs contained in the array call.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the function call token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the function call token.
      *
      * @return array
      */
-    public function getFunctionCallParameters(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getFunctionCallParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->doesFunctionCallHaveParameters($phpcsFile, $stackPtr) === false) {
             return array();
@@ -496,7 +496,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
             $nestedParenthesisCount = 0;
 
         } else {
-            $opener = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+            $opener = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
             $closer = $tokens[$opener]['parenthesis_closer'];
 
             $nestedParenthesisCount = 1;
@@ -544,7 +544,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
             // Check if there are more tokens before the closing parenthesis.
             // Prevents code like the following from setting a third parameter:
             // functionCall( $param1, $param2, );
-            $hasNextParam = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $nextComma + 1, $closer, true, null, true);
+            $hasNextParam = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $nextComma + 1, $closer, true, null, true);
             if ($hasNextParam === false) {
                 break;
             }
@@ -568,13 +568,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * of the parameter at a specific offset.
      * If the specified parameter is not found, will return false.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-     * @param int                  $stackPtr    The position of the function call token.
-     * @param int                  $paramOffset The 1-based index position of the parameter to retrieve.
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $stackPtr    The position of the function call token.
+     * @param int                   $paramOffset The 1-based index position of the parameter to retrieve.
      *
      * @return array|false
      */
-    public function getFunctionCallParameter(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $paramOffset)
+    public function getFunctionCallParameter(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $paramOffset)
     {
         $parameters = $this->getFunctionCallParameters($phpcsFile, $stackPtr);
 
@@ -593,18 +593,18 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * will check that the token has at least one condition which is of a
      * type defined in $validScopes.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile   The file being scanned.
-     * @param int                  $stackPtr    The position of the token.
-     * @param array|int            $validScopes Optional. Array of valid scopes
-     *                                          or int value of a valid scope.
-     *                                          Pass the T_.. constant(s) for the
-     *                                          desired scope to this parameter.
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $stackPtr    The position of the token.
+     * @param array|int             $validScopes Optional. Array of valid scopes
+     *                                           or int value of a valid scope.
+     *                                           Pass the T_.. constant(s) for the
+     *                                           desired scope to this parameter.
      *
      * @return bool Without the optional $scopeTypes: True if within a scope, false otherwise.
      *              If the $scopeTypes are set: True if *one* of the conditions is a
      *              valid scope, false otherwise.
      */
-    public function tokenHasScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $validScopes = null)
+    public function tokenHasScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $validScopes = null)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -630,15 +630,15 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Verify whether a token is within a class scope.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token.
-     * @param bool                 $strict    Whether to strictly check for the T_CLASS
-     *                                        scope or also accept interfaces and traits
-     *                                        as scope.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token.
+     * @param bool                  $strict    Whether to strictly check for the T_CLASS
+     *                                         scope or also accept interfaces and traits
+     *                                         as scope.
      *
      * @return bool True if within class scope, false otherwise.
      */
-    public function inClassScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $strict = true)
+    public function inClassScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $strict = true)
     {
         $validScopes = array(T_CLASS);
         if (defined('T_ANON_CLASS') === true) {
@@ -662,20 +662,20 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * In PHPCS 1.x no conditions are set for a scoped use statement.
      * This method works around that limitation.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token.
      *
      * @return bool True if within use scope, false otherwise.
      */
-    public function inUseScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function inUseScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         static $isLowPHPCS, $ignoreTokens;
 
         if (isset($isLowPHPCS) === false) {
-            $isLowPHPCS = version_compare(PHP_CodeSniffer::VERSION, '2.3.0', '<');
+            $isLowPHPCS = version_compare(\PHP_CodeSniffer::VERSION, '2.3.0', '<');
         }
         if (isset($ignoreTokens) === false) {
-            $ignoreTokens              = PHP_CodeSniffer_Tokens::$emptyTokens;
+            $ignoreTokens              = \PHP_CodeSniffer_Tokens::$emptyTokens;
             $ignoreTokens[T_STRING]    = T_STRING;
             $ignoreTokens[T_AS]        = T_AS;
             $ignoreTokens[T_PUBLIC]    = T_PUBLIC;
@@ -706,12 +706,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Returns an empty string if the class name could not be reliably inferred.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of a T_NEW token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of a T_NEW token.
      *
      * @return string
      */
-    public function getFQClassNameFromNewToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getFQClassNameFromNewToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -724,7 +724,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
             return '';
         }
 
-        $start = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $start = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         if ($start === false) {
             return '';
         }
@@ -760,12 +760,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * Returns an empty string if the class does not extend another class or if
      * the class name could not be reliably inferred.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of a T_CLASS token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of a T_CLASS token.
      *
      * @return string
      */
-    public function getFQExtendedClassName(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getFQExtendedClassName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -793,12 +793,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Returns an empty string if the class name could not be reliably inferred.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of a T_NEW token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of a T_NEW token.
      *
      * @return string
      */
-    public function getFQClassNameFromDoubleColonToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getFQClassNameFromDoubleColonToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -857,13 +857,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * Checks if a class/function/constant name is already fully qualified and
      * if not, enrich it with the relevant namespace information.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token.
-     * @param string               $name      The class / function / constant name.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token.
+     * @param string                $name      The class / function / constant name.
      *
      * @return string
      */
-    public function getFQName(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $name)
+    public function getFQName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $name)
     {
         if (strpos($name, '\\') === 0) {
             // Already fully qualified.
@@ -896,7 +896,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     public function isNamespaced($FQName)
     {
         if (strpos($FQName, '\\') !== 0) {
-            throw new PHP_CodeSniffer_Exception('$FQName must be a fully qualified name');
+            throw new \PHP_CodeSniffer_Exception('$FQName must be a fully qualified name');
         }
 
         return (strpos(substr($FQName, 1), '\\') !== false);
@@ -906,12 +906,12 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Determine the namespace name an arbitrary token lives in.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The token position for which to determine the namespace.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The token position for which to determine the namespace.
      *
      * @return string Namespace name or empty string if it couldn't be determined or no namespace applies.
      */
-    public function determineNamespace(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function determineNamespace(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -969,13 +969,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * For hierarchical namespaces, the name will be composed of several tokens,
      * i.e. MyProject\Sub\Level which will be returned together as one string.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int|bool             $stackPtr  The position of a T_NAMESPACE token.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int|bool              $stackPtr  The position of a T_NAMESPACE token.
      *
      * @return string|false Namespace name or false if not a namespace declaration.
      *                      Namespace name can be an empty string for global namespace declaration.
      */
-    public function getDeclaredNamespaceName(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getDeclaredNamespaceName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -993,7 +993,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
             return false;
         }
 
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($tokens[$nextToken]['code'] === T_OPEN_CURLY_BRACKET) {
             // Declaration for global namespace when using multiple namespaces in a file.
             // I.e.: namespace {}
@@ -1025,14 +1025,14 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Expects to be passed T_RETURN_TYPE, T_FUNCTION or T_CLOSURE token.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token.
      *
      * @return int|false Stack pointer to the return type token or false if
      *                   no return type was found or the passed token was
      *                   not of the correct type.
      */
-    public function getReturnTypeHintToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getReturnTypeHintToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -1079,13 +1079,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * anonymous classes. Along the same lines, the`getMemberProperties()`
      * method does not support the `var` prefix.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The position in the stack of the
-     *                                        T_VARIABLE token to verify.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The position in the stack of the
+     *                                         T_VARIABLE token to verify.
      *
      * @return bool
      */
-    public function isClassProperty(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function isClassProperty(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -1113,13 +1113,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Check whether a T_CONST token is a class constant declaration.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The position in the stack of the
-     *                                        T_CONST token to verify.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The position in the stack of the
+     *                                         T_CONST token to verify.
      *
      * @return bool
      */
-    public function isClassConstant(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function isClassConstant(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -1147,17 +1147,17 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Used to check, for instance, if a T_CONST is a class constant.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile   Instance of phpcsFile.
-     * @param int                  $stackPtr    The position in the stack of the
-     *                                          T_CONST token to verify.
-     * @param array                $validScopes Array of token types.
-     *                                          Keys should be the token types in string
-     *                                          format to allow for newer token types.
-     *                                          Value is irrelevant.
+     * @param \PHP_CodeSniffer_File $phpcsFile   Instance of phpcsFile.
+     * @param int                   $stackPtr    The position in the stack of the
+     *                                           T_CONST token to verify.
+     * @param array                 $validScopes Array of token types.
+     *                                           Keys should be the token types in string
+     *                                           format to allow for newer token types.
+     *                                           Value is irrelevant.
      *
      * @return bool
      */
-    protected function validDirectScope(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $validScopes)
+    protected function validDirectScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $validScopes)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -1191,15 +1191,15 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * Strips potential nullable indicator and potential global namespace
      * indicator from the type hints before returning them.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token.
      *
      * @return array Array with type hints or an empty array if
      *               - the function does not have any parameters
      *               - no type hints were found
      *               - or the passed token was not of the correct type.
      */
-    public function getTypeHintsFromFunctionDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getTypeHintsFromFunctionDeclaration(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -1254,7 +1254,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      * Parameters with default values have an additional array index of
      * 'default' with the value of the default as a string.
      *
-     * {@internal Duplicate of same method as contained in the `PHP_CodeSniffer_File`
+     * {@internal Duplicate of same method as contained in the `\PHP_CodeSniffer_File`
      * class, but with some improvements which have been introduced in
      * PHPCS 2.8.0.
      * {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1117},
@@ -1271,18 +1271,18 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Last synced with PHPCS version: PHPCS 2.9.0-alpha at commit f1511adad043edfd6d2e595e77385c32577eb2bc}}
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The position in the stack of the
-     *                                        function token to acquire the
-     *                                        parameters for.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The position in the stack of the
+     *                                         function token to acquire the
+     *                                         parameters for.
      *
      * @return array|false
-     * @throws PHP_CodeSniffer_Exception If the specified $stackPtr is not of
-     *                                   type T_FUNCTION or T_CLOSURE.
+     * @throws \PHP_CodeSniffer_Exception If the specified $stackPtr is not of
+     *                                    type T_FUNCTION or T_CLOSURE.
      */
-    public function getMethodParameters(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getMethodParameters(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
             return $phpcsFile->getMethodParameters($stackPtr);
         }
 
@@ -1294,7 +1294,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
         }
 
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION && $tokens[$stackPtr]['code'] !== T_CLOSURE) {
-            throw new PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
+            throw new \PHP_CodeSniffer_Exception('$stackPtr must be of type T_FUNCTION or T_CLOSURE');
         }
 
         $opener = $tokens[$stackPtr]['parenthesis_opener'];
@@ -1444,7 +1444,7 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Returns FALSE on error or if there is no extended class name.
      *
-     * {@internal Duplicate of same method as contained in the `PHP_CodeSniffer_File`
+     * {@internal Duplicate of same method as contained in the `\PHP_CodeSniffer_File`
      * class, but with some improvements which have been introduced in
      * PHPCS 2.8.0.
      * {@link https://github.com/squizlabs/PHP_CodeSniffer/commit/0011d448119d4c568e3ac1f825ae78815bf2cc34}.
@@ -1455,15 +1455,15 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
      *
      * Last synced with PHPCS version: PHPCS 2.9.0 at commit b940fb7dca8c2a37f0514161b495363e5b36d879}}
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The position in the stack of the
-     *                                        class token.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The position in the stack of the
+     *                                         class token.
      *
      * @return string|false
      */
-    public function findExtendedClassName(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function findExtendedClassName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.7.1', '>') === true) {
             return $phpcsFile->findExtendedClassName($stackPtr);
         }
 
@@ -1512,13 +1512,13 @@ abstract class Sniff implements PHP_CodeSniffer_Sniff
     /**
      * Get the hash algorithm name from the parameter in a hash function call.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                  $stackPtr  The position of the T_STRING function token.
+     * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
+     * @param int                   $stackPtr  The position of the T_STRING function token.
      *
      * @return string|false The algorithm name without quotes if this was a relevant hash
      *                      function call or false if it was not.
      */
-    public function getHashAlgorithmParameter(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function getHashAlgorithmParameter(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff.
+ * \PHPCompatibility\Sniffs\PHP\CaseSensitiveKeywordsSniff.
  *
  * PHP version 5.5
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff.
+ * \PHPCompatibility\Sniffs\PHP\CaseSensitiveKeywordsSniff.
  *
  * Prior to PHP 5.5, cases existed where the self, parent, and static keywords
  * were treated in a case sensitive fashion.
@@ -21,7 +25,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff extends PHPCompatibility_Sniff
+class CaseSensitiveKeywordsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/CaseSensitiveKeywordsSniff.php
@@ -45,13 +45,13 @@ class CaseSensitiveKeywordsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff.
+ * \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingConstSniff.
  *
  * PHP version 5.6
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff.
+ * \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingConstSniff.
  *
  * Constant arrays using the constant keyword in PHP 5.6
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff extends PHPCompatibility_Sniff
+class ConstantArraysUsingConstSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
@@ -40,13 +40,13 @@ class ConstantArraysUsingConstSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.5') !== true) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -40,13 +40,13 @@ class ConstantArraysUsingDefineSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') !== true) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingDefineSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff.
+ * \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingDefineSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff.
+ * \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingDefineSniff.
  *
  * Constant arrays using define in PHP 7.0
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff extends PHPCompatibility_Sniff
+class ConstantArraysUsingDefineSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -786,13 +786,13 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedFunctionsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedFunctionsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
 {
     /**
      * A list of deprecated and removed functions with their alternatives.

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -221,13 +221,13 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedIniDirectivesSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,8 +8,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedIniDirectivesSniff.
  *
  * Discourages the use of deprecated INI directives through ini_set() or ini_get().
  *
@@ -18,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
 {
     /**
      * A list of deprecated INI directives.

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -43,20 +43,20 @@ class DeprecatedNewReferenceSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
         }
 
         $tokens = $phpcsFile->getTokens();
-        $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['type'] !== 'T_BITWISE_AND') {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedNewReferenceSniff.
  *
  * PHP version 5.4
  *
@@ -10,8 +10,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedNewReferenceSniff.
  *
  * Discourages the use of assigning the return value of new by reference
  *
@@ -22,7 +26,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff extends PHPCompatibility_Sniff
+class DeprecatedNewReferenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedPHP4StyleConstructorsSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Koen Eelen <koen.eelen@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff.
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedPHP4StyleConstructorsSniff.
  *
  * PHP version 7.0
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Koen Eelen <koen.eelen@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff extends PHPCompatibility_Sniff
+class DeprecatedPHP4StyleConstructorsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniff.php
@@ -39,13 +39,13 @@ class DeprecatedPHP4StyleConstructorsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff.
+ * \PHPCompatibility\Sniffs\PHP\EmptyNonVariableSniff.
  *
  * PHP version 5.5
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff.
+ * \PHPCompatibility\Sniffs\PHP\EmptyNonVariableSniff.
  *
  * Verify that nothing but variables are passed to empty().
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff extends PHPCompatibility_Sniff
+class EmptyNonVariableSniff extends Sniff
 {
     /**
      * List of tokens to check against.

--- a/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/EmptyNonVariableSniff.php
@@ -55,12 +55,12 @@ class EmptyNonVariableSniff extends Sniff
     {
         // Set the token blacklist only once.
         $tokenBlackList = array_unique(array_merge(
-            PHP_CodeSniffer_Tokens::$assignmentTokens,
-            PHP_CodeSniffer_Tokens::$equalityTokens,
-            PHP_CodeSniffer_Tokens::$comparisonTokens,
-            PHP_CodeSniffer_Tokens::$operators,
-            PHP_CodeSniffer_Tokens::$booleanOperators,
-            PHP_CodeSniffer_Tokens::$castTokens,
+            \PHP_CodeSniffer_Tokens::$assignmentTokens,
+            \PHP_CodeSniffer_Tokens::$equalityTokens,
+            \PHP_CodeSniffer_Tokens::$comparisonTokens,
+            \PHP_CodeSniffer_Tokens::$operators,
+            \PHP_CodeSniffer_Tokens::$booleanOperators,
+            \PHP_CodeSniffer_Tokens::$castTokens,
             array(T_OPEN_PARENTHESIS, T_STRING_CONCAT)
         ));
         $this->tokenBlackList = array_combine($tokenBlackList, $tokenBlackList);
@@ -71,13 +71,13 @@ class EmptyNonVariableSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -144,13 +144,13 @@ class EmptyNonVariableSniff extends Sniff
     /**
      * Add the error message.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    protected function addError($phpcsFile, $stackPtr)
+    protected function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $phpcsFile->addError(
             'Only variables can be passed to empty() prior to PHP 5.5.',

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoop.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueOutsideLoop.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoop.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueOutsideLoop.
  *
  * Forbids use of break or continue statements outside of looping structures.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoopSniff extends PHPCompatibility_Sniff
+class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniff.php
@@ -67,13 +67,13 @@ class ForbiddenBreakContinueOutsideLoopSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -54,13 +54,13 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.4') === false) {
             return;
@@ -73,7 +73,7 @@ class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
             if ($tokens[$curToken]['type'] === 'T_STRING') {
                 // If the next non-whitespace token after the string
                 // is an opening parenthesis then it's a function call.
-                $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $curToken + 1, null, true);
+                $openBracket = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $curToken + 1, null, true);
                 if ($tokens[$openBracket]['code'] === T_OPEN_PARENTHESIS) {
                     $errorType = 'variableArgument';
                     break;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArguments.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueVariableArguments.
  *
  * PHP version 5.4
  *
@@ -10,8 +10,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArguments.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueVariableArguments.
  *
  * Forbids variable arguments on break or continue statements.
  *
@@ -22,7 +26,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff extends PHPCompatibility_Sniff
+class ForbiddenBreakContinueVariableArgumentsSniff extends Sniff
 {
     /**
      * Error types this sniff handles for forbidden break/continue arguments.

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReference.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenCallTimePassByReference.
  *
  * PHP version 5.4
  *
@@ -11,8 +11,12 @@
  * @copyright 2009 Florian Grandel
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReference.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenCallTimePassByReference.
  *
  * Discourages the use of call time pass by references
  *
@@ -24,7 +28,7 @@
  * @author    Florian Grandel <jerico.dev@gmail.com>
  * @copyright 2009 Florian Grandel
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff extends PHPCompatibility_Sniff
+class ForbiddenCallTimePassByReferenceSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -45,13 +45,13 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
@@ -63,7 +63,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // within their definitions. For example: function myFunction...
         // "myFunction" is T_STRING but we should skip because it is not a
         // function or method *call*.
-        $findTokens   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $findTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $findTokens[] = T_BITWISE_AND;
 
         $prevNonEmpty = $phpcsFile->findPrevious(
@@ -80,7 +80,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
         // If the next non-whitespace token after the function or method call
         // is not an opening parenthesis then it can't really be a *call*.
         $openBracket = $phpcsFile->findNext(
-            PHP_CodeSniffer_Tokens::$emptyTokens,
+            \PHP_CodeSniffer_Tokens::$emptyTokens,
             ($stackPtr + 1),
             null,
             true
@@ -126,14 +126,14 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
     /**
      * Determine whether a parameter is passed by reference.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param array                $parameter    Information on the current parameter
-     *                                           to be examined.
-     * @param int                  $nestingLevel Target nesting level.
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param array                 $parameter    Information on the current parameter
+     *                                            to be examined.
+     * @param int                   $nestingLevel Target nesting level.
      *
      * @return bool
      */
-    protected function isCallTimePassByReferenceParam(PHP_CodeSniffer_File $phpcsFile, $parameter, $nestingLevel)
+    protected function isCallTimePassByReferenceParam(\PHP_CodeSniffer_File $phpcsFile, $parameter, $nestingLevel)
     {
         $tokens   = $phpcsFile->getTokens();
 
@@ -157,7 +157,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                PHP_CodeSniffer_Tokens::$emptyTokens,
+                \PHP_CodeSniffer_Tokens::$emptyTokens,
                 ($nextVariable - 1),
                 $searchStartToken,
                 true
@@ -170,7 +170,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
 
             // Checking this: $value = my_function(...[*]&$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
-                PHP_CodeSniffer_Tokens::$emptyTokens,
+                \PHP_CodeSniffer_Tokens::$emptyTokens,
                 ($tokenBefore - 1),
                 $searchStartToken,
                 true
@@ -215,7 +215,7 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 // Global constants still remain uncovered.
                 case T_STRING:
                     $tokenBeforePlus = $phpcsFile->findPrevious(
-                        PHP_CodeSniffer_Tokens::$emptyTokens,
+                        \PHP_CodeSniffer_Tokens::$emptyTokens,
                         ($tokenBefore - 1),
                         $searchStartToken,
                         true

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
@@ -9,6 +9,10 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
  * PHP 7.1 Forbidden variable names in closure use statements.
  *
@@ -21,7 +25,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenClosureUseVariableNamesSniff extends PHPCompatibility_Sniff
+class ForbiddenClosureUseVariableNamesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniff.php
@@ -42,13 +42,13 @@ class ForbiddenClosureUseVariableNamesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.1') === false) {
             return;
@@ -57,7 +57,7 @@ class ForbiddenClosureUseVariableNamesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify this use statement is used with a closure - if so, it has to have parenthesis before it.
-        $previousNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $previousNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($previousNonEmpty === false || $tokens[$previousNonEmpty]['code'] !== T_CLOSE_PARENTHESIS
             || isset($tokens[$previousNonEmpty]['parenthesis_opener']) === false
         ) {
@@ -65,7 +65,7 @@ class ForbiddenClosureUseVariableNamesSniff extends Sniff
         }
 
         // ... and (a variable within) parenthesis after it.
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -75,7 +75,7 @@ class ForbiddenClosureUseVariableNamesSniff extends Sniff
             return;
         }
 
-        $closurePtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
+        $closurePtr = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($tokens[$previousNonEmpty]['parenthesis_opener'] - 1), null, true);
         if ($closurePtr === false || $tokens[$closurePtr]['code'] !== T_CLOSURE) {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -43,8 +43,8 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     {
         // Set up a list of tokens to disregard when determining whether the list() is empty.
         // Only needs to be set up once.
-        $this->ignoreTokens = PHP_CodeSniffer_Tokens::$emptyTokens;
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<')) {
+        $this->ignoreTokens = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.0', '<')) {
             $this->ignoreTokens = array_combine($this->ignoreTokens, $this->ignoreTokens);
         }
         $this->ignoreTokens[T_COMMA]             = T_COMMA;
@@ -58,13 +58,13 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0')) {
             $tokens = $phpcsFile->getTokens();

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenEmptyListAssignmentSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenEmptyListAssignmentSniff.
  *
  * Empty list() assignments have been removed in PHP 7.0
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff extends PHPCompatibility_Sniff
+class ForbiddenEmptyListAssignmentSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -12,6 +12,7 @@
 namespace PHPCompatibility\Sniffs\PHP;
 
 use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\PHP\ForbiddenEmptyListAssignmentSniff.
@@ -44,7 +45,7 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
         // Set up a list of tokens to disregard when determining whether the list() is empty.
         // Only needs to be set up once.
         $this->ignoreTokens = \PHP_CodeSniffer_Tokens::$emptyTokens;
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.0', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
             $this->ignoreTokens = array_combine($this->ignoreTokens, $this->ignoreTokens);
         }
         $this->ignoreTokens[T_COMMA]             = T_COMMA;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameName.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenFunctionParametersWithSameName.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameName.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenFunctionParametersWithSameName.
  *
  * Functions can not have multiple parameters with the same name since PHP 7.0
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff extends PHPCompatibility_Sniff
+class ForbiddenFunctionParametersWithSameNameSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -44,13 +44,13 @@ class ForbiddenFunctionParametersWithSameNameSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
@@ -40,13 +40,13 @@ class ForbiddenGlobalVariableVariableSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenGlobalVariableVariableSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenGlobalVariableVariableSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenGlobalVariableVariableSniff.
  *
  * Variable variables are forbidden with global
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff extends PHPCompatibility_Sniff
+class ForbiddenGlobalVariableVariableSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -109,13 +109,13 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -134,7 +134,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
 
         if (in_array($tokenCode, array(T_CLASS, T_INTERFACE, T_TRAIT), true)) {
             // Check for the declared name being a name which is not tokenized as T_STRING.
-            $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty !== false && isset($this->forbiddenTokens[$tokens[$nextNonEmpty]['code']]) === true) {
                 $name = $tokens[$nextNonEmpty]['content'];
             } else {
@@ -170,7 +170,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
             }
         } elseif ($tokenCode === T_STRING) {
             // Traits and namespaces which are not yet tokenized as T_TRAIT/T_NAMESPACE.
-            $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
             if ($nextNonEmpty === false) {
                 return;
             }
@@ -195,7 +195,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
                         break;
                     }
 
-                    $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
+                    $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $endOfStatement, true);
                 } while ($nextNonEmpty !== false);
             }
             unset($nextNonEmptyCode, $nextNonEmptyLc, $endOfStatement);

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredClassSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsDeclaredClassSniff.
  *
  * PHP version 7.0+
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredClassSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsDeclaredClassSniff.
  *
  * Prohibits the use of some reserved keywords to name a class, interface, trait or namespace.
  * Emits errors for reserved words and warnings for soft-reserved words.
@@ -23,7 +27,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff extends PHPCompatibility_Sniff
+class ForbiddenNamesAsDeclaredSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -82,13 +82,13 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens         = $phpcsFile->getTokens();
         $tokenCode      = $tokens[$stackPtr]['code'];
@@ -109,14 +109,14 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
         }
 
         // Make sure this is a function call.
-        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($next === false || $tokens[$next]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
             return;
         }
 
         // This sniff isn't concerned about function declaration.
-        $prev = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prev = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prev !== false && $tokens[$prev]['code'] === T_FUNCTION) {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsInvokedFunctionsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,8 +8,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsInvokedFunctionsSniff.
  *
  * Prohibits the use of reserved keywords invoked as functions.
  *
@@ -18,7 +22,7 @@
  * @author    Jansen Price <jansen.price@gmail.com>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff extends PHPCompatibility_Sniff
+class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,8 +8,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesSniff.
  *
  * Prohibits the use of reserved keywords as class, function, namespace or constant names.
  *
@@ -18,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff extends PHPCompatibility_Sniff
+class ForbiddenNamesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -11,6 +11,7 @@
 namespace PHPCompatibility\Sniffs\PHP;
 
 use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\PHP\ForbiddenNamesSniff.
@@ -140,7 +141,7 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->isLowPHPCS = version_compare(\PHP_CodeSniffer::VERSION, '2.0', '<');
+        $this->isLowPHPCS = version_compare(PHPCSHelper::getVersion(), '2.0', '<');
 
         $this->allowed_modifiers          = array_combine(
             \PHP_CodeSniffer_Tokens::$scopeModifiers,

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -140,11 +140,11 @@ class ForbiddenNamesSniff extends Sniff
      */
     public function register()
     {
-        $this->isLowPHPCS = version_compare(PHP_CodeSniffer::VERSION, '2.0', '<');
+        $this->isLowPHPCS = version_compare(\PHP_CodeSniffer::VERSION, '2.0', '<');
 
         $this->allowed_modifiers          = array_combine(
-            PHP_CodeSniffer_Tokens::$scopeModifiers,
-            PHP_CodeSniffer_Tokens::$scopeModifiers
+            \PHP_CodeSniffer_Tokens::$scopeModifiers,
+            \PHP_CodeSniffer_Tokens::$scopeModifiers
         );
         $this->allowed_modifiers[T_FINAL] = T_FINAL;
 
@@ -158,13 +158,13 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -181,17 +181,17 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     * @param array                $tokens    The stack of tokens that make up
-     *                                        the file.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     * @param array                 $tokens    The stack of tokens that make up
+     *                                         the file.
      *
      * @return void
      */
-    public function processNonString(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processNonString(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
     {
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             return;
         }
@@ -202,7 +202,7 @@ class ForbiddenNamesSniff extends Sniff
          * In PHPCS < 2.3.4 these were tokenized as T_CLASS no matter what.
          */
         if ($tokens[$stackPtr]['type'] === 'T_ANON_CLASS' || $tokens[$stackPtr]['type'] === 'T_CLASS') {
-            $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
             if ($prevNonEmpty !== false && $tokens[$prevNonEmpty]['type'] === 'T_NEW') {
                 return;
             }
@@ -216,7 +216,7 @@ class ForbiddenNamesSniff extends Sniff
         elseif ($tokens[$stackPtr]['type'] === 'T_USE'
             && isset($this->validUseNames[strtolower($tokens[$nextNonEmpty]['content'])]) === true
         ) {
-            $maybeUseNext = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext !== false && $this->isEndOfUseStatement($tokens[$maybeUseNext]) === false) {
                 // Prevent duplicate messages: `const` is T_CONST in PHPCS 1.x and T_STRING in PHPCS 2.x.
                 if ($this->isLowPHPCS === true) {
@@ -235,7 +235,7 @@ class ForbiddenNamesSniff extends Sniff
             && isset($this->allowed_modifiers[$tokens[$nextNonEmpty]['code']]) === true
             && $this->inUseScope($phpcsFile, $stackPtr) === true
         ) {
-            $maybeUseNext = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false || $this->isEndOfUseStatement($tokens[$maybeUseNext]) === true) {
                 return;
             }
@@ -249,7 +249,7 @@ class ForbiddenNamesSniff extends Sniff
         elseif ($tokens[$stackPtr]['type'] === 'T_FUNCTION'
             && $tokens[$nextNonEmpty]['type'] === 'T_BITWISE_AND'
         ) {
-            $maybeUseNext = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
+            $maybeUseNext = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true, null, true);
             if ($maybeUseNext === false) {
                 // Live coding.
                 return;
@@ -325,15 +325,15 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     * @param array                $tokens    The stack of tokens that make up
-     *                                        the file.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     * @param array                 $tokens    The stack of tokens that make up
+     *                                         the file.
      *
      * @return void
      */
-    public function processString(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
+    public function processString(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $tokens)
     {
         $tokenContentLc = strtolower($tokens[$stackPtr]['content']);
 
@@ -377,11 +377,11 @@ class ForbiddenNamesSniff extends Sniff
     /**
      * Add the error message.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
-     * @param string               $content   The token content found.
-     * @param array                $data      The data to pass into the error message.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     * @param string                $content   The token content found.
+     * @param array                 $data      The data to pass into the error message.
      *
      * @return void
      */

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -41,13 +41,13 @@ class ForbiddenNegativeBitshiftSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNegativeBitshiftSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshift.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNegativeBitshift.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshift.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenNegativeBitshift.
  *
  * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff extends PHPCompatibility_Sniff
+class ForbiddenNegativeBitshiftSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenSwitchWithMultipleDefaultBlocksSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff.
+ * \PHPCompatibility\Sniffs\PHP\ForbiddenSwitchWithMultipleDefaultBlocksSniff.
  *
  * Switch statements can not have multiple default blocks since PHP 7.0
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff extends PHPCompatibility_Sniff
+class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniff.php
@@ -41,13 +41,13 @@ class ForbiddenSwitchWithMultipleDefaultBlocksSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
@@ -59,13 +59,13 @@ class InternalInterfacesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $interfaces = $this->findImplementedInterfaceNames($phpcsFile, $stackPtr);
 

--- a/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff.
+ * \PHPCompatibility\Sniffs\PHP\InternalInterfacesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff.
+ * \PHPCompatibility\Sniffs\PHP\InternalInterfacesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff extends PHPCompatibility_Sniff
+class InternalInterfacesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/LateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/LateStaticBindingSniff.php
@@ -39,15 +39,15 @@ class LateStaticBindingSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         if ($nextNonEmpty === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/LateStaticBindingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/LateStaticBindingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff.
+ * \PHPCompatibility\Sniffs\PHP\LateStaticBindingSniff.
  *
  * PHP version 5.3
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff.
+ * \PHPCompatibility\Sniffs\PHP\LateStaticBindingSniff.
  *
  * PHP version 5.3
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff extends PHPCompatibility_Sniff
+class LateStaticBindingSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff.
+ * \PHPCompatibility\Sniffs\PHP\MbstringReplaceEModifierSniff.
  *
  * PHP version 7.1
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff.
+ * \PHPCompatibility\Sniffs\PHP\MbstringReplaceEModifierSniff.
  *
  * PHP version 7.1
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff extends PHPCompatibility_Sniff
+class MbstringReplaceEModifierSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/MbstringReplaceEModifierSniff.php
@@ -53,13 +53,13 @@ class MbstringReplaceEModifierSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.1') === false) {
             return;
@@ -79,7 +79,7 @@ class MbstringReplaceEModifierSniff extends Sniff
             return;
         }
 
-        $stringToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
+        $stringToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$stringTokens, $optionsParam['start'], $optionsParam['end'] + 1);
         if ($stringToken === false) {
             // No string token found in the options parameter, so skip it (e.g. variable passed in).
             return;
@@ -91,7 +91,7 @@ class MbstringReplaceEModifierSniff extends Sniff
          * Get the content of any string tokens in the options parameter and remove the quotes and variables.
          */
         for ($i = $stringToken; $i <= $optionsParam['end']; $i++) {
-            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === false) {
+            if (in_array($tokens[$i]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === false) {
                 continue;
             }
 

--- a/PHPCompatibility/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewAnonymousClasses.
+ * \PHPCompatibility\Sniffs\PHP\NewAnonymousClasses.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewAnonymousClasses.
+ * \PHPCompatibility\Sniffs\PHP\NewAnonymousClasses.
  *
  * Anonymous classes are supported in PHP 7.0
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff extends PHPCompatibility_Sniff
+class NewAnonymousClassesSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewAnonymousClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewAnonymousClassesSniff.php
@@ -57,20 +57,20 @@ class NewAnonymousClassesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') === false) {
             return;
         }
 
         $tokens       = $phpcsFile->getTokens();
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         if ($nextNonEmpty === false || isset($this->indicators[$tokens[$nextNonEmpty]['code']]) === false) {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewArrayStringDereferencingSniff.php
@@ -43,13 +43,13 @@ class NewArrayStringDereferencingSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -89,7 +89,7 @@ class NewArrayStringDereferencingSniff extends Sniff
             return;
         }
 
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true, null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true, null, true);
 
         if ($nextNonEmpty !== false &&
             ($tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET' ||

--- a/PHPCompatibility/Sniffs/PHP/NewArrayStringDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewArrayStringDereferencingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewArrayStringDereferencingSniff.
  *
  * PHP version 5.5
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewArrayStringDereferencingSniff.
  *
  * Array and string literals can now be dereferenced directly to access individual elements and characters.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff extends PHPCompatibility_Sniff
+class NewArrayStringDereferencingSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -370,13 +370,13 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -401,13 +401,13 @@ class NewClassesSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test for when a token resulting in a singular class name is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    private function processSingularToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processSingularToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens      = $phpcsFile->getTokens();
         $FQClassName = '';
@@ -447,13 +447,13 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new classes when used as a type hint.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    private function processFunctionToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processFunctionToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         // Retrieve typehints stripped of global NS indicator and/or nullable indicator.
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
@@ -481,13 +481,13 @@ class NewClassesSniff extends AbstractNewFeatureSniff
      *
      * - Detect exceptions when used in a catch statement.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    private function processCatchToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processCatchToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewClassesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewClassesSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,15 +8,19 @@
  * @copyright 2013 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewClassesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewClassesSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewClassesSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewClassesSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewClosure.
+ * \PHPCompatibility\Sniffs\PHP\NewClosure.
  *
  * PHP version 5.3
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewClosure.
+ * \PHPCompatibility\Sniffs\PHP\NewClosure.
  *
  * Closures are available since PHP 5.3
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewClosureSniff extends PHPCompatibility_Sniff
+class NewClosureSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
@@ -40,13 +40,13 @@ class NewClosureSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2')) {
             $phpcsFile->addError(
@@ -131,16 +131,16 @@ class NewClosureSniff extends Sniff
     /**
      * Check whether the closure is declared as static.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return bool
      */
-    protected function isClosureStatic(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function isClosureStatic(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
         return ($prevToken !== false && $tokens[$prevToken]['code'] === T_STATIC);
     }
@@ -149,14 +149,14 @@ class NewClosureSniff extends Sniff
     /**
      * Check if the code within a closure uses the $this variable.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile  The file being scanned.
-     * @param int                  $stackPtr   The position of the closure token.
-     * @param int                  $startToken Optional. The position within the closure to continue searching from.
+     * @param \PHP_CodeSniffer_File $phpcsFile  The file being scanned.
+     * @param int                   $stackPtr   The position of the closure token.
+     * @param int                   $startToken Optional. The position within the closure to continue searching from.
      *
      * @return int|false The stackPtr to the first $this usage if found or false if
      *                   $this is not used or usage of $this could not reliably be determined.
      */
-    protected function findThisUsageInClosure(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $startToken = null)
+    protected function findThisUsageInClosure(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $startToken = null)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -40,23 +40,23 @@ class NewConstVisibilitySniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;
         }
 
         $tokens    = $phpcsFile->getTokens();
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
 
         // Is the previous token a visibility indicator ?
-        if ($prevToken === false || in_array($tokens[$prevToken]['code'], PHP_CodeSniffer_Tokens::$scopeModifiers, true) === false) {
+        if ($prevToken === false || in_array($tokens[$prevToken]['code'], \PHP_CodeSniffer_Tokens::$scopeModifiers, true) === false) {
             return;
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstVisibilitySniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewConstVisibility.
+ * \PHPCompatibility\Sniffs\PHP\NewConstVisibility.
  *
  * PHP version 7.1
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewConstVisibility.
+ * \PHPCompatibility\Sniffs\PHP\NewConstVisibility.
  *
  * Visibility for class constants is available since PHP 7.1.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff extends PHPCompatibility_Sniff
+class NewConstVisibilitySniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -65,7 +65,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
      */
     public function register()
     {
-        $this->ignoreTokens          = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $this->ignoreTokens          = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $this->ignoreTokens[T_EQUAL] = T_EQUAL;
 
         return array(T_DECLARE);
@@ -75,13 +75,13 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -89,7 +89,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             $openParenthesis  = $tokens[$stackPtr]['parenthesis_opener'];
             $closeParenthesis = $tokens[$stackPtr]['parenthesis_closer'];
         } else {
-            if (version_compare(PHP_CodeSniffer::VERSION, '2.3.4', '>=')) {
+            if (version_compare(\PHP_CodeSniffer::VERSION, '2.3.4', '>=')) {
                 return;
             }
 
@@ -220,16 +220,16 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Generates the error or warning for this item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
-     * @param array                $errorInfo Array with detail (version) information
-     *                                        relevant to the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
      *
      * @return void
      */
-    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         if ($errorInfo['not_in_version'] !== '') {
             parent::addError($phpcsFile, $stackPtr, $itemInfo, $errorInfo);
@@ -251,19 +251,19 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Generates a error or warning for this sniff.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the execution directive value
-     *                                        in the token array.
-     * @param string               $directive The directive.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the execution directive value
+     *                                         in the token array.
+     * @param string                $directive The directive.
      *
      * @return void
      */
-    protected function addWarningOnInvalidValue($phpcsFile, $stackPtr, $directive)
+    protected function addWarningOnInvalidValue(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $directive)
     {
         $tokens = $phpcsFile->getTokens();
 
         $value = $tokens[$stackPtr]['content'];
-        if (in_array($tokens[$stackPtr]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
+        if (in_array($tokens[$stackPtr]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
             $value = $this->stripQuotes($value);
         }
 

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewExecutionDirectivesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewExecutionDirectivesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewExecutionDirectivesSniff.php
@@ -10,6 +10,7 @@
 namespace PHPCompatibility\Sniffs\PHP;
 
 use PHPCompatibility\AbstractNewFeatureSniff;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * \PHPCompatibility\Sniffs\PHP\NewExecutionDirectivesSniff.
@@ -89,7 +90,7 @@ class NewExecutionDirectivesSniff extends AbstractNewFeatureSniff
             $openParenthesis  = $tokens[$stackPtr]['parenthesis_opener'];
             $closeParenthesis = $tokens[$stackPtr]['parenthesis_closer'];
         } else {
-            if (version_compare(\PHP_CodeSniffer::VERSION, '2.3.4', '>=')) {
+            if (version_compare(PHPCSHelper::getVersion(), '2.3.4', '>=')) {
                 return;
             }
 

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -37,13 +37,13 @@ class NewFunctionArrayDereferencingSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.3') === false) {
             return;
@@ -52,7 +52,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Next non-empty token should be the open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $openParenthesis = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
         if ($openParenthesis === false || $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
@@ -63,7 +63,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         }
 
         // Is this T_STRING really a function or method call ?
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         if ($prevToken !== false && in_array($tokens[$prevToken]['code'], array(T_DOUBLE_COLON, T_OBJECT_OPERATOR), true) === false) {
             $ignore = array(
                 T_FUNCTION,
@@ -81,7 +81,7 @@ class NewFunctionArrayDereferencingSniff extends Sniff
         }
 
         $closeParenthesis = $tokens[$openParenthesis]['parenthesis_closer'];
-        $nextNonEmpty     = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
+        $nextNonEmpty     = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($closeParenthesis + 1), null, true, null, true);
         if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['type'] === 'T_OPEN_SQUARE_BRACKET') {
             $phpcsFile->addError(
                 'Function array dereferencing is not present in PHP version 5.3 or earlier',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionArrayDereferencingSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewFunctionArrayDereferencingSniff.
  *
  * PHP version 5.4
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewFunctionArrayDereferencingSniff.
  *
  * PHP version 5.4
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff extends PHPCompatibility_Sniff
+class NewFunctionArrayDereferencingSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -757,13 +757,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -793,7 +793,7 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->newFunctionParameters[$functionLc] as $offset => $parameterDetails) {

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_newFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\newFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewFunctionParametersSniff extends AbstractNewFeatureSniff
 {
     /**
      * A list of new functions, not present in older versions.

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1280,13 +1280,13 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewFunctionsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_newFunctionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\newFunctionsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewFunctionsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewFunctionsSniff extends AbstractNewFeatureSniff
 {
     /**
      * A list of new functions, not present in older versions.

--- a/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
@@ -42,13 +42,13 @@ class NewGroupUseDeclarationsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.6') === false) {
             return;
@@ -64,7 +64,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
                 return;
             }
 
-            $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($hasCurlyBrace - 1), null, true);
+            $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($hasCurlyBrace - 1), null, true);
             if ($prevToken === false || $tokens[$prevToken]['code'] !== T_NS_SEPARATOR) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewGroupUseDeclarationsSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewGroupUseDeclarationsSniff.
  *
  * PHP version 7.0
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff extends PHPCompatibility_Sniff
+class NewGroupUseDeclarationsSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewHashAlgorithmsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewHashAlgorithmsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
 {
     /**
      * A list of new hash algorithms, not present in older versions.

--- a/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -91,13 +91,13 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
         if (empty($algo) || is_string($algo) === false) {

--- a/PHPCompatibility/Sniffs/PHP/NewHeredocInitializeSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewHeredocInitializeSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewHeredocInitializeSniff.
  *
  * PHP version 5.3
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewHeredocInitializeSniff.
  *
  * As of PHP 5.3.0, it's possible to initialize static variables and class
  * properties/constants using the Heredoc syntax.
@@ -21,7 +25,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff extends PHPCompatibility_Sniff
+class NewHeredocInitializeSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewHeredocInitializeSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewHeredocInitializeSniff.php
@@ -41,13 +41,13 @@ class NewHeredocInitializeSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2') !== true) {
             return;
@@ -55,13 +55,13 @@ class NewHeredocInitializeSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $equalSign = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $equalSign = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($equalSign === false || $tokens[$equalSign]['code'] !== T_EQUAL) {
             // Not an assignment.
             return;
         }
 
-        $prevNonEmpty = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($equalSign - 1), null, true, null, true);
+        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($equalSign - 1), null, true, null, true);
         if ($prevNonEmpty === false
             || ($tokens[$prevNonEmpty]['code'] !== T_VARIABLE
                 && $tokens[$prevNonEmpty]['code'] !== T_STRING)
@@ -76,7 +76,7 @@ class NewHeredocInitializeSniff extends Sniff
              */
             case 'T_STRING':
                 // Walk back to check for the const keyword.
-                $constPtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
+                $constPtr = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
                 if ($constPtr === false || $tokens[$constPtr]['code'] !== T_CONST) {
                     // Not a constant assignment.
                     return;
@@ -100,7 +100,7 @@ class NewHeredocInitializeSniff extends Sniff
                  */
                 else {
                     // Walk back to check this is a static variable `static $var =`.
-                    $staticPtr = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
+                    $staticPtr = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true, null, true);
                     if ($staticPtr === false || $tokens[$staticPtr]['code'] !== T_STATIC) {
                         // Not a static variable assignment.
                         return;
@@ -117,13 +117,13 @@ class NewHeredocInitializeSniff extends Sniff
     /**
      * Throw an error if a non-static value is found.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the token to link the error to.
-     * @param string               $type      Type of usage found.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token to link the error to.
+     * @param string                $type      Type of usage found.
      *
      * @return void
      */
-    protected function throwError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, $type)
+    protected function throwError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $type)
     {
         switch ($type) {
             case 'const':

--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewIniDirectivesSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,8 +8,12 @@
  * @copyright 2013 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewIniDirectivesSniff.
  *
  * Discourages the use of new INI directives through ini_set() or ini_get().
  *
@@ -18,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewIniDirectivesSniff extends AbstractNewFeatureSniff
 {
     /**
      * A list of new INI directives

--- a/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewIniDirectivesSniff.php
@@ -478,13 +478,13 @@ class NewIniDirectivesSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewInterfacesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewInterfacesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewInterfacesSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewInterfacesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewInterfacesSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewInterfacesSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -126,13 +126,13 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -161,13 +161,13 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      * - Detect classes implementing the new interfaces.
      * - Detect classes implementing the new interfaces with unsupported functions.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    private function processClassToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processClassToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $interfaces = $this->findImplementedInterfaceNames($phpcsFile, $stackPtr);
 
@@ -225,13 +225,13 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
      *
      * - Detect new interfaces when used as a type hint.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    private function processFunctionToken(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    private function processFunctionToken(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $typeHints = $this->getTypeHintsFromFunctionDeclaration($phpcsFile, $stackPtr);
         if (empty($typeHints) || is_array($typeHints) === false) {

--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewKeywordsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewKeywordsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,15 +8,19 @@
  * @copyright 2013 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewKeywordsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewKeywordsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewKeywordsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewKeywordsSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -171,13 +171,13 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];
@@ -229,8 +229,8 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
             return;
         }
 
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true);
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true);
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
 
         // Skip attempts to use keywords as functions or class names - the former

--- a/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewLanguageConstructsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,15 +8,19 @@
  * @copyright 2013 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewLanguageConstructsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2013 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -147,13 +147,13 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];

--- a/PHPCompatibility/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -41,13 +41,13 @@ class NewMagicClassConstantSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.4') === false) {
             return;
@@ -59,7 +59,7 @@ class NewMagicClassConstantSniff extends Sniff
             return;
         }
 
-        $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
         if ($prevToken === false || $tokens[$prevToken]['code'] !== T_DOUBLE_COLON) {
             return;
         }

--- a/PHPCompatibility/Sniffs/PHP/NewMagicClassConstantSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMagicClassConstantSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewMagicClassConstantSniff.
  *
  * PHP version 5.5
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewMagicClassConstantSniff.
  *
  * The special ClassName::class constant is available as of PHP 5.5.0, and allows for
  * fully qualified class name resolution at compile.
@@ -21,7 +25,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff extends PHPCompatibility_Sniff
+class NewMagicClassConstantSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMagicMethodsSniff.php
@@ -90,13 +90,13 @@ class NewMagicMethodsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $functionName   = $phpcsFile->getDeclarationName($stackPtr);
         $functionNameLc = strtolower($functionName);

--- a/PHPCompatibility/Sniffs/PHP/NewMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMagicMethodsSniff.php
@@ -1,14 +1,18 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewMagicMethodsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewMagicMethodsSniff.
  *
  * Warns for non-magic behaviour of magic methods prior to becoming magic.
  *
@@ -16,7 +20,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewMagicMethodsSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMultiCatchSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewMultiCatch.
+ * \PHPCompatibility\Sniffs\PHP\NewMultiCatch.
  *
  * PHP version 7.1
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewMultiCatch.
+ * \PHPCompatibility\Sniffs\PHP\NewMultiCatch.
  *
  * Catching multiple exception types in one statement is available since PHP 7.1.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewMultiCatchSniff extends PHPCompatibility_Sniff
+class NewMultiCatchSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewMultiCatchSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewMultiCatchSniff.php
@@ -40,13 +40,13 @@ class NewMultiCatchSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/NewNowdocQuotedHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNowdocQuotedHeredocSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewNowdocQuotedHeredocSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewNowdocQuotedHeredocSniff.
  *
  * PHP version 5.3
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewNowdocQuotedHeredocSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewNowdocQuotedHeredocSniff.
  *
  * PHP 5.3 introduces Nowdoc syntax and (double) quoted identifiers for heredocs.
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewNowdocQuotedHeredocSniff extends PHPCompatibility_Sniff
+class NewNowdocQuotedHeredocSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewNowdocQuotedHeredocSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNowdocQuotedHeredocSniff.php
@@ -55,15 +55,15 @@ class NewNowdocQuotedHeredocSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return int|void On older PHP versions passes a pointer to the nowdoc/heredoc closer
      *                  to skip passed anything in between in regards to processing
      *                  the file for this sniff.
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
@@ -54,13 +54,13 @@ class NewNullableTypesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('7.0') === false) {
             return;
@@ -87,13 +87,13 @@ class NewNullableTypesSniff extends Sniff
     /**
      * Process this test for function tokens.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    protected function processFunctionDeclaration(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processFunctionDeclaration(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $params = $this->getMethodParameters($phpcsFile, $stackPtr);
 
@@ -115,13 +115,13 @@ class NewNullableTypesSniff extends Sniff
     /**
      * Process this test for return type tokens.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    protected function processReturnType(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function processReturnType(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewNullableTypes.
+ * \PHPCompatibility\Sniffs\PHP\NewNullableTypes.
  *
  * PHP version 7.1
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewNullableTypes.
+ * \PHPCompatibility\Sniffs\PHP\NewNullableTypes.
  *
  * Nullable type hints and return types are available since PHP 7.1.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewNullableTypesSniff extends PHPCompatibility_Sniff
+class NewNullableTypesSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewReturnTypeDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewReturnTypeDeclarationsSniff.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewReturnTypeDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewReturnTypeDeclarationsSniff.
  *
  * PHP version 7.0
  *
@@ -18,7 +22,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewReturnTypeDeclarationsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
@@ -97,13 +97,13 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewScalarTypeDeclarationsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewScalarTypeDeclarationsSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff extends PHPCompatibility_AbstractNewFeatureSniff
+class NewScalarTypeDeclarationsSniff extends AbstractNewFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -93,13 +93,13 @@ class NewScalarTypeDeclarationsSniff extends AbstractNewFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         // Get all parameters from method signature.
         $paramNames = $this->getMethodParameters($phpcsFile, $stackPtr);

--- a/PHPCompatibility/Sniffs/PHP/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewUseConstFunctionSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewUseConstFunctionSniff.
  *
  * PHP version 5.6
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff.
+ * \PHPCompatibility\Sniffs\PHP\NewUseConstFunctionSniff.
  *
  * The use operator has been extended to support importing functions and
  * constants in addition to classes. This is achieved via the use function
@@ -22,7 +26,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff extends PHPCompatibility_Sniff
+class NewUseConstFunctionSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewUseConstFunctionSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewUseConstFunctionSniff.php
@@ -53,13 +53,13 @@ class NewUseConstFunctionSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.5') !== true) {
             return;
@@ -67,7 +67,7 @@ class NewUseConstFunctionSniff extends Sniff
 
         $tokens = $phpcsFile->getTokens();
 
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
         if ($nextNonEmpty === false) {
             // Live coding.
             return;
@@ -79,7 +79,7 @@ class NewUseConstFunctionSniff extends Sniff
         }
 
         // `use const` and `use function` have to be followed by the function/constant name.
-        $functionOrConstName = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
+        $functionOrConstName = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), null, true);
         if ($functionOrConstName === false
             // Identifies as T_AS or T_STRING, this covers both.
             || ($tokens[$functionOrConstName]['content'] === 'as'

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NonStaticMagicMethodsSniff.
  *
  * PHP version 5.4
  *
@@ -10,8 +10,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff.
+ * \PHPCompatibility\Sniffs\PHP\NonStaticMagicMethodsSniff.
  *
  * Verifies the use of the correct visibility and static properties of magic methods.
  *
@@ -20,7 +24,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff extends PHPCompatibility_Sniff
+class NonStaticMagicMethodsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -100,13 +100,13 @@ class NonStaticMagicMethodsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         // Should be removed, the requirement was previously also there, 5.3 just started throwing a warning about it.
         if ($this->supportsAbove('5.3') === false) {

--- a/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff
+ * \PHPCompatibility\Sniffs\PHP\ParameterShadowSuperGlobalsSniff
  *
  * PHP version 5.4
  *
@@ -10,8 +10,12 @@
  * @copyright 2015 Declan Kelly
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff
+ * \PHPCompatibility\Sniffs\PHP\ParameterShadowSuperGlobalsSniff
  *
  * Discourages use of superglobals as parameters for functions.
  *
@@ -24,7 +28,7 @@
  * @author    Declan Kelly <declankelly90@gmail.com>
  * @copyright 2015 Declan Kelly
  */
-class PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff extends PHPCompatibility_Sniff
+class ParameterShadowSuperGlobalsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ParameterShadowSuperGlobalsSniff.php
@@ -47,12 +47,12 @@ class ParameterShadowSuperGlobalsSniff extends Sniff
     /**
      * Processes the test.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.4') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -65,13 +65,13 @@ class PregReplaceEModifierSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.5') === false) {
             return;
@@ -93,7 +93,7 @@ class PregReplaceEModifierSniff extends Sniff
         }
 
         // Differentiate between an array of patterns passed and a single pattern.
-        $nextNonEmpty = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $firstParam['start'], ($firstParam['end'] +1), true);
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $firstParam['start'], ($firstParam['end'] +1), true);
         if ($nextNonEmpty !== false && ($tokens[$nextNonEmpty]['code'] === T_ARRAY || $tokens[$nextNonEmpty]['code'] === T_OPEN_SHORT_ARRAY)) {
             $arrayValues = $this->getFunctionCallParameters($phpcsFile, $nextNonEmpty);
             foreach ($arrayValues as $value) {
@@ -116,17 +116,17 @@ class PregReplaceEModifierSniff extends Sniff
     /**
      * Analyse a potential regex pattern for usage of the /e modifier.
      *
-     * @param array                $pattern      Array containing the start and end token
-     *                                           pointer of the potential regex pattern and
-     *                                           the raw string value of the pattern.
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token in the
-     *                                           stack passed in $tokens.
-     * @param string               $functionName The function which contained the pattern.
+     * @param array                 $pattern      Array containing the start and end token
+     *                                            pointer of the potential regex pattern and
+     *                                            the raw string value of the pattern.
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the
+     *                                            stack passed in $tokens.
+     * @param string                $functionName The function which contained the pattern.
      *
      * @return void
      */
-    protected function processRegexPattern($pattern, $phpcsFile, $stackPtr, $functionName)
+    protected function processRegexPattern($pattern, \PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -136,7 +136,7 @@ class PregReplaceEModifierSniff extends Sniff
          */
         $regex = '';
         for ($i = $pattern['start']; $i <= $pattern['end']; $i++) {
-            if (in_array($tokens[$i]['code'], PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
+            if (in_array($tokens[$i]['code'], \PHP_CodeSniffer_Tokens::$stringTokens, true) === true) {
                 $content = $this->stripQuotes($tokens[$i]['content']);
                 if ($tokens[$i]['code'] === T_DOUBLE_QUOTED_STRING) {
                     $content = $this->stripVariables($content);

--- a/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff.
+ * \PHPCompatibility\Sniffs\PHP\PregReplaceEModifierSniff.
  *
  * PHP version 5.5
  *
@@ -10,8 +10,12 @@
  * @copyright 2014 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff.
+ * \PHPCompatibility\Sniffs\PHP\PregReplaceEModifierSniff.
  *
  * Check for usage of the `e` modifier with PCRE functions which is deprecated since PHP 5.5
  * and removed as of PHP 7.0.
@@ -23,7 +27,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2014 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff extends PHPCompatibility_Sniff
+class PregReplaceEModifierSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -60,13 +60,13 @@ class RemovedAlternativePHPTagsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTags.
+ * \PHPCompatibility\Sniffs\PHP\RemovedAlternativePHPTags.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTags.
+ * \PHPCompatibility\Sniffs\PHP\RemovedAlternativePHPTags.
  *
  * Check for usage of alternative PHP tags - removed in PHP 7.0.
  *
@@ -23,7 +27,7 @@
  * Based on `Generic_Sniffs_PHP_DisallowAlternativePHPTags` by Juliette Reinders Folmer
  * which was merged into PHPCS 2.7.0.
  */
-class PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff extends PHPCompatibility_Sniff
+class RemovedAlternativePHPTagsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedExtensionsSniff.
  *
  * @category  PHP
  * @package   PHPCompatibility
@@ -8,8 +8,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedExtensionsSniff.
  *
  * Discourages the use of removed extensions. Suggests alternative extensions if available
  *
@@ -18,7 +22,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
 {
     /**
      * A list of functions to whitelist, if any.

--- a/PHPCompatibility/Sniffs/PHP/RemovedExtensionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedExtensionsSniff.php
@@ -188,18 +188,18 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
         // Find the next non-empty token.
-        $openBracket = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $openBracket = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($tokens[$openBracket]['code'] !== T_OPEN_PARENTHESIS) {
             // Not a function call.
@@ -212,7 +212,7 @@ class RemovedExtensionsSniff extends AbstractRemovedFeatureSniff
         }
 
         // Find the previous non-empty token.
-        $search   = PHP_CodeSniffer_Tokens::$emptyTokens;
+        $search   = \PHP_CodeSniffer_Tokens::$emptyTokens;
         $search[] = T_BITWISE_AND;
         $previous = $phpcsFile->findPrevious($search, ($stackPtr - 1), null, true);
         if ($tokens[$previous]['code'] === T_FUNCTION) {

--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -75,13 +75,13 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -111,7 +111,7 @@ class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis      = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->removedFunctionParameters[$functionLc] as $offset => $parameterDetails) {

--- a/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedFunctionParametersSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class RemovedFunctionParametersSniff extends AbstractRemovedFeatureSniff
 {
     /**
      * A list of removed function parameters, which were present in older versions.

--- a/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -91,13 +91,13 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('5.3') === false) {
             return;
@@ -117,7 +117,7 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // Check for static usage of class properties shadowing the removed global variables.
         if ($this->inClassScope($phpcsFile, $stackPtr, false) === true) {
-            $prevToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+            $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
             if ($prevToken !== false && $tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
                 return;
             }

--- a/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -1,14 +1,18 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedGlobalVariablesSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedGlobalVariablesSniff.
  *
  * Discourages the use of removed global variables. Suggests alternative extensions if available
  *
@@ -16,7 +20,7 @@
  * @package  PHPCompatibility
  * @author   Wim Godden <wim.godden@cu.be>
  */
-class PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedHashAlgorithmsSniff.
  *
  * PHP version 5.4
  *
@@ -10,8 +10,12 @@
  * @copyright 2012 Cu.be Solutions bvba
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff.
+ * \PHPCompatibility\Sniffs\PHP\RemovedHashAlgorithmsSniff.
  *
  * Discourages the use of deprecated and removed hash algorithms.
  *
@@ -22,7 +26,7 @@
  * @author    Wim Godden <wim.godden@cu.be>
  * @copyright 2012 Cu.be Solutions bvba
  */
-class PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff extends PHPCompatibility_AbstractRemovedFeatureSniff
+class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedHashAlgorithmsSniff.php
@@ -61,13 +61,13 @@ class RemovedHashAlgorithmsSniff extends AbstractRemovedFeatureSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $algo = $this->getHashAlgorithmParameter($phpcsFile, $stackPtr);
         if (empty($algo) || is_string($algo) === false) {

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -65,13 +65,13 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -101,7 +101,7 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
         }
 
         // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+        $openParenthesis      = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->functionParameters[$functionLc] as $offset => $parameterDetails) {
@@ -199,16 +199,16 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
     /**
      * Generates the error or warning for this item.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the relevant token in
-     *                                        the stack.
-     * @param array                $itemInfo  Base information about the item.
-     * @param array                $errorInfo Array with detail (version) information
-     *                                        relevant to the item.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
      *
      * @return void
      */
-    public function addError(PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
     {
         $error     = $this->getErrorMsgTemplate();
         $errorCode = $this->stringToErrorCode($itemInfo['name'].'_'.$errorInfo['paramName']).'Missing';

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\RequiredOptionalFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractComplexVersionSniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff.
+ * \PHPCompatibility\Sniffs\PHP\RequiredOptionalFunctionParametersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff extends PHPCompatibility_AbstractComplexVersionSniff
+class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ShortArraySniff.php
@@ -44,13 +44,13 @@ class ShortArraySniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.3') === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/ShortArraySniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ShortArraySniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ShortArray.
+ * \PHPCompatibility\Sniffs\PHP\ShortArray.
  *
  * PHP version 5.4
  *
@@ -9,8 +9,12 @@
  * @author   Alex Miroshnikov <unknown@example.com>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ShortArray.
+ * \PHPCompatibility\Sniffs\PHP\ShortArray.
  *
  * Short array syntax is available since PHP 5.4
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Alex Miroshnikov <unknown@example.com>
  */
-class PHPCompatibility_Sniffs_PHP_ShortArraySniff extends PHPCompatibility_Sniff
+class ShortArraySniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -43,13 +43,13 @@ class TernaryOperatorsSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in the
-     *                                        stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsBelow('5.2') === false) {
             return;
@@ -59,7 +59,7 @@ class TernaryOperatorsSniff extends Sniff
 
         // Get next non-whitespace token, and check it isn't the related inline else
         // symbol, which is not allowed prior to PHP 5.3.
-        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        $next = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
 
         if ($next !== false && $tokens[$next]['code'] === T_INLINE_ELSE) {
             $phpcsFile->addError(

--- a/PHPCompatibility/Sniffs/PHP/TernaryOperatorsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/TernaryOperatorsSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff.
+ * \PHPCompatibility\Sniffs\PHP\TernaryOperatorsSniff.
  *
  * PHP version 5.3
  *
@@ -10,8 +10,12 @@
  * @copyright 2012 Ben Selby
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff.
+ * \PHPCompatibility\Sniffs\PHP\TernaryOperatorsSniff.
  *
  * Performs checks on ternary operators, specifically that the middle expression
  * is not omitted for versions that don't support this.
@@ -23,7 +27,7 @@
  * @author    Ben Selby <bselby@plus.net>
  * @copyright 2012 Ben Selby
  */
-class PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff extends PHPCompatibility_Sniff
+class TernaryOperatorsSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ValidIntegersSniff.php
@@ -48,13 +48,13 @@ class ValidIntegersSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $token  = $tokens[$stackPtr];
@@ -159,14 +159,14 @@ class ValidIntegersSniff extends Sniff
     /**
      * Retrieve the content of the tokens which together look like a binary integer.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param array                $tokens    Token stack.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param array                 $tokens    Token stack.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack.
      *
      * @return string
      */
-    private function getBinaryInteger(PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr)
+    private function getBinaryInteger(\PHP_CodeSniffer_File $phpcsFile, $tokens, $stackPtr)
     {
         $length = 2; // PHP < 5.4 T_LNUMBER + T_STRING.
 

--- a/PHPCompatibility/Sniffs/PHP/ValidIntegersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ValidIntegersSniff.php
@@ -1,20 +1,24 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_ValidIntegersSniff.
+ * \PHPCompatibility\Sniffs\PHP\ValidIntegersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_ValidIntegersSniff.
+ * \PHPCompatibility\Sniffs\PHP\ValidIntegersSniff.
  *
  * @category PHP
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_ValidIntegersSniff extends PHPCompatibility_Sniff
+class ValidIntegersSniff extends Sniff
 {
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
@@ -40,13 +40,13 @@ class VariableVariablesSniff extends Sniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         if ($this->supportsAbove('7.0') === false) {
             return;
@@ -55,7 +55,7 @@ class VariableVariablesSniff extends Sniff
         $tokens = $phpcsFile->getTokens();
 
         // Verify that the next token is a square open bracket. If not, bow out.
-        $nextToken = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
 
         if ($nextToken === false || $tokens[$nextToken]['code'] !== T_OPEN_SQUARE_BRACKET || isset($tokens[$nextToken]['bracket_closer']) === false) {
             return;
@@ -69,7 +69,7 @@ class VariableVariablesSniff extends Sniff
         // For static object calls, it only applies when this is a function call.
         if ($tokens[($stackPtr - 1)]['code'] === T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
-            while (($hasBrackets = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
+            while (($hasBrackets = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
                 if ($tokens[$hasBrackets]['code'] === T_OPEN_SQUARE_BRACKET) {
                     if (isset($tokens[$hasBrackets]['bracket_closer'])) {
                         $hasBrackets = $tokens[$hasBrackets]['bracket_closer'];
@@ -90,7 +90,7 @@ class VariableVariablesSniff extends Sniff
             }
 
             // Now let's also prevent false positives when used with self and static which still work fine.
-            $classToken = $phpcsFile->findPrevious(PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
+            $classToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
             if ($classToken !== false) {
                 if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
                     return;

--- a/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHPCompatibility_Sniffs_PHP_VariableVariables.
+ * \PHPCompatibility\Sniffs\PHP\VariableVariables.
  *
  * PHP version 7.0
  *
@@ -9,8 +9,12 @@
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
 
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
 /**
- * PHPCompatibility_Sniffs_PHP_VariableVariables.
+ * \PHPCompatibility\Sniffs\PHP\VariableVariables.
  *
  * The interpretation of variable variables has changed in PHP 7.0.
  *
@@ -20,7 +24,7 @@
  * @package  PHPCompatibility
  * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class PHPCompatibility_Sniffs_PHP_VariableVariablesSniff extends PHPCompatibility_Sniff
+class VariableVariablesSniff extends Sniff
 {
     /**
      * Returns an array of tokens this test wants to listen for.

--- a/PHPCompatibility/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
+++ b/PHPCompatibility/Tests/BaseClass/DoesFunctionCallHaveParametersTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Function parameters function tests
@@ -12,11 +13,11 @@
  * @group utilityDoesFunctionCallHaveParameters
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestFrame
+class DoesFunctionCallHaveParametersTest extends MethodTestFrame
 {
 
     /**
@@ -32,7 +33,7 @@ class BaseClass_DoesFunctionCallHaveParametersTest extends BaseClass_MethodTestF
      *
      * @dataProvider dataDoesFunctionCallHaveParameters
      *
-     * @covers PHPCompatibility_Sniff::doesFunctionCallHaveParameters
+     * @covers \PHPCompatibility\Sniff::doesFunctionCallHaveParameters
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param bool   $expected      Whether or not the function/array has parameters/values.

--- a/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
+++ b/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
@@ -7,6 +7,8 @@
 
 namespace PHPCompatibility\Tests\BaseClass;
 
+use PHPCompatibility\PHPCSHelper;
+
 /**
  * Generic sniff functions sniff tests
  *
@@ -61,7 +63,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
 
         // Only really needed for the testVersion related tests, but doesn't harm the other test in this file.
-        \PHP_CodeSniffer::setConfigData('testVersion', null, true);
+        PHPCSHelper::setConfigData('testVersion', null, true);
     }
 
 
@@ -85,7 +87,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     public function testGetTestVersion($testVersion, $expected)
     {
         if (isset($testVersion)) {
-            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            PHPCSHelper::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
@@ -248,7 +250,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     public function testSupportsAbove($phpVersion, $testVersion, $expected)
     {
         if (isset($testVersion)) {
-            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            PHPCSHelper::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->helperClass->supportsAbove($phpVersion));
@@ -293,7 +295,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
     public function testSupportsBelow($phpVersion, $testVersion, $expected)
     {
         if (isset($testVersion)) {
-            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            PHPCSHelper::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->helperClass->supportsBelow($phpVersion));

--- a/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
+++ b/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
@@ -13,11 +13,11 @@ namespace PHPCompatibility\Tests\BaseClass;
  * @group utilityMiscFunctions
  * @group utilityFunctions
  *
- * @uses    PHPUnit_Framework_TestCase
+ * @uses    \PHPUnit_Framework_TestCase
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class FunctionsTest extends PHPUnit_Framework_TestCase
+class FunctionsTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -61,7 +61,7 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
         parent::tearDown();
 
         // Only really needed for the testVersion related tests, but doesn't harm the other test in this file.
-        PHP_CodeSniffer::setConfigData('testVersion', null, true);
+        \PHP_CodeSniffer::setConfigData('testVersion', null, true);
     }
 
 
@@ -85,7 +85,7 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
     public function testGetTestVersion($testVersion, $expected)
     {
         if (isset($testVersion)) {
-            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->invokeMethod($this->helperClass, 'GetTestVersion'));
@@ -248,7 +248,7 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
     public function testSupportsAbove($phpVersion, $testVersion, $expected)
     {
         if (isset($testVersion)) {
-            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->helperClass->supportsAbove($phpVersion));
@@ -293,7 +293,7 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
     public function testSupportsBelow($phpVersion, $testVersion, $expected)
     {
         if (isset($testVersion)) {
-            PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
+            \PHP_CodeSniffer::setConfigData('testVersion', $testVersion, true);
         }
 
         $this->assertSame($expected, $this->helperClass->supportsBelow($phpVersion));
@@ -513,7 +513,7 @@ class FunctionsTest extends PHPUnit_Framework_TestCase
      */
     private function invokeMethod(&$object, $methodName, array $parameters = array())
     {
-        $reflection = new ReflectionClass(get_class($object));
+        $reflection = new \ReflectionClass(get_class($object));
         $method = $reflection->getMethod($methodName);
         $method->setAccessible(true);
 

--- a/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
+++ b/PHPCompatibility/Tests/BaseClass/FunctionsTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Generic sniff functions sniff tests
@@ -16,13 +17,13 @@
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
+class FunctionsTest extends PHPUnit_Framework_TestCase
 {
 
     /**
      * A wrapper for the abstract PHPCompatibility sniff.
      *
-     * @var PHPCompatibility_Sniff
+     * @var \PHPCompatibility\Sniff
      */
     protected $helperClass;
 
@@ -47,7 +48,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->helperClass = new BaseClass_TestHelperPHPCompatibility;
+        $this->helperClass = new TestHelperPHPCompatibility;
     }
 
     /**
@@ -69,7 +70,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataGetTestVersion
      *
-     * @covers PHPCompatibility_Sniff::getTestVersion
+     * @covers \PHPCompatibility\Sniff::getTestVersion
      *
      * @requires PHP 5.3.2
      * @internal Requirement is needed to be able to test the private method
@@ -130,7 +131,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataGetTestVersionInvalidRange
      *
-     * @covers PHPCompatibility_Sniff::getTestVersion
+     * @covers \PHPCompatibility\Sniff::getTestVersion
      *
      * @requires PHP 5.3.2
      * @internal Requirement is needed to be able to test the private method
@@ -176,7 +177,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataGetTestVersionInvalidVersion
      *
-     * @covers PHPCompatibility_Sniff::getTestVersion
+     * @covers \PHPCompatibility\Sniff::getTestVersion
      *
      * @requires PHP 5.3.2
      * @internal Requirement is needed to be able to test the private method
@@ -236,7 +237,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataSupportsAbove
      *
-     * @covers PHPCompatibility_Sniff::supportsAbove
+     * @covers \PHPCompatibility\Sniff::supportsAbove
      *
      * @param string $phpVersion  The PHP version we want to test.
      * @param string $testVersion The testVersion as normally set via the command line or ruleset.
@@ -281,7 +282,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataSupportsBelow
      *
-     * @covers PHPCompatibility_Sniff::supportsBelow
+     * @covers \PHPCompatibility\Sniff::supportsBelow
      *
      * @param string $phpVersion  The PHP version we want to test.
      * @param string $testVersion The testVersion as normally set via the command line or ruleset.
@@ -326,7 +327,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataStringToErrorCode
      *
-     * @covers PHPCompatibility_Sniff::stringToErrorCode
+     * @covers \PHPCompatibility\Sniff::stringToErrorCode
      *
      * @param string $input    The input string.
      * @param string $expected The expected error code.
@@ -361,7 +362,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
     *
     * @dataProvider dataStripQuotes
     *
-    * @covers PHPCompatibility_Sniff::stripQuotes
+    * @covers \PHPCompatibility\Sniff::stripQuotes
     *
     * @param string $input    The input string.
     * @param string $expected The expected function output.
@@ -397,7 +398,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
      *
      * @dataProvider dataArrayKeysToLowercase
      *
-     * @covers PHPCompatibility_Sniff::arrayKeysToLowercase
+     * @covers \PHPCompatibility\Sniff::arrayKeysToLowercase
      *
      * @param string $input    The input string.
      * @param string $expected The expected function output.
@@ -440,7 +441,7 @@ class BaseClass_FunctionsTest extends PHPUnit_Framework_TestCase
     *
     * @dataProvider dataStripVariables
     *
-    * @covers PHPCompatibility_Sniff::stripQuotes
+    * @covers \PHPCompatibility\Sniff::stripQuotes
     *
     * @param string $input    The input string.
     * @param string $expected The expected function output.

--- a/PHPCompatibility/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFQClassNameFromDoubleColonTokenTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Classname determination from double colon token function tests
@@ -12,11 +13,11 @@
  * @group utilityGetFQClassNameFromDoubleColonToken
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodTestFrame
+class GetFQClassNameFromDoubleColonTokenTest extends MethodTestFrame
 {
 
     /**
@@ -34,7 +35,7 @@ class BaseClass_GetFQClassNameFromDoubleColonTokenTest extends BaseClass_MethodT
      *
      * @dataProvider dataGetFQClassNameFromDoubleColonToken
      *
-     * @covers PHPCompatibility_Sniff::getFQClassNameFromDoubleColonToken
+     * @covers \PHPCompatibility\Sniff::getFQClassNameFromDoubleColonToken
      *
      * @param string $commentString The comment which prefaces the T_DOUBLE_COLON token in the test file.
      * @param string $expected      The expected fully qualified class name.

--- a/PHPCompatibility/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFQClassNameFromNewTokenTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Classname determination function tests
@@ -12,11 +13,11 @@
  * @group utilityGetFQClassNameFromNewToken
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
+class GetFQClassNameFromNewTokenTest extends MethodTestFrame
 {
 
     /**
@@ -34,7 +35,7 @@ class BaseClass_GetFQClassNameFromNewTokenTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataGetFQClassNameFromNewToken
      *
-     * @covers PHPCompatibility_Sniff::getFQClassNameFromNewToken
+     * @covers \PHPCompatibility\Sniff::getFQClassNameFromNewToken
      *
      * @param string $commentString The comment which prefaces the T_NEW token in the test file.
      * @param string $expected      The expected fully qualified class name.

--- a/PHPCompatibility/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Extended class name determination function tests
@@ -12,11 +13,11 @@
  * @group utilityGetFQExtendedClassName
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
+class GetFQExtendedClassNameTest extends MethodTestFrame
 {
 
     /**
@@ -34,7 +35,7 @@ class BaseClass_GetFQExtendedClassNameTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataGetFQExtendedClassName
      *
-     * @covers PHPCompatibility_Sniff::getFQExtendedClassName
+     * @covers \PHPCompatibility\Sniff::getFQExtendedClassName
      *
      * @param string $commentString The comment which prefaces the T_CLASS token in the test file.
      * @param string $expected      The expected fully qualified class name.

--- a/PHPCompatibility/Tests/BaseClass/GetFunctionParameterCountTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFunctionParameterCountTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Function parameters count function tests
@@ -12,11 +13,11 @@
  * @group utilityGetFunctionParameterCount
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_GetFunctionParameterCountTest extends BaseClass_MethodTestFrame
+class GetFunctionParameterCountTest extends MethodTestFrame
 {
 
     /**
@@ -32,7 +33,7 @@ class BaseClass_GetFunctionParameterCountTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataGetFunctionCallParameterCount
      *
-     * @covers PHPCompatibility_Sniff::getFunctionCallParameterCount
+     * @covers \PHPCompatibility\Sniff::getFunctionCallParameterCount
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected parameter count.

--- a/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFunctionParametersTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Function parameters retrieval function tests
@@ -12,11 +13,11 @@
  * @group utilityGetFunctionParameters
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
+class GetFunctionParametersTest extends MethodTestFrame
 {
 
     /**
@@ -32,7 +33,7 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataGetFunctionCallParameters
      *
-     * @covers PHPCompatibility_Sniff::getFunctionCallParameters
+     * @covers \PHPCompatibility\Sniff::getFunctionCallParameters
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected parameter array.
@@ -256,7 +257,7 @@ class BaseClass_GetFunctionParametersTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataGetFunctionCallParameter
      *
-     * @covers PHPCompatibility_Sniff::getFunctionCallParameter
+     * @covers \PHPCompatibility\Sniff::getFunctionCallParameter
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param int    $paramPosition The position of the parameter we want to retrieve the details for.

--- a/PHPCompatibility/Tests/BaseClass/IsClassConstantTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassConstantTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * isClassConstant() function tests
@@ -12,11 +13,11 @@
  * @group utilityIsClassConstant
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_isClassConstantTest extends BaseClass_MethodTestFrame
+class IsClassConstantTest extends MethodTestFrame
 {
 
     /**
@@ -32,7 +33,7 @@ class BaseClass_isClassConstantTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataIsClassConstant
      *
-     * @covers PHPCompatibility_Sniff::isClassConstant
+     * @covers \PHPCompatibility\Sniff::isClassConstant
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected boolean return value.

--- a/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
@@ -7,6 +7,8 @@
 
 namespace PHPCompatibility\Tests\BaseClass;
 
+use PHPCompatibility\PHPCSHelper;
+
 /**
  * isClassProperty() function tests
  *
@@ -44,7 +46,7 @@ class IsClassPropertyTest extends MethodTestFrame
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * isClassProperty() function tests
@@ -12,11 +13,11 @@
  * @group utilityIsClassProperty
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_isClassPropertyTest extends BaseClass_MethodTestFrame
+class IsClassPropertyTest extends MethodTestFrame
 {
 
     /**
@@ -56,7 +57,7 @@ class BaseClass_isClassPropertyTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataIsClassProperty
      *
-     * @covers PHPCompatibility_Sniff::isClassProperty
+     * @covers \PHPCompatibility\Sniff::isClassProperty
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param string $expected      The expected boolean return value.

--- a/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
@@ -44,7 +44,7 @@ class IsClassPropertyTest extends MethodTestFrame
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
+++ b/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
@@ -5,6 +5,8 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
+
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
  *
@@ -12,7 +14,7 @@
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
+abstract class MethodTestFrame extends PHPUnit_Framework_TestCase
 {
 
     /**
@@ -40,7 +42,7 @@ abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
     /**
      * A wrapper for the abstract PHPCompatibility sniff.
      *
-     * @var PHPCompatibility_Sniff
+     * @var \PHPCompatibility\Sniff
      */
     protected $helperClass;
 
@@ -65,7 +67,7 @@ abstract class BaseClass_MethodTestFrame extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->helperClass = new BaseClass_TestHelperPHPCompatibility;
+        $this->helperClass = new TestHelperPHPCompatibility;
 
         $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->case_directory . $this->filename;
         $phpcs    = new PHP_CodeSniffer();

--- a/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
+++ b/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
@@ -10,11 +10,11 @@ namespace PHPCompatibility\Tests\BaseClass;
 /**
  * Set up and Tear down methods for testing methods in the Sniff.php file.
  *
- * @uses    PHPUnit_Framework_TestCase
+ * @uses    \PHPUnit_Framework_TestCase
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-abstract class MethodTestFrame extends PHPUnit_Framework_TestCase
+abstract class MethodTestFrame extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -33,9 +33,9 @@ abstract class MethodTestFrame extends PHPUnit_Framework_TestCase
     protected $case_directory = '../sniff-examples/utility-functions/';
 
     /**
-     * The PHP_CodeSniffer_File object containing parsed contents of this file.
+     * The \PHP_CodeSniffer_File object containing parsed contents of this file.
      *
-     * @var PHP_CodeSniffer_File
+     * @var \PHP_CodeSniffer_File
      */
     protected $phpcsFile;
 
@@ -70,10 +70,10 @@ abstract class MethodTestFrame extends PHPUnit_Framework_TestCase
         $this->helperClass = new TestHelperPHPCompatibility;
 
         $filename = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $this->case_directory . $this->filename;
-        $phpcs    = new PHP_CodeSniffer();
+        $phpcs    = new \PHP_CodeSniffer();
 
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '<')) {
-            $this->phpcsFile = new PHP_CodeSniffer_File(
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.0', '<')) {
+            $this->phpcsFile = new \PHP_CodeSniffer_File(
                 $filename,
                 array(),
                 array(),
@@ -83,7 +83,7 @@ abstract class MethodTestFrame extends PHPUnit_Framework_TestCase
             );
 
         } else {
-            $this->phpcsFile = new PHP_CodeSniffer_File(
+            $this->phpcsFile = new \PHP_CodeSniffer_File(
                 $filename,
                 array(),
                 array(),

--- a/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
@@ -5,18 +5,18 @@
  * @package PHPCompatibility
  */
 
-if (class_exists('PHPCompatibility_Sniff', true) === false) {
-    require_once dirname(dirname(dirname(__FILE__))) . '/Sniff.php';
-}
+namespace PHPCompatibility\Tests\BaseClass;
+
+use PHPCompatibility\Sniff;
 
 /**
- * Helper class to facilitate testing of the methods within the abstract PHPCompatibility_Sniff class.
+ * Helper class to facilitate testing of the methods within the abstract \PHPCompatibility\Sniff class.
  *
- * @uses    PHPCompatibility_Sniff
+ * @uses    \PHPCompatibility\Sniff
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_TestHelperPHPCompatibility extends PHPCompatibility_Sniff
+class TestHelperPHPCompatibility extends Sniff
 {
     /**
      * Dummy method to bypass the abstract method implementation requirements.

--- a/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
@@ -30,13 +30,13 @@ class TestHelperPHPCompatibility extends Sniff
     /**
      * Dummy method to bypass the abstract method implementation requirements.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack.
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
     }
 }

--- a/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
+++ b/PHPCompatibility/Tests/BaseClass/TokenScopeTest.php
@@ -5,6 +5,7 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\BaseClass;
 
 /**
  * Token scope function tests
@@ -12,11 +13,11 @@
  * @group utilityTokenScope
  * @group utilityFunctions
  *
- * @uses    BaseClass_MethodTestFrame
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */
-class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
+class TokenScopeTest extends MethodTestFrame
 {
 
     /**
@@ -32,7 +33,7 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataTokenHasScope
      *
-     * @covers PHPCompatibility_Sniff::tokenHasScope
+     * @covers \PHPCompatibility\Sniff::tokenHasScope
      *
      * @param string    $commentString The comment which prefaces the target token in the test file.
      * @param int       $targetType    The token type for the target token.
@@ -98,7 +99,7 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataInClassScope
      *
-     * @covers PHPCompatibility_Sniff::inClassScope
+     * @covers \PHPCompatibility\Sniff::inClassScope
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param int    $targetType    The token type for the target token.
@@ -137,7 +138,7 @@ class BaseClass_TokenScopeTest extends BaseClass_MethodTestFrame
      *
      * @dataProvider dataInUseScope
      *
-     * @covers PHPCompatibility_Sniff::inUseScope
+     * @covers \PHPCompatibility\Sniff::inUseScope
      *
      * @param string $commentString The comment which prefaces the target token in the test file.
      * @param int    $targetType    The token type for the target token.

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -13,11 +13,11 @@ namespace PHPCompatibility\Tests;
  * Adds PHPCS sniffing logic and custom assertions for PHPCS errors and
  * warnings.
  *
- * @uses    PHPUnit_Framework_TestCase
+ * @uses    \PHPUnit_Framework_TestCase
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */
-class BaseSniffTest extends PHPUnit_Framework_TestCase
+class BaseSniffTest extends \PHPUnit_Framework_TestCase
 {
     const STANDARD_NAME = 'PHPCompatibility';
 
@@ -54,16 +54,16 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (self::$phpcs === null) {
-            self::$phpcs = new PHP_CodeSniffer();
+            self::$phpcs = new \PHP_CodeSniffer();
         }
 
-        PHP_CodeSniffer::setConfigData('testVersion', null, true);
-        if (method_exists('PHP_CodeSniffer_CLI', 'setCommandLineValues')) { // For PHPCS 2.x.
+        \PHP_CodeSniffer::setConfigData('testVersion', null, true);
+        if (method_exists('\PHP_CodeSniffer_CLI', 'setCommandLineValues')) { // For PHPCS 2.x.
             self::$phpcs->cli->setCommandLineValues(array('-pq', '--colors'));
         }
 
         // Restrict the sniffing of the test case files to the particular sniff being tested.
-        if (method_exists('PHP_CodeSniffer', 'initStandard')) {
+        if (method_exists('\PHP_CodeSniffer', 'initStandard')) {
             self::$phpcs->initStandard(self::STANDARD_NAME, array($this->getSniffCode()));
         } else {
             // PHPCS 1.x.
@@ -112,7 +112,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
      * @param string $filename         Filename to sniff.
      * @param string $targetPhpVersion Value of 'testVersion' to set on PHPCS object.
      *
-     * @return PHP_CodeSniffer_File|false File object.
+     * @return \PHP_CodeSniffer_File|false File object.
      */
     public function sniffFile($filename, $targetPhpVersion = 'none')
     {
@@ -121,19 +121,19 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
         }
 
         if ('none' !== $targetPhpVersion) {
-            PHP_CodeSniffer::setConfigData('testVersion', $targetPhpVersion, true);
+            \PHP_CodeSniffer::setConfigData('testVersion', $targetPhpVersion, true);
         }
 
         $pathToFile = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $filename;
         try {
-            if (method_exists('PHP_CodeSniffer', 'initStandard')) {
+            if (method_exists('\PHP_CodeSniffer', 'initStandard')) {
                 self::$sniffFiles[$filename][$targetPhpVersion] = self::$phpcs->processFile($pathToFile);
             } else {
                 // PHPCS 1.x - Sniff code restrictions have to be passed via the function call.
                 self::$sniffFiles[$filename][$targetPhpVersion] = self::$phpcs->processFile($pathToFile, null, array($this->getSniffCode()));
             }
 
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $this->fail('An unexpected exception has been caught: ' . $e->getMessage());
             return false;
         }
@@ -144,13 +144,13 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     /**
      * Assert a PHPCS error on a particular line number.
      *
-     * @param PHP_CodeSniffer_File $file            Codesniffer file object.
-     * @param int                  $lineNumber      Line number.
-     * @param string               $expectedMessage Expected error message (assertContains).
+     * @param \PHP_CodeSniffer_File $file            Codesniffer file object.
+     * @param int                   $lineNumber      Line number.
+     * @param string                $expectedMessage Expected error message (assertContains).
      *
      * @return bool
      */
-    public function assertError(PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
+    public function assertError(\PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
     {
         $errors = $this->gatherErrors($file);
 
@@ -160,13 +160,13 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     /**
      * Assert a PHPCS warning on a particular line number.
      *
-     * @param PHP_CodeSniffer_File $file            Codesniffer file object.
-     * @param int                  $lineNumber      Line number.
-     * @param string               $expectedMessage Expected message (assertContains).
+     * @param \PHP_CodeSniffer_File $file            Codesniffer file object.
+     * @param int                   $lineNumber      Line number.
+     * @param string                $expectedMessage Expected message (assertContains).
      *
      * @return bool
      */
-    public function assertWarning(PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
+    public function assertWarning(\PHP_CodeSniffer_File $file, $lineNumber, $expectedMessage)
     {
         $warnings = $this->gatherWarnings($file);
 
@@ -186,7 +186,7 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     private function assertForType($issues, $type, $lineNumber, $expectedMessage)
     {
         if (!isset($issues[$lineNumber])) {
-            throw new Exception("Expected $type '$expectedMessage' on line number $lineNumber, but none found.");
+            throw new \Exception("Expected $type '$expectedMessage' on line number $lineNumber, but none found.");
         }
 
         $insteadFoundMessages = array();
@@ -207,12 +207,12 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     /**
      * Assert no violation (warning or error) on a given line number.
      *
-     * @param PHP_CodeSniffer_File $file       Codesniffer File object.
-     * @param mixed                $lineNumber Line number.
+     * @param \PHP_CodeSniffer_File $file       Codesniffer File object.
+     * @param mixed                 $lineNumber Line number.
      *
      * @return bool
      */
-    public function assertNoViolation(PHP_CodeSniffer_File $file, $lineNumber = 0)
+    public function assertNoViolation(\PHP_CodeSniffer_File $file, $lineNumber = 0)
     {
         $errors   = $this->gatherErrors($file);
         $warnings = $this->gatherWarnings($file);
@@ -252,11 +252,11 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
      *
      * This is useful for debugging sniffs on a file.
      *
-     * @param PHP_CodeSniffer_File $file Codesniffer file object.
+     * @param \PHP_CodeSniffer_File $file Codesniffer file object.
      *
      * @return array
      */
-    public function showViolations(PHP_CodeSniffer_File $file)
+    public function showViolations(\PHP_CodeSniffer_File $file)
     {
         $violations = array(
             'errors'   => $this->gatherErrors($file),
@@ -269,11 +269,11 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     /**
      * Gather all error messages by line number from phpcs file result.
      *
-     * @param PHP_CodeSniffer_File $file Codesniffer File object.
+     * @param \PHP_CodeSniffer_File $file Codesniffer File object.
      *
      * @return array
      */
-    public function gatherErrors(PHP_CodeSniffer_File $file)
+    public function gatherErrors(\PHP_CodeSniffer_File $file)
     {
         $foundErrors = $file->getErrors();
 
@@ -283,11 +283,11 @@ class BaseSniffTest extends PHPUnit_Framework_TestCase
     /**
      * Gather all warning messages by line number from phpcs file result.
      *
-     * @param PHP_CodeSniffer_File $file Codesniffer File object.
+     * @param \PHP_CodeSniffer_File $file Codesniffer File object.
      *
      * @return array
      */
-    public function gatherWarnings(PHP_CodeSniffer_File $file)
+    public function gatherWarnings(\PHP_CodeSniffer_File $file)
     {
         $foundWarnings = $file->getWarnings();
 

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -5,6 +5,8 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests;
+
 /**
  * BaseSniffTest
  *

--- a/PHPCompatibility/Tests/BaseSniffTest.php
+++ b/PHPCompatibility/Tests/BaseSniffTest.php
@@ -7,6 +7,8 @@
 
 namespace PHPCompatibility\Tests;
 
+use PHPCompatibility\PHPCSHelper;
+
 /**
  * BaseSniffTest
  *
@@ -121,7 +123,7 @@ class BaseSniffTest extends \PHPUnit_Framework_TestCase
         }
 
         if ('none' !== $targetPhpVersion) {
-            \PHP_CodeSniffer::setConfigData('testVersion', $targetPhpVersion, true);
+            PHPCSHelper::setConfigData('testVersion', $targetPhpVersion, true);
         }
 
         $pathToFile = realpath(dirname(__FILE__)) . DIRECTORY_SEPARATOR . $filename;

--- a/PHPCompatibility/Tests/Sniffs/PHP/CaseSensitiveKeywordsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/CaseSensitiveKeywordsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * self, parent and static were sometimes treated case sensitively prior to PHP 5.5.
@@ -12,9 +15,9 @@
  * @group caseSensitiveKeywords
  * @group keywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_CaseSensitiveKeywordsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\CaseSensitiveKeywordsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Constant arrays using the const keyword in PHP 5.6 sniff test file
@@ -12,9 +15,9 @@
  * @group constantArraysUsingConst
  * @group constants
  *
- * @covers PHPCompatibility_Sniffs_PHP_ConstantArraysUsingConstSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingConstSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingDefineSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Constant arrays using define in PHP 7.0 sniff test file
@@ -12,9 +15,9 @@
  * @group constantArraysUsingDefine
  * @group constants
  *
- * @covers PHPCompatibility_Sniffs_PHP_ConstantArraysUsingDefineSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ConstantArraysUsingDefineSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Deprecated functions sniff tests
@@ -12,9 +15,9 @@
  * @group deprecatedFunctions
  * @group functions
  *
- * @covers PHPCompatibility_Sniffs_PHP_DeprecatedFunctionsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedFunctionsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Deprecated ini directives sniff tests
@@ -12,9 +15,9 @@
  * @group deprecatedIniDirectives
  * @group iniDirectives
  *
- * @covers PHPCompatibility_Sniffs_PHP_DeprecatedIniDirectivesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedIniDirectivesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Deprecated new reference sniff tests
@@ -12,9 +15,9 @@
  * @group deprecatedNewReference
  * @group references
  *
- * @covers PHPCompatibility_Sniffs_PHP_DeprecatedNewReferenceSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedNewReferenceSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedPHP4StyleConstructorsSniffTest.php
@@ -5,14 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
 /**
  * PHP4 style constructors sniff test
  *
  * @group deprecatedPHP4StyleConstructors
  *
- * @covers PHPCompatibility_Sniffs_PHP_DeprecatedPHP4StyleConstructorsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedPHP4StyleConstructorsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Koen Eelen <koen.eelen@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/EmptyNonVariableSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Empty with non variable sniff test file
  *
  * @group emptyNonVariable
  *
- * @covers PHPCompatibility_Sniffs_PHP_EmptyNonVariableSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\EmptyNonVariableSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenBreakContinueOutsideLoopSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden break and continue outside loop sniff test.
@@ -14,9 +17,9 @@
  * @group forbiddenBreakContinueOutsideLoop
  * @group breakContinue
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueOutsideLoopSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueOutsideLoopSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenBreakContinueVariableArgumentsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden break and continue variable arguments sniff test
@@ -16,9 +19,9 @@
  * @group forbiddenBreakContinueVariableArguments
  * @group breakContinue
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenBreakContinueVariableArgumentsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenBreakContinueVariableArgumentsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden call time pass by reference sniff test
@@ -12,9 +15,9 @@
  * @group forbiddenCallTimePassByReference
  * @group references
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenCallTimePassByReferenceSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenCallTimePassByReferenceSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * PHP 7.1 Forbidden variable names in closure use statements tests.
@@ -116,7 +117,7 @@ class ForbiddenClosureUseVariableNamesSniffTest extends BaseSniffTest
      */
     public function testNoFalsePositivesLiveCoding($line)
     {
-        if (strpos(\PHP_CodeSniffer::VERSION, '2.5.1') !== false) {
+        if (strpos(PHPCSHelper::getVersion(), '2.5.1') !== false) {
             $this->markTestSkipped('PHPCS 2.5.1 has a bug in the tokenizer which affects this test.');
             return;
         }

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
@@ -116,7 +116,7 @@ class ForbiddenClosureUseVariableNamesSniffTest extends BaseSniffTest
      */
     public function testNoFalsePositivesLiveCoding($line)
     {
-        if (strpos(PHP_CodeSniffer::VERSION, '2.5.1') !== false) {
+        if (strpos(\PHP_CodeSniffer::VERSION, '2.5.1') !== false) {
             $this->markTestSkipped('PHPCS 2.5.1 has a bug in the tokenizer which affects this test.');
             return;
         }

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenClosureUseVariableNamesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * PHP 7.1 Forbidden variable names in closure use statements tests.
@@ -12,9 +15,9 @@
  * @group forbiddenClosureUseVariableNames
  * @group closures
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenClosureUseVariableNamesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenClosureUseVariableNamesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenEmptyListAssignmentSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Empty list() assignments have been removed in PHP 7.0 sniff test file
@@ -12,9 +15,9 @@
  * @group forbiddenEmptyListAssignment
  * @group listAssignments
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenEmptyListAssignmentSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenEmptyListAssignmentSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Functions can not have multiple parameters with the same name since PHP 7.0 sniff test
@@ -12,9 +15,9 @@
  * @group forbiddenFunctionParametersWithSameName
  * @group functionDeclarations
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenFunctionParametersWithSameNameSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenFunctionParametersWithSameNameSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Global with variable variables have been removed in PHP 7.0 sniff test file
@@ -12,9 +15,9 @@
  * @group forbiddenGlobalVariableVariable
  * @group variableVariables
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenGlobalVariableVariableSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenGlobalVariableVariableSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden names as declared name for class, interface, trait or namespace.
@@ -12,9 +15,9 @@
  * @group forbiddenNamesAsDeclared
  * @group reservedKeywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsDeclaredSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsDeclaredSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden names as function invocations sniff test file
@@ -12,9 +15,9 @@
  * @group forbiddenNamesAsInvokedFunctions
  * @group reservedKeywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesAsInvokedFunctionsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenNamesAsInvokedFunctionsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Forbidden names sniff test
@@ -12,9 +15,9 @@
  * @group forbiddenNames
  * @group reservedKeywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenNamesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */
@@ -43,8 +46,8 @@ class ForbiddenNamesSniffTest extends BaseSniffTest
         $filename = "sniff-examples/forbidden-names/$usecase.php";
 
         // Set the testVersion to the highest PHP version encountered in the
-        // PHPCompatibility_Sniffs_PHP_ForbiddenNamesSniff::$invalidNames list
-        // to catch all errors.
+        // \PHPCompatibility\Sniffs\PHP\ForbiddenNamesSniff::$invalidNames
+        // list to catch all errors.
         $file = $this->sniffFile($filename, '5.5');
 
         $this->assertNoViolation($file, 2);

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Bitwise shifts by negative number will throw an ArithmeticError in PHP 7.0.
  *
  * @group forbiddenNegativeBitshift
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenNegativeBitshiftSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenNegativeBitshiftSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenSwitchWithMultipleDefaultBlocksSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Switch statements can only have one default case in PHP 7.0
  *
  * @group forbiddenSwitchWithMultipleDefaultBlocks
  *
- * @covers PHPCompatibility_Sniffs_PHP_ForbiddenSwitchWithMultipleDefaultBlocksSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ForbiddenSwitchWithMultipleDefaultBlocksSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Internal Interfaces Sniff tests
@@ -12,9 +15,9 @@
  * @group internalInterfaces
  * @group interfaces
  *
- * @covers PHPCompatibility_Sniffs_PHP_InternalInterfacesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\InternalInterfacesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/InternalInterfacesSniffTest.php
@@ -28,7 +28,7 @@ class InternalInterfacesSniffTest extends BaseSniffTest
     /**
      * Sniffed file
      *
-     * @var PHP_CodeSniffer_File
+     * @var \PHP_CodeSniffer_File
      */
     protected $sniffResult;
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/LateStaticBindingSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Late static binding sniff test file
  *
  * @group lateStaticBinding
  *
- * @covers PHPCompatibility_Sniffs_PHP_LateStaticBindingSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\LateStaticBindingSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Deprecated Mbstring regex replace e modifier test file.
@@ -12,9 +15,9 @@
  * @group mbstringReplaceEModifier
  * @group regexEModifier
  *
- * @covers PHPCompatibility_Sniffs_PHP_MbstringReplaceEModifierSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\MbstringReplaceEModifierSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewAnonymousClassesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Anonymous Classes Sniff tests
@@ -12,9 +15,9 @@
  * @group newAnonymousClasses
  * @group closures
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewAnonymousClassesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewAnonymousClassesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewArrayStringDereferencingSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewArrayStringDereferencingSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New array and string literal dereferencing sniff test.
@@ -12,9 +15,9 @@
  * @group newArrayStringDereferencing
  * @group dereferencing
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewArrayStringDereferencingSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewArrayStringDereferencingSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Classes Sniff tests
@@ -12,9 +15,9 @@
  * @group newClasses
  * @group classes
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewClassesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewClassesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Closure Sniff tests
@@ -12,9 +15,9 @@
  * @group newClosure
  * @group closures
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewClosureSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewClosureSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewConstVisibilitySniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New const visibility sniff test file
@@ -12,9 +15,9 @@
  * @group constVisibility
  * @group constants
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewConstVisibilitySniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewConstVisibilitySniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -28,7 +28,7 @@ class NewExecutionDirectivesSniffTest extends BaseSniffTest
     /**
      * Sniffed file
      *
-     * @var PHP_CodeSniffer_File
+     * @var \PHP_CodeSniffer_File
      */
     protected $sniffResult;
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewExecutionDirectivesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New execution directives test file
@@ -12,9 +15,9 @@
  * @group newExecutionDirectives
  * @group executionDirectives
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewExecutionDirectivesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewExecutionDirectivesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionArrayDereferencingSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New function array dereferencing sniff tests
@@ -12,9 +15,9 @@
  * @group newFunctionArrayDereferencing
  * @group dereferencing
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewFunctionArrayDereferencingSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewFunctionArrayDereferencingSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Functions Parameter Sniff tests
@@ -12,9 +15,9 @@
  * @group newFunctionParameters
  * @group functionParameters
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewFunctionParametersSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewFunctionParametersSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Functions Sniff tests
@@ -12,9 +15,9 @@
  * @group newFunctions
  * @group functions
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewFunctionsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewFunctionsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New use group declaration sniff tests
  *
  * @group newGroupUseDeclarations
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewGroupUseDeclarationsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewGroupUseDeclarationsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewHashAlgorithmsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewHashAlgorithmsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New hash algorithms sniff tests.
@@ -12,9 +15,9 @@
  * @group newHashAlgorithms
  * @group hashAlgorithms
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewHashAlgorithmsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewHashAlgorithmsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
@@ -42,7 +42,7 @@ class NewHeredocInitializeSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * New initialize with heredoc in PHP 5.3 sniff test file
@@ -42,7 +43,7 @@ class NewHeredocInitializeSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewHeredocInitializeSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New initialize with heredoc in PHP 5.3 sniff test file
@@ -13,9 +16,9 @@
  * @group constants
  * @group variables
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewHeredocInitializeSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewHeredocInitializeSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewIniDirectivesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New ini directives sniff tests
@@ -12,9 +15,9 @@
  * @group newIniDirectives
  * @group iniDirectives
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewIniDirectivesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewIniDirectivesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Interfaces Sniff tests
@@ -12,9 +15,9 @@
  * @group newInterfaces
  * @group interfaces
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewInterfacesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewInterfacesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New keywords sniff tests
@@ -12,9 +15,9 @@
  * @group newKeywords
  * @group reservedKeywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewKeywordsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewKeywordsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New language constructs sniff tests
  *
  * @group newLanguageConstructs
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewLanguageConstructsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewLanguageConstructsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMagicClassConstantSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New magic ::class constant sniff test file.
@@ -12,9 +15,9 @@
  * @group newMagicClassConstant
  * @group constants
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewMagicClassConstantSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewMagicClassConstantSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New Magic Methods Sniff tests.
@@ -12,9 +15,9 @@
  * @group newMagicMethods
  * @group magicMethods
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewMagicMethodsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewMagicMethodsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -39,7 +39,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -64,7 +64,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
      * @param bool   $isTrait     Whether to load the class/interface test file or the trait test file.
      * @param string $testVersion Value of 'testVersion' to set on PHPCS object.
      *
-     * @return PHP_CodeSniffer_File File object|false
+     * @return \PHP_CodeSniffer_File File object|false
      */
     protected function getTestFile($isTrait, $testVersion = null)
     {

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMagicMethodsSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * New Magic Methods Sniff tests.
@@ -39,7 +40,7 @@ class NewMagicMethodsSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewMultiCatchSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New catching multiple exception types sniff test file
@@ -12,9 +15,9 @@
  * @group multiCatch
  * @group exceptions
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewMultiCatchSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewMultiCatchSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
@@ -133,7 +133,7 @@ class NewNowdocQuotedHeredocSniffTest extends BaseSniffTest
         );
 
         // PHPCS 1.x does not support skipping forward.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.0', '>=')) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.0', '>=')) {
             $data[] = array(42);
             $data[] = array(46);
             $data[] = array(82);

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * New nowdoc and quoted heredoc sniff tests
@@ -133,7 +134,7 @@ class NewNowdocQuotedHeredocSniffTest extends BaseSniffTest
         );
 
         // PHPCS 1.x does not support skipping forward.
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.0', '>=')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.0', '>=')) {
             $data[] = array(42);
             $data[] = array(46);
             $data[] = array(82);

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewNowdocQuotedHeredocSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New nowdoc and quoted heredoc sniff tests
@@ -12,9 +15,9 @@
  * @group newNowdocQuotedHeredoc
  * @group reservedKeywords
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewNowdocQuotedHeredocSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewNowdocQuotedHeredocSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New nullable type hints / return types sniff test file
@@ -12,9 +15,9 @@
  * @group nullableTypes
  * @group typeDeclarations
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewNullableTypesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewNullableTypesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New return types test file
@@ -12,9 +15,9 @@
  * @group newReturnTypeDeclarations
  * @group typeDeclarations
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewReturnTypeDeclarationsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewReturnTypeDeclarationsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New type declarations test file
@@ -12,9 +15,9 @@
  * @group newScalarTypeDeclarations
  * @group typeDeclarations
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewScalarTypeDeclarationsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewScalarTypeDeclarationsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewUseConstFunctionSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewUseConstFunctionSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * New use const function in PHP 5.6 sniff test file
@@ -12,9 +15,9 @@
  * @group newUseConstFunction
  * @group use
  *
- * @covers PHPCompatibility_Sniffs_PHP_NewUseConstFunctionSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NewUseConstFunctionSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -39,7 +39,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 
@@ -64,7 +64,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
      * @param bool   $isTrait     Whether to load the class/interface test file or the trait test file.
      * @param string $testVersion Value of 'testVersion' to set on PHPCS object.
      *
-     * @return PHP_CodeSniffer_File File object|false
+     * @return \PHP_CodeSniffer_File File object|false
      */
     protected function getTestFile($isTrait, $testVersion = null)
     {

--- a/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * Non Static Magic Sniff tests
@@ -39,7 +40,7 @@ class NonStaticMagicMethodsSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         // When using PHPCS 2.3.4 or lower combined with PHP 5.3 or lower, traits are not recognized.
-        if (version_compare(\PHP_CodeSniffer::VERSION, '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
+        if (version_compare(PHPCSHelper::getVersion(), '2.4.0', '<') && version_compare(phpversion(), '5.4', '<')) {
             self::$recognizesTraits = false;
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NonStaticMagicMethodsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Non Static Magic Sniff tests
@@ -12,9 +15,9 @@
  * @group nonStaticMagicMethods
  * @group magicMethods
  *
- * @covers PHPCompatibility_Sniffs_PHP_NonStaticMagicMethodsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\NonStaticMagicMethodsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ParameterShadowSuperGlobalsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * ParameterShadowSuperGlobalsSniffTest
@@ -12,9 +15,9 @@
  * @group parameterShadowSuperGlobals
  * @group superglobals
  *
- * @covers PHPCompatibility_Sniffs_PHP_ParameterShadowSuperGlobalsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ParameterShadowSuperGlobalsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * preg_replace() /e modifier sniff tests
@@ -12,9 +15,9 @@
  * @group pregReplaceEModifier
  * @group regexEModifier
  *
- * @covers PHPCompatibility_Sniffs_PHP_PregReplaceEModifierSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\PregReplaceEModifierSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Removed alternative PHP tags sniff test file
  *
  * @group removedAlternativePHPTags
  *
- * @covers PHPCompatibility_Sniffs_PHP_RemovedAlternativePHPTagsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RemovedAlternativePHPTagsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -8,6 +8,7 @@
 namespace PHPCompatibility\Tests\Sniffs\PHP;
 
 use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
 
 /**
  * Removed extensions sniff tests
@@ -263,16 +264,22 @@ class RemovedExtensionsSniffTest extends BaseSniffTest
      */
     public function dataNoFalsePositives()
     {
-        return array(
+        $data = array(
             array(57), // Not a function call.
             array(58), // Function declaration.
             array(59), // Class instantiation.
             array(60), // Method call.
-            array(68), // Whitelisted function.
-            array(74), // Whitelisted function array.
-            array(75), // Whitelisted function array.
             array(78), // Live coding.
         );
+
+        // Inline setting changes in combination with namespaced sniffs is only supported since PHPCS 2.6.0.
+        if (version_compare(PHPCSHelper::getVersion(), '2.6.0', '>=')) {
+            $data[] = array(68); // Whitelisted function.
+            $data[] = array(74); // Whitelisted function array.
+            $data[] = array(75); // Whitelisted function array.
+        }
+
+        return $data;
     }
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedExtensionsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Removed extensions sniff tests
@@ -12,9 +15,9 @@
  * @group removedExtensions
  * @group extensions
  *
- * @covers PHPCompatibility_Sniffs_PHP_RemovedExtensionsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RemovedExtensionsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedFunctionParametersSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Removed Functions Parameter Sniff test file
@@ -12,9 +15,9 @@
  * @group removedFunctionParameters
  * @group functionParameters
  *
- * @covers PHPCompatibility_Sniffs_PHP_RemovedFunctionParametersSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RemovedFunctionParametersSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Removed global variables sniff tests
@@ -12,9 +15,9 @@
  * @group removedGlobalVariables
  * @group superglobals
  *
- * @covers PHPCompatibility_Sniffs_PHP_RemovedGlobalVariablesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RemovedGlobalVariablesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Wim Godden <wim@cu.be>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedHashAlgorithmsSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Removed hash algorithms sniff tests
@@ -12,9 +15,9 @@
  * @group removedHashAlgorithms
  * @group hashAlgorithms
  *
- * @covers PHPCompatibility_Sniffs_PHP_RemovedHashAlgorithmsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RemovedHashAlgorithmsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Required Optional Parameter Sniff test file
@@ -12,9 +15,9 @@
  * @group requiredOptionalFunctionParameters
  * @group functionParameters
  *
- * @covers PHPCompatibility_Sniffs_PHP_RequiredOptionalFunctionParametersSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\RequiredOptionalFunctionParametersSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ShortArraySniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ShortArraySniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Short array syntax sniff tests
@@ -12,9 +15,9 @@
  * @group shortArray
  * @group arraySyntax
  *
- * @covers PHPCompatibility_Sniffs_PHP_ShortArraySniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ShortArraySniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Alex Miroshnikov <unknown@example.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/TernaryOperatorsSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Ternary Operators Sniff tests
  *
  * @group ternaryOperators
  *
- * @covers PHPCompatibility_Sniffs_PHP_TernaryOperatorsSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\TernaryOperatorsSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Jansen Price <jansen.price@gmail.com>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -5,15 +5,18 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * Valid Integers Sniff tests
  *
  * @group validIntegers
  *
- * @covers PHPCompatibility_Sniffs_PHP_ValidIntegersSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\ValidIntegersSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
@@ -5,6 +5,9 @@
  * @package PHPCompatibility
  */
 
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
 
 /**
  * VariableVariables sniff test file
@@ -12,9 +15,9 @@
  * @group variableVariables
  * @group variables
  *
- * @covers PHPCompatibility_Sniffs_PHP_VariableVariablesSniff
+ * @covers \PHPCompatibility\Sniffs\PHP\VariableVariablesSniff
  *
- * @uses    BaseSniffTest
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
  * @package PHPCompatibility
  * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
  */

--- a/PHPCompatibility/Tests/bootstrap.php
+++ b/PHPCompatibility/Tests/bootstrap.php
@@ -9,28 +9,50 @@ if (defined('PHP_CODESNIFFER_IN_TESTS') === false) {
     define('PHP_CODESNIFFER_IN_TESTS', true);
 }
 
+// The below two defines are needed for PHPCS 3.x.
+if (defined('PHP_CODESNIFFER_CBF') === false) {
+    define('PHP_CODESNIFFER_CBF', false);
+}
+
+if (defined('PHP_CODESNIFFER_VERBOSITY') === false) {
+    define('PHP_CODESNIFFER_VERBOSITY', 0);
+}
+
 // Get the PHPCS dir from an environment variable.
 $phpcsDir = getenv('PHPCS_DIR');
 
 if ($phpcsDir === false) {
     // Ok, no environment variable set, so this might be a PEAR install of PHPCS.
+    // @todo fix path for PEAR install!
     $phpcsDir = dirname(__FILE__) . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..';
 }
 $phpcsDir .= DIRECTORY_SEPARATOR;
 
-if (file_exists($phpcsDir . 'CodeSniffer.php')) {
+if (file_exists($phpcsDir . 'autoload.php')) {
+    // PHPCS 3.x.
+    require $phpcsDir . 'autoload.php';
+
+} elseif (file_exists($phpcsDir . 'CodeSniffer.php')) {
+    // PHPCS 1.x, 2.x.
     require $phpcsDir . 'CodeSniffer.php';
 
 } else {
     // Otherwise we must be in a composer install.
-    $vendorDir = dirname(__FILE__) . '/../../vendor';
+    $vendorDir        = dirname(__FILE__) . '/../../vendor';
+    $composerAutoload = $vendorDir . DIRECTORY_SEPARATOR . 'autoload.php';
+    $phpcsAutoload    = $vendorDir . DIRECTORY_SEPARATOR . 'squizlabs' . DIRECTORY_SEPARATOR . 'php_codesniffer' . DIRECTORY_SEPARATOR . 'autoload.php';
 
-    if (!@include($vendorDir . '/autoload.php')) {
+    if (!@include($composerAutoload)) {
         echo 'You must set up the project dependencies, run the following commands:
     wget http://getcomposer.org/composer.phar
     php composer.phar install
     ';
         die(1);
+    }
+
+    // PHPCS 3.x no longer uses Composer autoload, so include the PHPCS native autoloader.
+    if (file_exists($phpcsAutoload)) {
+        require_once $phpcsAutoload;
     }
 }
 
@@ -41,6 +63,15 @@ if (class_exists('PHPUnit\Runner\Version')) {
 
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'PHPCSHelper.php';
+
+/*
+ * Alias the PHPCS 3.x classes to their PHPCS 2.x equivalent if necessary.
+ * Also provide a custom autoloader for our abstract base classes as the PHPCS native autoloader
+ * has trouble with them in combination with the PHPCompatibility custom unit test suite.
+ */
+if (version_compare(\PHPCompatibility\PHPCSHelper::getVersion(), '2.99.99', '>')) {
+    include_once dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . 'PHPCSAliases.php';
+}
 
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseClass' . DIRECTORY_SEPARATOR . 'MethodTestFrame.php';

--- a/PHPCompatibility/Tests/bootstrap.php
+++ b/PHPCompatibility/Tests/bootstrap.php
@@ -39,5 +39,8 @@ if (class_exists('PHPUnit\Runner\Version')) {
     require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'PHPUnit6Compat.php';
 }
 
+
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'PHPCSHelper.php';
+
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseSniffTest.php';
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'BaseClass' . DIRECTORY_SEPARATOR . 'MethodTestFrame.php';

--- a/PHPCompatibility/ruleset.xml
+++ b/PHPCompatibility/ruleset.xml
@@ -3,6 +3,8 @@
 <ruleset name="PHPCompatibility">
     <description>Coding Standard that checks for PHP version compatibility.</description>
 
+    <autoload>./../PHPCSAliases.php</autoload>
+
     <!-- This rule covers checking for non-magic methods using __ prefix. -->
     <!-- Covers part 2 of issue 64: https://github.com/wimg/PHPCompatibility/issues/64 -->
     <rule ref="Generic.NamingConventions.CamelCapsFunctionName">

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Pull requests that check for compatibility issues in PHP4 code - in particular b
 Requirements
 -------
 
+PHP: 5.3+
+PHP Codesniffer: 1.5.x, 2.x or 3.0.1+
+
 The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer. You should get reasonably consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on PHP 5.4 or higher.
 
 PHP CodeSniffer 1.5.1 is required for 90% of the sniffs, PHPCS 2.6 or later is required for full support, notices may be thrown on older versions.
 
-**_The PHPCompatibility standard is currently not compatible with PHPCS 3.0, though the [intention is to fix this](https://github.com/wimg/PHPCompatibility/issues/367) in the near future._**
 
 Thank you
 ---------
@@ -47,7 +49,7 @@ Thanks to [WP Engine](https://wpengine.com) for their support on the PHP 7.0 sni
 Installation using PEAR (method 1)
 -----------------------
 
-* Install [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) with `pear install PHP_CodeSniffer-2.9.0`.
+* Install [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) with `pear install PHP_CodeSniffer`.
 * Checkout the latest release from https://github.com/wimg/PHPCompatibility/releases into the `PHP/CodeSniffer/Standards/PHPCompatibility` directory.
 
 
@@ -58,7 +60,7 @@ Installation in Composer project (method 2)
 
 ```json
 "require-dev": {
-   "squizlabs/php_codesniffer": "^2.0",
+   "squizlabs/php_codesniffer": "^2.0 || ^3.0.1",
    "wimg/php-compatibility": "*",
    "simplyadmire/composer-plugins" : "@dev"
 },
@@ -72,7 +74,7 @@ Installation in Composer project (method 2)
 Installation via a git check-out to an arbitrary directory (method 3)
 -----------------------
 
-* Install the latest `2.x` version of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation) (Composer, PEAR, Phar file, Git checkout).
+* Install [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation) (Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), Phar file, Git checkout).
 * Checkout the latest release from https://github.com/wimg/PHPCompatibility/releases into an arbitrary directory.
 * Add the path to the directory **_above_** the directory in which you cloned the PHPCompability repo to the PHPCS configuration using the below command.
    ```bash

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ To whitelist userland functions, you can pass a comma-delimited list of function
 	</rule>
 ```
 
+This property was added in PHPCompatibility version 7.0.1.
+As of PHPCompatibility version 8.0.0, this custom property is only supported in combination with PHPCS > 2.6.0 due to an upstream bug (which was fixed in PHPCS 2.6.0).
+
 
 License
 -------

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,9 @@
   "name" : "wimg/php-compatibility",
   "description" : "This is a set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
   "require" : {
-    "php" : ">=5.1.2",
+    "php" : ">=5.3",
     "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : "^2.0"
+    "squizlabs/php_codesniffer" : "^2.0 || ^3.0.1"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "*"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,20 +14,12 @@
 	<!--
 		PHP cross version compatibility ;-).
 	-->
-	<config name="testVersion" value="5.1-99.0"/>
+	<config name="testVersion" value="5.3-99.0"/>
 	<rule ref="PHPCompatibility"/>
 
 	<!-- Verified correct usage. -->
 	<rule ref="PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved">
 		<exclude-pattern>*/RemovedAlternativePHPTags*.php</exclude-pattern>
-	</rule>
-
-	<!-- Verified correct usage: PHPUnit 6 compatibility layer. -->
-	<rule ref="PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound">
-		<exclude-pattern>*/Tests/PHPUnit6Compat.php</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.PHP.NewFunctions.class_aliasFound">
-		<exclude-pattern>*/Tests/PHPUnit6Compat.php</exclude-pattern>
 	</rule>
 
 	<!--
@@ -36,10 +28,6 @@
 	<rule ref="PSR2">
 		<!-- To address at a later point in time. -->
 		<exclude name="Generic.Files.LineLength.TooLong"/>
-
-		<!-- These will be addressed when making the repo compatible with PHPCS 3.x. -->
-		<exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
-		<exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
 
 		<!-- Ignoring a number of whitespace issues around blank lines. -->
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>


### PR DESCRIPTION
This PR makes the PHPCompatibility standard compatible with PHPCS 3.x while still maintaining compatibility with PHPCS 1.x and 2.x.

The installation/upgrade instructions will be pulled in a separate PR. See https://github.com/wimg/PHPCompatibility/pull/446#issuecomment-315614965
The unit tests will - at this moment - not run when using PHPCS 3.x icw the old installation instructions. A solution for this will be outlined in the `contributing` document in the above mentioned separate PR.

This PR will be easiest to review by looking at each commit individually.

Fixes #367 

P.S.: I'm aware of an issue with the whitelisting of functions for the RemovedExtensions sniff on PHPCS 1.x which is causing the unit tests to fail. I'm looking into this.