### PR TITLE
Update readme, contributing  and changelog for v 8.0.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Reporting bugs
 --------------
 
 Before reporting a bug, you should check what sniff an error is coming from.
-Running `phpcs` with the `-s` flag will show the names of the sniffs with each error.
+Running `phpcs` with the `-s` flag will show the name of the sniff with each error.
 
 Bug reports containing a minimal code sample which can be used to reproduce the issue are highly appreciated as those are most easily actionable.
 
@@ -13,7 +13,7 @@ Requesting features
 
 The PHPCompatibility standard only concerns itself with cross-version PHP compatibility of code.
 
-When requesting a new feature, please add a link to a relevant page in the PHP Manual / PHP Changelog / PHP RFC website which illustrates the feature you are requesting.
+When requesting a new feature, please add a link to a relevant page in the [PHP Manual](http://php.net/manual/en/) / PHP Changelog / [PHP RFC website](https://wiki.php.net/rfc) which illustrates the feature you are requesting.
 
 Pull requests
 -------------
@@ -26,53 +26,45 @@ Please make sure that your pull request contains unit tests covering what's bein
 
 * All code should be compatible with PHPCS 1.5.6, PHPCS 2.x and PHPCS 3.x.
 * All code should be compatible with PHP 5.3 to PHP nightly.
-* All code should comply with the PHPCompatibility coding standards. The ruleset used by PHPCompatibility is largely based on PSR2 with minor variations and some additional checks for documentation and such.
+* All code should comply with the PHPCompatibility coding standards.
+    The ruleset used by PHPCompatibility is largely based on PSR-2 with minor variations and some additional checks for documentation and such.
 
 
 Running the Sniff Tests
 -----------------------
-All the sniffs are fully tested with PHPUnit tests. In order to run the tests
-on the sniffs, the following installation steps are required.
+All the sniffs are fully tested with PHPUnit tests. In order to run the tests on the sniffs, the following installation steps are required.
 
-1. Install the latest release or the `master` branch of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer.git).
+1. Install PHP CodeSniffer and PHP Compatibility by following the instructions in the Readme for either [installing with Composer](https://github.com/wimg/PHPCompatibility/blob/master/README.md#installation-in-a-composer-project-method-1) or via a [Git Checkout to an arbitrary directory](https://github.com/wimg/PHPCompatibility/blob/master/README.md#installation-via-a-git-check-out-to-an-arbitrary-directory-method-2).
 
-    This can be done with composer using the following command:
+    If you install using Composer, make sure you run `composer install --prefer-source` to get access to the unit tests and other development related files.
 
-        $ composer require "squizlabs/php_codesniffer=^2.0 || ^3.0.1"
+    **Pro-tip**: If you develop regularly for the PHPCompatibility standard, it may be preferable to use a git clone based install of PHP CodeSniffer to allow you to easily test sniffs with different PHP CodeSniffer versions by switching between tags.
 
-    or by adding the following into `~/.composer/composer.json`:
-    ```json
-        {
-            "require": {
-                "phpunit/phpunit": ">=4.0",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0.1"
-            }
-        }
+2. If you used Composer, PHPUnit should be installed automatically and you are done.
+
+    Run the tests by running `phpunit` in the root directory of PHPCompatibility.
+    It will read the `phpunit.xml.dist` file and execute the tests.
+
+3. If you used any of the other installation methods and don't have PHPUnit installed on your system yet, download and [install PHPUnit](https://phpunit.de/getting-started.html).
+
+4. To get the unit tests running with a non-Composer-based install, you need to set an environment variable so the PHPCompatibility unit test suite will know where to find PHPCS.
+
+    The most flexible way to do this, is by setting this variable in a custom `phpunit.xml` file.
+    
+    1. Copy the existing `phpunit.xml.dist` file in the root directory of the PHPCompatibility repository and name it `phpunit.xml`.
+    2. Add the following snippet to the new file, replacing the value `/path/to/PHPCS` with the path to the directory in which you installed PHP CodeSniffer on your system:
+    ```xml
+    <php>
+        <env name="PHPCS_DIR" value="/path/to/PHPCS"/>
+    </php>
     ```
-
-2. Run the following command to compose in the versions indicated in the above
-   global composer.json file:
-
-        $ composer global install --prefer-source
-
-3. Update your system `$PATH` to include the globally composed files:
-
-        $ export PATH=~/.composer/vendor/bin:$PATH
-
-4. Be sure that the `PHPCompatibility` directory is symlinked into
-   `PHP_Codesniffer`'s standards directory:
-
-        $ ln -s /path/to/PHPCompatibility ~/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/PHPCompatibility
-
-5. Verify the standard is available with `phpcs -i`. The output should include `PHPCompatibility`.
-
-6. Run the tests by running `phpunit` in the root directory of PHPCompatibility.
-   It will read the `phpunit.xml` file and execute the tests.
+    3. Run the tests by running `phpunit` from the root directory of your PHPCompatibility install.
+       It will automatically read the `phpunit.xml` file and execute the tests.
 
 
 #### Issues when running the PHPCS Unit tests for another standard
 
-This sniff library uses its own PHPUnit setup rather than the PHPCS native unit testing framework to allow for testing the sniffs with various config settings for the `testVersion` variable.
+This sniff library uses its own PHPUnit setup rather than the PHP CodeSniffer native unit testing framework to allow for testing the sniffs with various settings for the `testVersion` config variable.
 
 If you are running the PHPCS native unit tests or the unit tests for another sniff library which uses the PHPCS native unit testing framework, PHPUnit might throw errors related to this sniff library depending on your setup.
 
@@ -80,9 +72,9 @@ This will generally only happen if you have both PHPCompatibility as well as ano
 
 To fix these errors, make sure you are running PHPCS 2.7.1 or higher and add the following to the `phpunit.xml` file for the sniff library you are testing:
 ```xml
-	<php>
-		<env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility"/>
-	</php>
+    <php>
+        <env name="PHPCS_IGNORE_TESTS" value="PHPCompatibility"/>
+    </php>
 ```
 
 This will prevent PHPCS trying to include the PHPCompatibility unit tests when creating the test suite.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PHP Compatibility Coding Standard for PHP_CodeSniffer
+PHP Compatibility Coding Standard for PHP CodeSniffer
 =====================================================
 [![Latest Stable Version](https://poser.pugx.org/wimg/php-compatibility/v/stable.png)](https://packagist.org/packages/wimg/php-compatibility)
 [![Latest Unstable Version](https://poser.pugx.org/wimg/php-compatibility/v/unstable.png)](https://packagist.org/packages/wimg/php-compatibility)
@@ -15,26 +15,30 @@ PHP Compatibility Coding Standard for PHP_CodeSniffer
 [![Not Tested Runtime Badge](http://php-eye.com/badge/wimg/php-compatibility/not-tested.svg?branch=dev-master)](http://php-eye.com/package/wimg/php-compatibility)
 
 
-This is a set of sniffs for [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP version compatibility.
+This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP version compatibility.
 It will allow you to analyse your code for compatibility with higher and lower versions of PHP. 
 
 
 PHP Version Support
 -------
 
-The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release.  This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be).  Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
+The project aims to cover all PHP compatibility changes introduced since PHP 5.0 up to the latest PHP release. This is an ongoing process and coverage is not yet 100% (if, indeed, it ever could be). Progress is tracked on [our Github issue tracker](https://github.com/wimg/PHPCompatibility/issues).
 
-Pull requests that check for compatibility issues in PHP4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
+Pull requests that check for compatibility issues in PHP 4 code - in particular between PHP 4 and PHP 5.0 - are very welcome as there are still situations where people need help upgrading legacy systems. However, coverage for changes introduced before PHP 5.1 will remain patchy as sniffs for this are not actively being developed at this time.
 
 Requirements
 -------
 
-PHP: 5.3+
-PHP Codesniffer: 1.5.x, 2.x or 3.0.1+
+* PHP 5.3+ for use with PHP CodeSniffer 1.x and 2.x.
+* PHP 5.4+ for use with PHP CodeSniffer 3.x.
 
-The sniffs are designed to give the same results regardless of which PHP version you are using to run CodeSniffer. You should get reasonably consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on PHP 5.4 or higher.
+PHP CodeSniffer: 1.5.6, 2.2.0+ or 3.0.2+.
 
-PHP CodeSniffer 1.5.1 is required for 90% of the sniffs, PHPCS 2.6 or later is required for full support, notices may be thrown on older versions.
+The sniffs are designed to give the same results regardless of which PHP version you are using to run PHP CodeSniffer. You should get reasonably consistent results independently of the PHP version used in your test environment, though for the best results it is recommended to run the sniffs on PHP 5.4 or higher.
+
+PHP CodeSniffer 1.5.6 is required for 90% of the sniffs, PHP CodeSniffer 2.6.0 or later is required for full support, notices may be thrown on older versions.
+
+As of version 8.0.0, the PHPCompatibility standard can also be used with PHP CodeSniffer 3.x.
 
 
 Thank you
@@ -46,78 +50,117 @@ Thanks to all [contributors](https://github.com/wimg/PHPCompatibility/graphs/con
 Thanks to [WP Engine](https://wpengine.com) for their support on the PHP 7.0 sniffs.
 
 
-Installation using PEAR (method 1)
------------------------
+:warning: Upgrading to PHPCompatibility 8.0.0 :warning:
+--------
+As of version 8.0.0, the installation instructions have changed. For most users, this means they will have to run a one-time-only extra command, make a change to their Composer configuration and/or adjust their build scripts.
 
-* Install [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) with `pear install PHP_CodeSniffer`.
-* Checkout the latest release from https://github.com/wimg/PHPCompatibility/releases into the `PHP/CodeSniffer/Standards/PHPCompatibility` directory.
+Please read the changelog for version [8.0.0](https://github.com/wimg/PHPCompatibility/releases/tag/8.0.0) carefully before upgrading.
 
 
-Installation in Composer project (method 2)
+Installation in a Composer project (method 1)
 -------------------------------------------
 
-* Add the following lines to the `require-dev` section of your composer.json file.
+* Add the following lines to the `require-dev` section of your `composer.json` file.
+    ```json
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^2.2 || ^3.0.2",
+        "wimg/php-compatibility": "*"
+    },
+    "prefer-stable" : true
+    ```
+* Next, PHP CodeSniffer has to be informed of the location of the standard.
+    - If PHPCompatibility is the **_only_** external PHP CodeSniffer standard you use, you can add the following to your `composer.json` file to automatically run the necessary command:
+        ```json
+        "scripts": {
+            "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility",
+            "post-update-cmd" : "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wimg/php-compatibility"
+        }
+        ```
+    - Alternatively - and **_strongly recommended_** if you use more than one external PHP CodeSniffer standard - you can use any of the following Composer plugins to handle this for you.
 
-```json
-"require-dev": {
-   "squizlabs/php_codesniffer": "^2.0 || ^3.0.1",
-   "wimg/php-compatibility": "*",
-   "simplyadmire/composer-plugins" : "@dev"
-},
-"prefer-stable" : true
+       Just add the Composer plugin you prefer to the `require-dev` section of your `composer.json` file.
 
