### PR TITLE
PHP 7.2 / NewGroupUseDeclarations: add sniffing for trailing comma's

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewGroupUseDeclarationsSniff.php
@@ -50,7 +50,7 @@ class NewGroupUseDeclarationsSniff extends Sniff
      */
     public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsBelow('5.6') === false) {
+        if ($this->supportsBelow('7.1') === false) {
             return;
         }
 
@@ -68,14 +68,37 @@ class NewGroupUseDeclarationsSniff extends Sniff
             if ($prevToken === false || $tokens[$prevToken]['code'] !== T_NS_SEPARATOR) {
                 return;
             }
+
+            $stackPtr = $hasCurlyBrace;
         }
 
         // Still here ? In that case, it is a group use statement.
-        $phpcsFile->addError(
-            'Group use declarations are not allowed in PHP 5.6 or earlier',
-            $stackPtr,
-            'Found'
-        );
+        if ($this->supportsBelow('5.6') === true) {
+            $phpcsFile->addError(
+                'Group use declarations are not allowed in PHP 5.6 or earlier',
+                $stackPtr,
+                'Found'
+            );
+        }
 
+        $closers = array(T_CLOSE_CURLY_BRACKET);
+        if (defined('T_CLOSE_USE_GROUP')) {
+            $closers[] = T_CLOSE_USE_GROUP;
+        }
+
+        $closeCurly = $phpcsFile->findNext($closers, ($stackPtr + 1), null, false, null, true);
+        if ($closeCurly === false) {
+            return;
+        }
+
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($closeCurly - 1), null, true);
+        if ($tokens[$prevToken]['code'] === T_COMMA) {
+            $phpcsFile->addError(
+                'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier',
+                $prevToken,
+                'TrailingCommaFound'
+            );
+        }
     }//end process()
+
 }//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewGroupUseDeclarationsSniffTest.php
@@ -54,6 +54,77 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
             array(23),
             array(24),
             array(25),
+            array(26),
+            array(33),
+            array(34),
+            array(35),
+            array(36),
+        );
+    }
+
+
+    /**
+     * testGroupUseTrailingComma
+     *
+     * @dataProvider dataGroupUseTrailingComma
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testGroupUseTrailingComma($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertError($file, $line, 'Trailing comma\'s are not allowed in group use statements in PHP 7.1 or earlier');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testGroupUseTrailingComma()
+     *
+     * @return array
+     */
+    public function dataGroupUseTrailingComma()
+    {
+        return array(
+            array(33),
+            array(34),
+            array(35),
+            array(39),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesTrailingComma
+     *
+     * @dataProvider dataNoFalsePositivesTrailingComma
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesTrailingComma($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesTrailingComma()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesTrailingComma()
+    {
+        return array(
+            array(23),
+            array(24),
+            array(25),
+            array(29),
         );
     }
 
@@ -104,7 +175,7 @@ class NewGroupUseDeclarationsSniffTest extends BaseSniffTest
      */
     public function testNoViolationsInFileOnValidVersion()
     {
-        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
         $this->assertNoViolation($file);
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_group_use_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_group_use_declarations.php
@@ -23,3 +23,18 @@ use HelloWorld { sayHello as private myPrivateHello; }
 use some\namespace\{ClassA, ClassB, ClassC as C};
 use function some\namespace\{fn_a, fn_b, fn_c};
 use const some\namespace\{ConstA, ConstB, ConstC};
+use Foo\Bar\{
+    Foo,
+    Bar,
+    Baz as C
+};
+
+// PHP 7.2+ code.
+use some\namespace\{ ClassA, ClassB, ClassC as C, };
+use function some\namespace\{ fn_a, fn_b, fn_c, };
+use const some\namespace\{ConstA, ConstB, ConstC,};
+use Foo\Bar\{
+    Foo,
+    Bar,
+    Baz as C,
+};


### PR DESCRIPTION
Refs:
* https://github.com/php/php-src/blob/PHP-7.2/UPGRADING#L110
* https://wiki.php.net/rfc/list-syntax-trailing-commas - out of this RFC only the group use trailing comma's has been implemented.
* https://github.com/php/php-src/commit/12300f465e5bed1fa7d0bc445aef68b6a2753c3b