### PR TITLE
:sparkles: New `NewTypeCasts` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewTypeCastsSniff.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewTypeCastsSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractNewFeatureSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewTypeCastsSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewTypeCastsSniff extends AbstractNewFeatureSniff
+{
+
+    /**
+     * A list of new type casts, not present in older versions.
+     *
+     * The array lists : version number with false (not present) or true (present).
+     * If's sufficient to list the first version where the keyword appears.
+     *
+     * @var array(string => array(string => int|string|null))
+     */
+    protected $newTypeCasts = array(
+        'T_UNSET_CAST' => array(
+            '4.4'         => false,
+            '5.0'         => true,
+            'description' => 'The unset cast',
+        ),
+        'T_BINARY_CAST' => array(
+            '5.2.0'       => false,
+            '5.2.1'       => true,
+            'description' => 'The binary cast',
+        ),
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $tokens = array();
+        foreach ($this->newTypeCasts as $token => $versions) {
+            if (defined($token)) {
+                $tokens[] = constant($token);
+            }
+        }
+
+        /*
+         * Work around tokenizer issues.
+         *
+         * - (binary) cast is incorrectly tokenized as T_STRING_CAST by PHP and PHPCS.
+         * - b"something" binary cast is incorrectly tokenized as T_CONSTANT_ENCAPSED_STRING by PHP and PHPCS.
+         *
+         * @link https://github.com/squizlabs/PHP_CodeSniffer/issues/1574
+         */
+        $tokens[] = T_STRING_CAST;
+        $tokens[] = T_CONSTANT_ENCAPSED_STRING;
+
+        return $tokens;
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $tokenType = $tokens[$stackPtr]['type'];
+
+        // Detect incorrectly tokenized binary casts.
+        if (isset($this->newTypeCasts[$tokenType]) === false) {
+            $tokenContent = $tokens[$stackPtr]['content'];
+            switch ($tokenType) {
+                case 'T_STRING_CAST':
+                    if (preg_match('`^\(\s*binary\s*\)$`i', $tokenContent) !== 1) {
+                        return;
+                    }
+
+                    $tokenType = 'T_BINARY_CAST';
+                    break;
+                case 'T_CONSTANT_ENCAPSED_STRING':
+                    if (strpos($tokenContent, 'b"') === 0 && substr($tokenContent, -1) === '"') {
+                        $tokenType = 'T_BINARY_CAST';
+                    } else {
+                        return;
+                    }
+                    break;
+
+            }
+        }
+
+        // If the translation did not yield one of the tokens we are looking for, bow out.
+        if (isset($this->newTypeCasts[$tokenType]) === false) {
+            return;
+        }
+
+        $itemInfo = array(
+            'name'    => $tokenType,
+            'content' => $tokens[$stackPtr]['content'],
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+
+    }//end process()
+
+
+    /**
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @param array $itemInfo Base information about the item.
+     *
+     * @return array Version and other information about the item.
+     */
+    public function getItemArray(array $itemInfo)
+    {
+        return $this->newTypeCasts[$itemInfo['name']];
+    }
+
+
+    /**
+     * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * @return array
+     */
+    protected function getNonVersionArrayKeys()
+    {
+        return array('description');
+    }
+
+
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo)
+    {
+        $errorInfo = parent::getErrorInfo($itemArray, $itemInfo);
+        $errorInfo['description'] = $itemArray['description'];
+
+        return $errorInfo;
+    }
+
+
+    /**
+     * Filter the error message before it's passed to PHPCS.
+     *
+     * @param string $error     The error message which was created.
+     * @param array  $itemInfo  Base information about the item this error message applied to.
+     * @param array  $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return string
+     */
+    protected function filterErrorMsg($error, array $itemInfo, array $errorInfo)
+    {
+        return $error . '. Found: %s';
+    }
+
+
+    /**
+     * Filter the error data before it's passed to PHPCS.
+     *
+     * @param array $data      The error data array which was created.
+     * @param array $itemInfo  Base information about the item this error message applied to.
+     * @param array $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return array
+     */
+    protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
+    {
+        $data[0] = $errorInfo['description'];
+        $data[]  = $itemInfo['content'];
+        return $data;
+    }
+
+
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewTypeCastsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewTypeCastsSniffTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * New type casts sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New type casts sniff tests
+ *
+ * @group newTypeCasts
+ * @group typecasts
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\NewTypeCastsSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewTypeCastsSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_type_casts.php';
+
+    /**
+     * testNewTypeCasts
+     *
+     * @dataProvider dataNewFunction
+     *
+     * @param string $castDescription   The type of type cast.
+     * @param string $lastVersionBefore The PHP version just *before* the type cast was introduced.
+     * @param array  $lines             The line numbers in the test file which apply to this type cast.
+     * @param string $okVersion         A PHP version in which the type cast was valid.
+     * @param string $testVersion       Optional. A PHP version in which to test for the error if different
+     *                                  from the $lastVersionBefore.
+     *
+     * @return void
+     */
+    public function testNewTypeCasts($castDescription, $lastVersionBefore, $lines, $okVersion, $testVersion = null)
+    {
+        $errorVersion = (isset($testVersion)) ? $testVersion : $lastVersionBefore;
+        $file         = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error        = "{$castDescription} is not present in PHP version {$lastVersionBefore} or earlier";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNewFunction()
+     *
+     * @return array
+     */
+    public function dataNewFunction()
+    {
+        return array(
+            array('The unset cast', '4.4', array(8, 13, 15), '5.0'),
+            array('The binary cast', '5.2.0', array(9, 10, 14, 16), '5.3', '5.2'), // Test (global) namespaced function.
+        );
+    }
+
+
+    /**
+     * Test functions that shouldn't be flagged by this sniff.
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '4.4'); // Low version below the first addition.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(5),
+            array(19),
+            array(20),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '99.0'); // High version beyond newest addition.
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_type_casts.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_type_casts.php
@@ -1,0 +1,20 @@
+<?php
+
+// Pre-existing type casts.
+(string) 1234;
+(real) '1.5';
+
+// Newly introduced type casts.
+(unset) $a;
+(binary) 1234;
+$binary = b"binary string";
+
+// Verify space & case independency.
+(	unset	) $a;
+( binary ) 1234;
+( Unset ) $a;
+( BINARY ) 1234;
+
+// Just making sure / no false positives.
+$not_binary = b'124';
+$ordinary = 'b"something"';


### PR DESCRIPTION
Addresses sniffing for the `(unset)` and `(binary)` type casts as these were added after PHP 4.

This is a sister-PR to the new `DeprecatedTypeCasts` sniff which will detect `(unset)` being deprecated as of PHP 7.2 / PR #498.

Refs:
* http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting