### PR TITLE
NewReturnTypeDeclarations: add two missing valid types

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1057,10 +1057,11 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             return false;
         }
 
-        // `self` and `callable` are not being recognized as return types in PHPCS < 2.6.0.
+        // `self`, `parent` and `callable` are not being recognized as return types in PHPCS < 2.6.0.
         $unrecognizedTypes = array(
             T_CALLABLE,
             T_SELF,
+            T_PARENT,
         );
 
         // Return types are not recognized at all in PHPCS < 2.4.0.

--- a/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
@@ -58,6 +58,10 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             '5.6' => false,
             '7.0' => true,
         ),
+        'parent' => array(
+            '5.6' => false,
+            '7.0' => true,
+        ),
         'self' => array(
             '5.6' => false,
             '7.0' => true,
@@ -67,6 +71,10 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
             '7.0' => true,
         ),
 
+        'iterable' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
         'void' => array(
             '7.0' => false,
             '7.1' => true,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
@@ -63,16 +63,18 @@ class NewReturnTypeDeclarationsSniffTest extends BaseSniffTest
             array('array', '5.6', 8, '7.0'),
             array('callable', '5.6', 9, '7.0'),
             array('self', '5.6', 10, '7.0'),
-            array('Class name', '5.6', 11, '7.0'),
+            array('parent', '5.6', 11, '7.0'),
             array('Class name', '5.6', 12, '7.0'),
             array('Class name', '5.6', 13, '7.0'),
             array('Class name', '5.6', 14, '7.0'),
+            array('Class name', '5.6', 15, '7.0'),
 
-            array('void', '7.0', 17, '7.1'),
+            array('iterable', '7.0', 18, '7.1'),
+            array('void', '7.0', 19, '7.1'),
 
-            array('callable', '5.6', 20, '7.0'),
+            array('callable', '5.6', 22, '7.0'),
 
-            array('object', '7.1', 27, '7.2'),
+            array('object', '7.1', 29, '7.2'),
         );
     }
 
@@ -102,8 +104,8 @@ class NewReturnTypeDeclarationsSniffTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return array(
-            array(23),
-            array(24),
+            array(25),
+            array(26),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
@@ -8,12 +8,14 @@ function foo($a): string {}
 function foo($a): array {}
 function foo($a): callable {}
 function foo($a): self {}
+function foo($a): parent {}
 function foo($a): Baz {}
 function foo($a): \Baz {}
 function foo($a): myNamespace\Baz {}
 function foo($a): \myNamespace\Baz {}
 
 // PHP 7.1+
+function foo($a): iterable {}
 function foo($a): void {}
 
 // Anonymous function.


### PR DESCRIPTION
* `parent` while undocumented in http://php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.types, is actually accepted as a valid return type declaration - see: https://3v4l.org/lOpPS
* `iterable` was added in PHP 7.1.
    Refs:
    - http://php.net/manual/en/language.types.iterable.php
    - https://wiki.php.net/rfc/iterable

Includes unit tests.