### PR TITLE
PHPCS 3.x compat: create the aliases correctly

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -24,7 +24,7 @@
  * manner.}}
  */
 if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
-    if (class_exists('\PHP_CodeSniffer_Sniff') === false) {
+    if (interface_exists('\PHP_CodeSniffer_Sniff') === false) {
         class_alias('PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff');
     }
     if (class_exists('\PHP_CodeSniffer_File') === false) {


### PR DESCRIPTION
`PHP_CodeSniffer_Sniff` is an interface, not a class, so should be checked for as such.

This will prevent `Warning: Cannot declare interface \PHP_CodeSniffer_Sniff, because the name is already in use` errors when other external standards use the same methodology to create cross-version compatibility.