### PR TITLE
Travis: run the build tests against PHP 7.2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.2
   - nightly
 
 env:
@@ -54,10 +55,8 @@ matrix:
 
     # PHP 5.4 with low PHPCS needs "precise" + one build with Coveralls.
     - php: 5.4
-      dist: precise
       env: PHPCS_VERSION=">=1.5.1,<2.0"
     - php: 5.4
-      dist: precise
       env: PHPCS_VERSION="2.2.*"
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
@@ -71,6 +70,8 @@ matrix:
       env: PHPCS_VERSION="2.6.*"
     - php: 7.1
       env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="dev-master"
+    - php: 7.2
+      env: PHPCS_VERSION="2.7.*"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ php:
 env:
   global:
     - COVERALLS_VERSION="notset"
+    - PHPUNIT_VERSION="travis"
   matrix:
     # `master`, i.e PHPCS 3.x.
     - PHPCS_VERSION="dev-master" LINT=1
@@ -48,16 +49,16 @@ matrix:
     # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
       dist: precise
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0" PHPUNIT_VERSION="~4.5"
     - php: 5.3
       dist: precise
-      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="~1.0" PHPUNIT_VERSION="~4.5"
 
     # PHP 5.4 with low PHPCS needs "precise" + one build with Coveralls.
     - php: 5.4
-      env: PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" PHPUNIT_VERSION="~4.5"
     - php: 5.4
-      env: PHPCS_VERSION="2.2.*"
+      env: PHPCS_VERSION="2.2.*" PHPUNIT_VERSION="~4.5"
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
 
@@ -77,10 +78,10 @@ matrix:
 
     - php: hhvm
       dist: trusty
-      env: PHPCS_VERSION=">=1.5.1,<2.0"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" PHPUNIT_VERSION="5.7.17"
     - php: hhvm
       dist: trusty
-      env: PHPCS_VERSION="dev-master" LINT=1
+      env: PHPCS_VERSION="dev-master" LINT=1 PHPUNIT_VERSION="5.7.17"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -93,7 +94,7 @@ before_install:
   - composer self-update
   - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then composer require phpunit/phpunit:5.7.17; fi
+  - if [[ $PHPUNIT_VERSION != "travis" ]]; then composer require phpunit/phpunit:${PHPUNIT_VERSION}; fi
   # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.
   # --prefer-dist will allow for optimal use of the travis caching ability.
   - composer install --no-dev --prefer-dist
@@ -106,9 +107,10 @@ script:
   # Lint all PHP files against parse errors.
   - if [[ "$LINT" == "1" ]]; then find -L . -path ./PHPCompatibility/Tests/sniff-examples -prune -o -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
   # Run the unit tests.
-  - if [[ $COVERALLS_VERSION != "notset" ]]; then phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhv* && $COVERALLS_VERSION == "notset" ]]; then phpunit; fi
-  - if [[ $TRAVIS_PHP_VERSION == hhv* ]]; then vendor/bin/phpunit; fi
+  - if [[ $PHPUNIT_VERSION == "travis" && $COVERALLS_VERSION != "notset" ]]; then phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
+  - if [[ $PHPUNIT_VERSION != "travis" && $COVERALLS_VERSION != "notset" ]]; then vendor/bin/phpunit --configuration phpunit-travis.xml --coverage-clover build/logs/clover.xml; fi
+  - if [[ $PHPUNIT_VERSION == "travis" && $COVERALLS_VERSION == "notset" ]]; then phpunit; fi
+  - if [[ $PHPUNIT_VERSION != "travis" && $COVERALLS_VERSION == "notset" ]]; then vendor/bin/phpunit; fi
   # Check the code style of the code base.
   - if [[ "$SNIFF" == "1" ]]; then vendor/bin/phpcs . --runtime-set ignore_warnings_on_exit 1; fi
   # Validate the xml file.


### PR DESCRIPTION
The new Trusty images as per Sept 7 include an image for PHP 7.2 (even though it hasn't been released yet) and nightly is now PHP 7.3-dev.