### PR TITLE
Minor fix: better to do the class name comparison in a case insensitive manner

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -53,7 +53,7 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
 if (defined('PHP_CODESNIFFER_IN_TESTS')) {
     spl_autoload_register(function ($class) {
         // Only try & load our own classes.
-        if (strpos($class, 'PHPCompatibility') !== 0) {
+        if (stripos($class, 'PHPCompatibility') !== 0) {
             return;
         }
 


### PR DESCRIPTION
… in the auto loader to allow for PHP cross-version compatibility difference.