### PR TITLE
Hotfix: temporary plaster to fix upstream issue

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -38,19 +38,20 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
     }
 
     define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);
-}
 
-
-/*
- * Register an autoloader.
- *
- * {@internal This autoloader is not needed for running the sniffs, however, it *is*
- * needed for running the unit tests as the PHPCS native autoloader runs into trouble there.
- * This issue will be fixed in PHPCS 3.1, so the below code can be removed once the
- * minimum PHPCS 3.x requirement for PHPCompatibility has gone up to 3.1.
- * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564} }}
- */
-if (defined('PHP_CODESNIFFER_IN_TESTS')) {
+    /*
+     * Register an autoloader.
+     *
+     * {@internal This autoloader is not needed for running the sniffs, however, it *is*
+     * needed for running the unit tests as the PHPCS native autoloader runs into trouble there.
+     * This issue will be fixed in PHPCS 3.1, so the below code can be removed once the
+     * minimum PHPCS 3.x requirement for PHPCompatibility has gone up to 3.1.
+     * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1564} }}
+     *
+     * {@internal Update: when `installed_paths` is set via the ruleset, this autoloader
+     * **is** needed to run the sniffs.
+     * Upstream issue: {@link https://github.com/squizlabs/PHP_CodeSniffer/issues/1591} }}
+     */
     spl_autoload_register(function ($class) {
         // Only try & load our own classes.
         if (stripos($class, 'PHPCompatibility') !== 0) {


### PR DESCRIPTION
When the `installed_paths` variable is set via the ruleset and not using `--config-set` on the command line, PHPCS has trouble loading arbitrary files for external rulesets, like the main `Sniff` class.

Discovered in the WordPress Coding Standards, but the same issue applies to PHPCompatibility as well.
See: WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1087

The underlying issue has been reported upstream https://github.com/squizlabs/PHP_CodeSniffer/issues/1591 and should be fixed there.

In the mean time, this will fix it for the time being.

I believe that this fix warrants a release of 8.0.1 soon after.