### PR TITLE
:sparkles: New `DeprecatedTypeCasts` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedTypeCastsSniff.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedTypeCastsSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\AbstractRemovedFeatureSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\DeprecatedTypeCastsSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DeprecatedTypeCastsSniff extends AbstractRemovedFeatureSniff
+{
+    /**
+     * A list of deprecated and removed type casts with their alternatives.
+     *
+     * The array lists : version number with false (deprecated) or true (removed) and an alternative function.
+     * If no alternative exists, it is NULL, i.e, the function should just not be used.
+     *
+     * @var array(string => array(string => bool|string|null))
+     */
+    protected $deprecatedTypeCasts = array(
+        'T_UNSET_CAST' => array(
+            '7.2'         => false,
+            'alternative' => 'unset()',
+            'description' => 'unset',
+        ),
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $tokens = array();
+        foreach ($this->deprecatedTypeCasts as $token => $versions) {
+            $tokens[] = constant($token);
+        }
+
+        return $tokens;
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens    = $phpcsFile->getTokens();
+        $tokenType = $tokens[$stackPtr]['type'];
+
+        if (isset($this->deprecatedTypeCasts[$tokenType]) === false) {
+            return;
+        }
+
+        $itemInfo = array(
+            'name'        => $tokenType,
+            'description' => $this->deprecatedTypeCasts[$tokenType]['description'],
+        );
+        $this->handleFeature($phpcsFile, $stackPtr, $itemInfo);
+
+    }//end process()
+
+
+    /**
+     * Get an array of the non-PHP-version array keys used in a sub-array.
+     *
+     * @return array
+     */
+    protected function getNonVersionArrayKeys()
+    {
+        return array('description', 'alternative');
+    }
+
+    /**
+     * Get the relevant sub-array for a specific item from a multi-dimensional array.
+     *
+     * @param array $itemInfo Base information about the item.
+     *
+     * @return array Version and other information about the item.
+     */
+    public function getItemArray(array $itemInfo)
+    {
+        return $this->deprecatedTypeCasts[$itemInfo['name']];
+    }
+
+
+    /**
+     * Get the error message template for this sniff.
+     *
+     * @return string
+     */
+    protected function getErrorMsgTemplate()
+    {
+        return 'The %s cast is ';
+    }
+
+
+    /**
+     * Filter the error data before it's passed to PHPCS.
+     *
+     * @param array $data      The error data array which was created.
+     * @param array $itemInfo  Base information about the item this error message applied to.
+     * @param array $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return array
+     */
+    protected function filterErrorData(array $data, array $itemInfo, array $errorInfo)
+    {
+        $data[0] = $itemInfo['description'];
+        return $data;
+    }
+
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedTypeCastsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedTypeCastsSniffTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Deprecated type casts sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Deprecated type casts sniff tests
+ *
+ * @group deprecatedTypeCasts
+ * @group typecasts
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedTypeCastsSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DeprecatedTypeCastsSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/deprecated_type_casts.php';
+
+
+    /**
+     * testDeprecatedTypeCastWithAlternative
+     *
+     * @dataProvider dataDeprecatedTypeCastWithAlternative
+     *
+     * @param string $castDescription   The type of type cast.
+     * @param string $deprecatedIn      The PHP version in which the function was deprecated.
+     * @param string $alternative       An alternative function.
+     * @param array  $lines             The line numbers in the test file which apply to this function.
+     * @param string $okVersion         A PHP version in which the function was still valid.
+     * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
+     *                                  if different from the $deprecatedIn version.
+     *
+     * @return void
+     */
+    public function testDeprecatedTypeCastWithAlternative($castDescription, $deprecatedIn, $alternative, $lines, $okVersion, $deprecatedVersion = null)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($deprecatedVersion)) ? $deprecatedVersion : $deprecatedIn;
+        $file         = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error        = "{$castDescription} is deprecated since PHP {$deprecatedIn}; Use {$alternative} instead";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedTypeCastWithAlternative()
+     *
+     * @return array
+     */
+    public function dataDeprecatedTypeCastWithAlternative()
+    {
+        return array(
+            array('The unset cast', '7.2', 'unset()', array(8, 11, 12), '7.1'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '99.0'); // High version beyond latest deprecation.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+            array(5),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1'); // Low version below the first deprecation.
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_type_casts.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_type_casts.php
@@ -1,0 +1,12 @@
+<?php
+
+// Some other type casts.
+(string) 1234;
+(real) '1.5';
+
+// Deprecated introduced type casts.
+(unset) $a;
+
+// Verify space & case independency.
+(	unset	) $a;
+( Unset ) $a;


### PR DESCRIPTION
Addresses sniffing for the `(unset)` type cast which will be deprecated in PHP 7.2.

This is a sister-PR to the new `NewTypeCasts` sniff / PR #497.

Refs:
* http://php.net/manual/en/language.types.type-juggling.php#language.types.typecasting
* https://wiki.php.net/rfc/deprecations_php_7_2#unset_cast
* https://github.com/php/php-src/commit/7a73c5f6bba386e0d82dd467e9dacceb10b851e3