-```
-* Run `composer update --lock` to install both phpcs and PHPCompatibility coding standard.
-* Use the coding standard with `./vendor/bin/phpcs --standard=PHPCompatibility`
+       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.1"
+       * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
+       * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin *might* still work, but appears to be abandoned.
+    - As a last alternative in case you use a custom ruleset, _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:
+        ```xml
+        <config name="installed_paths" value="vendor/wimg/php-compatibility" />
+        ```
+* Run `composer update --lock` to install both PHP CodeSniffer, the PHPCompatibility coding standard and - optionally - the Composer plugin.
+* Verify that the PHPCompatibility standard is registered correctly by running `./vendor/bin/phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+* Now you can use the following command to inspect your code:
+    ```bash
+    ./vendor/bin/phpcs -p . --standard=PHPCompatibility
+    ```
 
 
-Installation via a git check-out to an arbitrary directory (method 3)
+Installation via a git check-out to an arbitrary directory (method 2)
 -----------------------
 
-* Install [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation) (Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), Phar file, Git checkout).
-* Checkout the latest release from https://github.com/wimg/PHPCompatibility/releases into an arbitrary directory.
-* Add the path to the directory **_above_** the directory in which you cloned the PHPCompability repo to the PHPCS configuration using the below command.
+* Install [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) via [your preferred method](https://github.com/squizlabs/PHP_CodeSniffer#installation).
+
+    PHP CodeSniffer offers a variety of installation methods to suit your work-flow: Composer, [PEAR](http://pear.php.net/PHP_CodeSniffer), a Phar file, zipped/tarred release archives or checking the repository out using Git.
+
+    **Pro-tip:** Register the path to PHPCS in your system `$PATH` environment variable to make the `phpcs` command available from anywhere in your file system.
+* Download the [latest PHPCompatibility release](https://github.com/wimg/PHPCompatibility/releases) and unzip/untar it into an arbitrary directory.
+
+    You can also choose to clone the repository using git to easily update your install regularly.
+* Add the path to the directory in which you placed your copy of the PHPCompatibility repo to the PHP CodeSniffer configuration using the below command from the command line:
    ```bash
-   phpcs --config-set installed_paths /path/to/dir/above
+   phpcs --config-set installed_paths /path/to/PHPCompatibility
    ```
-   I.e. if you cloned the `PHPCompatibility` repository to the `/my/custom/standards/PHPCompatibility` directory, you will need to add the `/my/custom/standards` directory to the PHPCS [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
+   I.e. if you placed the `PHPCompatibility` repository in the `/my/custom/standards/PHPCompatibility` directory, you will need to add that directory to the PHP CodeSniffer [`installed_paths` configuration variable](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-installed-standard-paths).
 
-   **Pro-tip:** Alternatively, _and only if you use PHPCS version 2.6.0 or higher_, you can tell PHP_CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:
+   **Warning**: :warning: The `installed_paths` command overwrites any previously set `installed_paths`. If you have previously set `installed_paths` for other external standards, run `phpcs --config-show` first and then run the `installed_paths` command with all the paths you need separated by comma's, i.e.:
+   ```bash
+   phpcs --config-set installed_paths /path/1,/path/2,/path/3
+   ```
+
+   **Pro-tip:** Alternatively, in case you use a custom ruleset _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard(s) by adding the following snippet to your custom ruleset:
    ```xml
-   <config name="installed_paths" value="/path/to/dir/above"/>
+   <config name="installed_paths" value="/path/to/PHPCompatibility" />
    ```
+* Verify that the PHPCompatibility standard is registered correctly by running `phpcs -i` on the command line. PHPCompatibility should be listed as one of the available standards.
+* Now you can use the following command to inspect your code:
+    ```bash
+    phpcs -p . --standard=PHPCompatibility
+    ```
 
 
-Using the compatibility sniffs
+Sniffing your code for compatibility with specific PHP version(s)
 ------------------------------
-* Run the coding standard from the command-line with `phpcs --standard=PHPCompatibility`
-* You can specify which PHP version you want to test against by specifying `--runtime-set testVersion 5.5`.
-* You can also specify a range of PHP versions that your code needs to support. In this situation, compatibility issues that affect any of the PHP versions in that range will be reported: `--runtime-set testVersion 5.3-5.5`.
-    You can omit one or other part of the range if you want to support everything above/below a particular version, i.e. `--runtime-set testVersion 7.0-` to support PHP 7 and above.
+* Run the coding standard from the command-line with `phpcs -p . --standard=PHPCompatibility`.
+* By default, you will only receive notifications about deprecated and/or removed PHP features.
+* To get the most out of the PHPCompatibility standard, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+    - You can run the checks for just one specific PHP version by adding `--runtime-set testVersion 5.5` to your command line command.
+    - You can also specify a range of PHP versions that your code needs to support. In this situation, compatibility issues that affect any of the PHP versions in that range will be reported: `--runtime-set testVersion 5.3-5.5`.
+    - As of PHPCompatibility 7.1.3, you can omit one part of the range if you want to support everything above or below a particular version, i.e. use `--runtime-set testVersion 7.0-` to run all the checks for PHP 7.0 and above.
 
 More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 
 Using a custom ruleset
 ------------------------------
-Alternatively, you can add PHPCompatibility to a custom PHPCS ruleset.
+Like with any PHP CodeSniffer standard, you can add PHPCompatibility to a custom PHP CodeSniffer ruleset.
 
 ```xml
 <?xml version="1.0"?>
 <ruleset name="Custom ruleset">
-	<description>My rules for PHP_CodeSniffer</description>
+    <description>My rules for PHP CodeSniffer</description>
 
-	<!-- Run against the PHPCompatibility ruleset -->
-	<rule ref="PHPCompatibility"/>
-	
-	<!-- Run against a second ruleset -->
-	<rule ref="PSR2"/>
+    <!-- Run against the PHPCompatibility ruleset -->
+    <rule ref="PHPCompatibility"/>
+
+    <!-- Run against a second ruleset -->
+    <rule ref="PSR2"/>
 
 </ruleset>
 ```
 
 You can also set the `testVersion` from within the ruleset:
 ```xml
-	<config name="testVersion" value="5.3-5.5"/>
+    <!-- Check for cross-version support for PHP 5.6 and higher. -->
+    <config name="testVersion" value="5.6-"/>
 ```
 
 Other advanced options, such as changing the message type or severity of select sniffs, as described in the [PHPCS Annotated ruleset](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml) wiki page are, of course, also supported.
@@ -132,16 +175,16 @@ This might clash with userland functions using the same function prefix.
 
 To whitelist userland functions, you can pass a comma-delimited list of function names to the sniff.
 ```xml
-	<!-- Whitelist the mysql_to_rfc3339() and mysql_another_function() functions. -->
-	<rule ref="PHPCompatibility.PHP.RemovedExtensions">
-		<properties>
-			<property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
-		</properties>
-	</rule>
+    <!-- Whitelist the mysql_to_rfc3339() and mysql_another_function() functions. -->
+    <rule ref="PHPCompatibility.PHP.RemovedExtensions">
+        <properties>
+            <property name="functionWhitelist" type="array" value="mysql_to_rfc3339,mysql_another_function"/>
+        </properties>
+    </rule>
 ```
 
 This property was added in PHPCompatibility version 7.0.1.
-As of PHPCompatibility version 8.0.0, this custom property is only supported in combination with PHPCS > 2.6.0 due to an upstream bug (which was fixed in PHPCS 2.6.0).
+As of PHPCompatibility version 8.0.0, this custom property is only supported in combination with PHP CodeSniffer > 2.6.0 due to an upstream bug (which was fixed in PHPCS 2.6.0).
 
 
 License

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description" : "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
   "require" : {
     "php" : ">=5.3",
-    "squizlabs/php_codesniffer" : "^2.2 || ^3.0.1"
+    "squizlabs/php_codesniffer" : "^2.2 || ^3.0.2"
   },
   "require-dev" : {
     "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
@@ -12,7 +12,7 @@
     "squizlabs/php_codesniffer": "2.6.2"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "*"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
   },
   "license" : "LGPL-3.0",
   "keywords" : [ "compatibility", "phpcs", "standards" ],


### PR DESCRIPTION
Readme:
* Updated install instructions
* Updated (minimum) requirements information for running PHPCompatibility
* Added a warning section about upgrading to PHPCompatibility 8.0.0

Contributing:
* Updated instructions on how to run the unit tests
* Adjust (minimum) requirements information for new features

Changelog:
* Extensive upgrade instructions
* Note about the changed version numbering

Composer:
* Up the minimum required PHPCS version to 3.0.2 to benefit from one more fix to the autoloading

Also:
* Use spaces not tabs for the code samples in Readme/Contributing/Changelogs.
* Added some more empty lines here and there to improve readability in Readme/Contributing.

Fixes #472
Fixes #306

All: testing with the new install instructions & testing the upgrade instructions is highly appreciated. Please leave a comment in this PR to indicate which part you have tested & what your finding were.

@GaryJones I'd especially appreciate it if you could look these changes over.

---------
#### To Do for releasing the next version:
- [x] Add info on all changed merged into `master` since the previous release - **Up to date up to this PR**
- [x] Add release date - **tentatively set at August 3rd**
- [x] Remove unused bullets/sections
- [ ] Squash commits in this PR & merge
- [ ] Tag the release
- [ ] Close the milestone for this version
- [x] Open a new milestone for the next version

**Side-note**: There is one open issue in the DealerDirect Composer plugin which may impact this release: https://github.com/DealerDirect/phpcodesniffer-composer-installer/issues/33. Based on @GaryJones's finding, we may need to explicitly recommend using the 0.3 version of the DealerDirect Composer plugin for now. 