### PR TITLE
Build: only lint the PHP files once per PHP version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 env:
   # `master`, i.e PHPCS 3.x.
-  - PHPCS_VERSION="dev-master" COVERALLS_VERSION="dev-master"
+  - PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="dev-master"
   # PHPCS 1.5.x
   - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
 
@@ -21,7 +21,7 @@ matrix:
     - php: 5.3
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.3
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="~1.0"
 
     # PHP 5.4 needs a different Coveralls version.
     - php: 5.4
@@ -29,7 +29,7 @@ matrix:
     - php: 5.4
       env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
     - php: 5.4
-      env: PHPCS_VERSION="dev-master" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
 
     # These will be changed to set variations of PHPCS 2.x in a next PR.
     - php: 5.5
@@ -47,14 +47,14 @@ matrix:
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
     - php: nightly
-      env: PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" LINT=1
 
     - php: hhvm
       dist: trusty
       env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: hhvm
       dist: trusty
-      env: PHPCS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" LINT=1
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -76,7 +76,7 @@ before_script:
 
 script:
   # Lint all PHP files against parse errors.
-  - find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+  - if [[ "$LINT" == "1" ]]; then find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
   # Check the code style of the code base.
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --runtime-set ignore_warnings_on_exit 1; fi
   # Run the unit tests.


### PR DESCRIPTION
No need to do it for each build.