### PR TITLE
Build: Mix up the build matrix and composer specificity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,23 +36,23 @@ matrix:
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
     - php: 5.4
       dist: precise
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION="2.2.*" COVERALLS_VERSION="~1.0"
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
 
-    # These will be changed to set variations of PHPCS 2.x in a next PR.
+    # Test against a variation of PHPCS 2.x versions.
     - php: 5.5
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.4.*" COVERALLS_VERSION="dev-master"
     - php: 5.6
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.8.*" COVERALLS_VERSION="dev-master"
     - php: 7.0
-      env: PHPCS_VERSION=">=2.0,<3.0" SNIFF=1  COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.6.*" SNIFF=1 COVERALLS_VERSION="dev-master"
       addons:
         apt:
           packages:
             - libxml2-utils
     - php: 7.1
-      env: PHPCS_VERSION=">=2.0,<3.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="dev-master"
 
     # Coverage is not checked on nightly and HHVM.
     - php: nightly
@@ -80,8 +80,9 @@ before_install:
   - composer self-update
   - if [[ $COVERALLS_VERSION ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:~4.0; fi
-  - composer install
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:5.7.17; fi
+  # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.
+  - composer install --no-dev
 
 before_script:
   - if [[ $COVERALLS_VERSION ]]; then mkdir -p build/logs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ cache:
 
 language: php
 
+## Cache composer downloads.
+cache:
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
 php:
   - 5.5
   - 5.6
@@ -82,7 +90,8 @@ before_install:
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:5.7.17; fi
   # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.
-  - composer install --no-dev
+  # --prefer-dist will allow for optimal use of the travis caching ability.
+  - composer install --no-dev --prefer-dist
 
 before_script:
   - if [[ $COVERALLS_VERSION ]]; then mkdir -p build/logs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,31 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - 7.1
+  - nightly
 
 env:
-  # `master`, i.e PHPCS 3.x.
-  - PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="dev-master"
-  # PHPCS 1.5.x
-  - PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+  global:
+    - COVERALLS_VERSION="notset"
+  matrix:
+    # `master`, i.e PHPCS 3.x.
+    - PHPCS_VERSION="dev-master" LINT=1
+    # PHPCS 1.5.x
+    - PHPCS_VERSION=">=1.5.1,<2.0"
 
 matrix:
   fast_finish: true
   include:
+    # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
+
+    - php: 7.1
+      env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="dev-master"
+      addons:
+        apt:
+          packages:
+            - libxml2-utils
+    - php: 7.1
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+
     # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
       dist: precise
@@ -38,37 +52,27 @@ matrix:
       dist: precise
       env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="~1.0"
 
-    # PHP 5.4 needs a different Coveralls version.
+    # PHP 5.4 with low PHPCS needs "precise" + one build with Coveralls.
     - php: 5.4
       dist: precise
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.4
       dist: precise
-      env: PHPCS_VERSION="2.2.*" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION="2.2.*"
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
 
     # Test against a variation of PHPCS 2.x versions.
     - php: 5.5
-      env: PHPCS_VERSION="2.4.*" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.4.*"
     - php: 5.6
-      env: PHPCS_VERSION="2.8.*" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.8.*"
     - php: 7.0
-      env: PHPCS_VERSION="2.6.*" SNIFF=1 COVERALLS_VERSION="dev-master"
-      addons:
-        apt:
-          packages:
-            - libxml2-utils
+      env: PHPCS_VERSION="2.6.*"
     - php: 7.1
       env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="dev-master"
-
-    # Coverage is not checked on nightly and HHVM.
-    - php: nightly
-      env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
-    - php: nightly
-      env: PHPCS_VERSION="dev-master" LINT=1
 
     - php: hhvm
       dist: trusty
@@ -86,7 +90,7 @@ before_install:
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
   - composer self-update
-  - if [[ $COVERALLS_VERSION ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:5.7.17; fi
   # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.
@@ -94,18 +98,18 @@ before_install:
   - composer install --no-dev --prefer-dist
 
 before_script:
-  - if [[ $COVERALLS_VERSION ]]; then mkdir -p build/logs; fi
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then mkdir -p build/logs; fi
   - phpenv rehash
 
 script:
   # Lint all PHP files against parse errors.
   - if [[ "$LINT" == "1" ]]; then find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+  # Run the unit tests.
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhv* && $COVERALLS_VERSION == "notset" ]]; then phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit; fi
   # Check the code style of the code base.
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --runtime-set ignore_warnings_on_exit 1; fi
-  # Run the unit tests.
-  - if [[ $COVERALLS_VERSION ]]; then phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
-  - if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then phpunit; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit; fi
   # Validate the xml file.
   # @link http://xmlsoft.org/xmllint.html
   - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./PHPCompatibility/ruleset.xml; fi
@@ -113,4 +117,4 @@ script:
   - if [[ "$SNIFF" == "1" ]]; then diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml"); fi
 
 after_success:
-  - if [[ $COVERALLS_VERSION ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,15 @@
 {
   "name" : "wimg/php-compatibility",
-  "description" : "This is a set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+  "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
   "require" : {
     "php" : ">=5.3",
-    "ext-tokenizer" : "*",
-    "squizlabs/php_codesniffer" : "^2.0 || ^3.0.1"
+    "squizlabs/php_codesniffer" : "^2.2 || ^3.0.1"
+  },
+  "require-dev" : {
+    "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+  },
+  "conflict": {
+    "squizlabs/php_codesniffer": "2.6.2"
   },
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "*"


### PR DESCRIPTION
N.B.: Since this PR was originally pulled, two more travis script related commits have been added. The original PR description only deals with the first commit. The others are outlined in a follow on comment.

--------
Build against various PHPCS versions, not just the oldest and most recent.

As discussed a while back:
As PHPCompatibility is supposed to support all PHPCS versions from 1.5.x upwards to the current version, it would be good to run the build tests against interim versions of PHPCS as well to make sure it actually does.

Over the last few months I've been running tests around this and have send in a number of PRs to solve issues with:
* sniffs which (silently) did not support all PHPCS versions
* test exclusions relating to specific/earlier PHPCS versions

These have all been merged in the mean time.

### Current PHPCS cross-version compatibility status:

For the latest results of the extensive cross-version build tests, see https://travis-ci.org/jrfnl/PHPCompatibility/builds/254166387

#### For the PHPCS 2.x range:
Except for PHPCS  2.0 <= 2.2, the sniffs now support all PHPCS interim versions & testing against interim versions now works ok.
The one exception is PHPCS 2.6.2. The sniffs work ok there, however the unit test framework fails because of a bug in PHPCS itself which was fixed in the next release.

#### For the PHPCS 1.x range:
The builds fail for all versions **_except_** 1.5.6.

### What this PR proposes:

Currently for each PHP version, we test against `1.5.x`, `master` (3.x) and the latest `2.x` version.

To maintain the level of compatibility we now have, I propose to change the build matrix to:
* Still test each PHP version against `1.5.x` and `master`,
* Still test against the last PHPCS 2.x version for the highest and lowest PHP version we test
* Change the "latest 2.x version" to a semi-random interim PHPCS version for the other PHP versions to cover every relevant minor version.

The build matrix does not contain enough different PHP versions to cover all PHPCS 2.x minors without adding more builds, so I've selected the most relevant PHPCS 2.x minor versions.

### Composer changes:

As it is now pretty clear which PHPCS versions are supported:
* The `requires` directive in `composer.json` has been made more specific.
* A `conflict` directive has been added to prevent PHPCS 2.6.2 causing trouble.

Additionally, I've made some more changes to the `composer.json` file:
* The Tokenizer extension is a dependency for PHPCS, not for PHPCompatibility itself, so I've removed it.
* I've added PHPUnit as a `dev` dependency as it **_is_** a dependency for PHPCompatibility as we don't use the PHPCS native unit test suite.
     This addition however leads to a Composer requirements conflict for HHVM, which is solved by the change of the PHPUnit version for the HHVM PHPUnit require statement.
     N.B.: PHPUnit does **_not_** officially support HHVM, so the specific version chosen is a carefully picked one which is known to work with HHVM.