### PR TITLE
PHP 7.2: `object` can now be use as a typehint

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -56,6 +56,7 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         'string'   => '7.0',
         'iterable' => '7.1',
         'void'     => '7.1',
+        'object'   => '7.2',
     );
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
@@ -71,6 +71,11 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+
+        'object' => array(
+            '7.1' => false,
+            '7.2' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -58,6 +58,10 @@ class NewScalarTypeDeclarationsSniff extends AbstractNewFeatureSniff
             '7.0' => false,
             '7.1' => true,
         ),
+        'object' => array(
+            '7.1' => false,
+            '7.2' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsDeclaredSniffTest.php
@@ -112,9 +112,50 @@ class ForbiddenNamesAsDeclaredSniffTest extends BaseSniffTest
     {
         return array(
             array('resource', array(29, 43, 57, 71, 86, 101), '7.0', '5.6'),
-            array('object', array(30, 44, 58, 72, 87, 102), '7.0', '5.6'),
             array('mixed', array(31, 45, 59, 73, 88, 103), '7.0', '5.6'),
             array('numeric', array(32, 46, 60, 74, 89, 104), '7.0', '5.6'),
+        );
+    }
+
+
+    /**
+     * testSoftHardReservedKeyword
+     *
+     * @dataProvider dataSoftHardReservedKeyword
+     *
+     * @param string $keyword      Soft reserved keyword.
+     * @param array  $lines        The line numbers in the test file which apply to this keyword.
+     * @param string $introducedIn The PHP version in which the keyword became a reserved word.
+     * @param string $okVersion    A PHP version in which the keyword was not yet reserved.
+     * @param string $soft2Hard    The PHP version in which the keyword status changed from
+     *                             soft reserved to (hard) reserved.
+     *
+     * @return void
+     */
+    public function testSoftHardReservedKeyword($keyword, $lines, $introducedIn, $okVersion, $soft2Hard)
+    {
+        // Test Soft reserved message and Ok version.
+        $this->testSoftReservedKeyword($keyword, $lines, $introducedIn, $okVersion);
+
+        // Test hard reserved message.
+        $file  = $this->sniffFile(self::TEST_FILE, $soft2Hard);
+        $error = "'{$keyword}' is a soft reserved keyword as of PHP version {$introducedIn} and a reserved keyword as of PHP version {$soft2Hard} and should not be used to name a class, interface or trait or as part of a namespace";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testSoftHardReservedKeyword()
+     *
+     * @return array
+     */
+    public function dataSoftHardReservedKeyword()
+    {
+        return array(
+            array('object', array(30, 44, 58, 72, 87, 102), '7.0', '5.6', '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
@@ -71,6 +71,8 @@ class NewReturnTypeDeclarationsSniffTest extends BaseSniffTest
             array('void', '7.0', 17, '7.1'),
 
             array('callable', '5.6', 20, '7.0'),
+
+            array('object', '7.1', 27, '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -68,6 +68,7 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
             array('int', '5.6', 53, '7.0'),
             array('callable', '5.3', 56, '5.4'),
             array('int', '5.6', 57, '7.0'),
+            array('object', '7.1', 60, '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
@@ -22,3 +22,6 @@ function($a): callable {}
 // OK: no return type hint.
 function foo($a) {}
 function ($a) {}
+
+// PHP 7.2+
+function foo($a): object {}

--- a/PHPCompatibility/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -55,3 +55,6 @@ function(int $a) {}
 // Deal with nullable type hints.
 function foo(?callable $a) {}
 function foo(?int $a) {}
+
+// Object type declaration - PHP 7.2+
+function foo(object $a) {}


### PR DESCRIPTION
`object` was already a soft reserved keyword as of PHP 7.0.

As of PHP 7.2, it:
* can be used as a parameter type hint
* can be used as a return type hint
* has become a "hard" reserved keyword.

References:
* https://wiki.php.net/rfc/object-typehint
* https://github.com/php/php-src/pull/2080