### PR TITLE
Sync `FindExtendedClassname()` method with upstream

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -776,7 +776,10 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             return '';
         }
 
-        if ($tokens[$stackPtr]['code'] !== T_CLASS && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS') {
+        if ($tokens[$stackPtr]['code'] !== T_CLASS
+            && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
+            && $tokens[$stackPtr]['type'] !== 'T_INTERFACE'
+        ) {
             return '';
         }
 
@@ -1443,7 +1446,8 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
 
     /**
-     * Returns the name of the class that the specified class extends.
+     * Returns the name of the class that the specified class extends
+     * (works for classes, anonymous classes and interfaces).
      *
      * Returns FALSE on error or if there is no extended class name.
      *
@@ -1456,17 +1460,16 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
      * that, this method can be removed and calls to it replaced with
      * `$phpcsFile->findExtendedClassName($stackPtr)` calls.
      *
-     * Last synced with PHPCS version: PHPCS 2.9.0 at commit b940fb7dca8c2a37f0514161b495363e5b36d879}}
+     * Last synced with PHPCS version: PHPCS 3.1.0-alpha at commit a9efcc9b0703f3f9f4a900623d4e97128a6aafc6}}
      *
      * @param \PHP_CodeSniffer_File $phpcsFile Instance of phpcsFile.
-     * @param int                   $stackPtr  The position in the stack of the
-     *                                         class token.
+     * @param int                   $stackPtr  The position of the class token in the stack.
      *
      * @return string|false
      */
     public function findExtendedClassName(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if (version_compare(PHPCSHelper::getVersion(), '2.7.1', '>') === true) {
+        if (version_compare(PHPCSHelper::getVersion(), '3.1.0', '>=') === true) {
             return $phpcsFile->findExtendedClassName($stackPtr);
         }
 
@@ -1478,7 +1481,8 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         }
 
         if ($tokens[$stackPtr]['code'] !== T_CLASS
-            && $tokens[$stackPtr]['code'] !== T_ANON_CLASS
+            && $tokens[$stackPtr]['type'] !== 'T_ANON_CLASS'
+            && $tokens[$stackPtr]['type'] !== 'T_INTERFACE'
         ) {
             return false;
         }

--- a/PHPCompatibility/Tests/BaseClass/GetFQExtendedClassNameTest.php
+++ b/PHPCompatibility/Tests/BaseClass/GetFQExtendedClassNameTest.php
@@ -42,7 +42,7 @@ class GetFQExtendedClassNameTest extends MethodTestFrame
      */
     public function testGetFQExtendedClassName($commentString, $expected)
     {
-        $stackPtr = $this->getTargetToken($commentString, T_CLASS);
+        $stackPtr = $this->getTargetToken($commentString, array(T_CLASS, T_INTERFACE));
         $result   = $this->helperClass->getFQExtendedClassName($this->phpcsFile, $stackPtr);
         $this->assertSame($expected, $result);
     }
@@ -72,6 +72,8 @@ class GetFQExtendedClassNameTest extends MethodTestFrame
             array('/* Case 13 */', '\Yet\More\Testing\DateTime'),
             array('/* Case 14 */', '\Yet\More\Testing\anotherNS\DateTime'),
             array('/* Case 15 */', '\FQNS\DateTime'),
+            array('/* Case 16 */', '\SomeInterface'),
+            array('/* Case 17 */', '\Yet\More\Testing\SomeInterface'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/get_fqextended_classname.php
@@ -44,3 +44,8 @@ class MyTestN extends DateTime {}
 class MyTestO extends anotherNS\DateTime {}
 /* Case 15 */
 class MyTestP extends \FQNS\DateTime {}
+
+/* Case 16 */
+interface MyInterface extends \SomeInterface {}
+/* Case 17 */
+interface MyInterface extends SomeInterface {}


### PR DESCRIPTION
Synced in the changes as were just merged from squizlabs/PHP_CodeSniffer/pull/1473

This allows the method to also detect the "Extended Classname" for interfaces extending other interfaces.

Adjusted the related `getFQExtendedClassName()` method accordingly and added unit tests for this change.

The change to the `FindExtendedClassname()` method is tested upstream.