### PR TITLE
PHP 7.2: deprecated/removed ini directives

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -205,6 +205,9 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'mbstring.func_overload' => array(
             '7.2' => false,
         ),
+        'track_errors' => array(
+            '7.2' => false,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -205,6 +205,9 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'mbstring.func_overload' => array(
             '7.2' => false,
         ),
+        'sql.safe_mode' => array(
+            '7.2' => true,
+        ),
         'track_errors' => array(
             '7.2' => false,
         ),

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -149,6 +149,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('mcrypt.modes_dir', '7.1', array(138, 139), '7.0'),
 
             array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
+            array('track_errors', '7.2', array(169, 170), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -149,7 +149,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('mcrypt.modes_dir', '7.1', array(138, 139), '7.0'),
 
             array('mbstring.func_overload', '7.2', array(166, 167), '7.1'),
-            array('track_errors', '7.2', array(169, 170), '7.1'),
+            array('track_errors', '7.2', array(172, 173), '7.1'),
         );
     }
 
@@ -259,6 +259,8 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('session.entropy_length', '7.1', array(144, 145), '7.0'),
             array('session.hash_function', '7.1', array(147, 148), '7.0'),
             array('session.hash_bits_per_character', '7.1', array(150, 151), '7.0'),
+
+            array('sql.safe_mode', '7.2', array(169, 170), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
@@ -165,3 +165,6 @@ ini_set();
 
 ini_set('mbstring.func_overload', 2);
 $a = ini_get('mbstring.func_overload');
+
+ini_set('track_errors', true);
+$a = ini_get('track_errors');

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
@@ -166,5 +166,8 @@ ini_set();
 ini_set('mbstring.func_overload', 2);
 $a = ini_get('mbstring.func_overload');
 
+ini_set('sql.safe_mode', true);
+$a = ini_get('sql.safe_mode');
+
 ini_set('track_errors', true);
 $a = ini_get('track_errors');


### PR DESCRIPTION
PHP 7.2: `track_errors` ini directive is now deprecated

Slated to be removed in PHP 8.0.

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2?s[]=track_errors#php_errormsg
* php/php-src@c61daf4
* php/php-src@47a1ab3

----
PHP 7.2: `sql.safe_mode` ini directive has been removed

Refs:
* https://github.com/php/php-src/blob/PHP-7.2/UPGRADING#L333
* php/php-src@197051f
