### PR TITLE
PHP 7.2: deprecated functions

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -773,6 +773,10 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.2' => false,
             'alternative' => 'a foreach loop',
         ),
+        'gmp_random' => array(
+            '7.2' => false,
+            'alternative' => 'gmp_random_bits() or gmp_random_range()',
+        ),
     );
 
 

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -765,6 +765,10 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.2' => false,
             'alternative' => 'imagecreatefrompng() or imagewbmp()',
         ),
+        'create_function' => array(
+            '7.2' => false,
+            'alternative' => 'an anonymous function',
+        ),
     );
 
 

--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -769,6 +769,10 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.2' => false,
             'alternative' => 'an anonymous function',
         ),
+        'each' => array(
+            '7.2' => false,
+            'alternative' => 'a foreach loop',
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -199,6 +199,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
             array('each', '7.2', 'a foreach loop', array(147), '7.1'),
+            array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -198,6 +198,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
             array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
+            array('each', '7.2', 'a foreach loop', array(147), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -197,6 +197,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
 
             array('jpeg2wbmp', '7.2', 'imagecreatefromjpeg() and imagewbmp()', array(144), '7.1'),
             array('png2wbmp', '7.2', 'imagecreatefrompng() or imagewbmp()', array(145), '7.1'),
+            array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -145,3 +145,4 @@ jpeg2wbmp();
 png2wbmp();
 create_function();
 while (list($key, $val) = each($array)) {}
+gmp_random(2);

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -144,3 +144,4 @@ abstract class Split {}
 jpeg2wbmp();
 png2wbmp();
 create_function();
+while (list($key, $val) = each($array)) {}

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -143,3 +143,4 @@ abstract class Split {}
 // More deprecated functions, PHP 7.2
 jpeg2wbmp();
 png2wbmp();
+create_function();


### PR DESCRIPTION
PHP 7.2: `create_function()` is now a deprecated function

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2#create_function
* https://github.com/php/php-src/commit/eaeecc523b665cfa856a376b9c55ca7fc9b7b596

----

PHP 7.2: `each()` is now a deprecated function

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2#each
* https://github.com/php/php-src/commit/06a034016280435feb80eea4d674ca5688ab4c06

----

PHP 7.2: `gmp_random()` is now a deprecated function

Refs:
* https://wiki.php.net/rfc/deprecations_php_7_2#gmp_random
* https://github.com/php/php-src/commit/fbeb900be4948d9a1bdc3e139937777534cc27e4