### PR TITLE
ForbiddenNamesAsInvokedFunctions: don't throw error on method invocations / PHP 7.0+

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniffTest.php
@@ -31,23 +31,35 @@ class ForbiddenNamesAsInvokedFunctionsSniffTest extends BaseSniffTest
      *
      * @dataProvider dataReservedKeyword
      *
-     * @param string $keyword      Reserved keyword.
-     * @param array  $lines        The line numbers in the test file which apply to this keyword.
-     * @param string $introducedIn The PHP version in which the keyword became a reserved word.
-     * @param string $okVersion    A PHP version in which the keyword was not yet reserved.
+     * @param string $keyword        Reserved keyword.
+     * @param array  $lines_function The line numbers in the test file which apply to this keyword as a function call.
+     * @param array  $lines_method   The line numbers in the test file which apply to this keyword as a method call.
+     * @param string $introducedIn   The PHP version in which the keyword became a reserved word.
+     * @param string $okVersion      A PHP version in which the keyword was not yet reserved.
      *
      * @return void
      */
-    public function testReservedKeyword($keyword, $lines, $introducedIn, $okVersion)
+    public function testReservedKeyword($keyword, $lines_function, $lines_method, $introducedIn, $okVersion)
     {
         $file  = $this->sniffFile(self::TEST_FILE, $introducedIn);
         $error = "'{$keyword}' is a reserved keyword introduced in PHP version {$introducedIn} and cannot be invoked as a function";
+        $lines = array_merge($lines_function, $lines_method);
         foreach ($lines as $line) {
             $this->assertError($file, $line, $error);
         }
 
         $file = $this->sniffFile(self::TEST_FILE, $okVersion);
         foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        if (empty($lines_method) === true) {
+            return;
+        }
+
+        // Test that method calls do not throw an error for PHP 7.0+.
+        $file = $this->sniffFile(self::TEST_FILE, '7.0-');
+        foreach ($lines_method as $line) {
             $this->assertNoViolation($file, $line);
         }
     }
@@ -62,22 +74,22 @@ class ForbiddenNamesAsInvokedFunctionsSniffTest extends BaseSniffTest
     public function dataReservedKeyword()
     {
         return array(
-            array('abstract', array(6), '5.0', '4.4'),
-            array('callable', array(7), '5.4', '5.3'),
-            array('catch', array(8), '5.0', '4.4'),
-            array('final', array(10), '5.0', '4.4'),
-            array('finally', array(11), '5.5', '5.4'),
-            array('goto', array(12), '5.3', '5.2'),
-            array('implements', array(13), '5.0', '4.4'),
-            array('interface', array(14), '5.0', '4.4'),
-            array('instanceof', array(15), '5.0', '4.4'),
-            array('insteadof', array(16), '5.4', '5.3'),
-            array('namespace', array(17), '5.3', '5.2'),
-            array('private', array(18), '5.0', '4.4'),
-            array('protected', array(19), '5.0', '4.4'),
-            array('public', array(20), '5.0', '4.4'),
-            array('trait', array(22), '5.4', '5.3'),
-            array('try', array(23), '5.0', '4.4'),
+            array('abstract', array(6), array(53), '5.0', '4.4'),
+            array('callable', array(7), array(54), '5.4', '5.3'),
+            array('catch', array(8), array(55), '5.0', '4.4'),
+            array('final', array(10), array(56), '5.0', '4.4'),
+            array('finally', array(11), array(57), '5.5', '5.4'),
+            array('goto', array(12), array(58), '5.3', '5.2'),
+            array('implements', array(13), array(59), '5.0', '4.4'),
+            array('interface', array(14), array(60), '5.0', '4.4'),
+            array('instanceof', array(15), array(61), '5.0', '4.4'),
+            array('insteadof', array(16), array(62), '5.4', '5.3'),
+            array('namespace', array(17), array(63), '5.3', '5.2'),
+            array('private', array(18), array(64), '5.0', '4.4'),
+            array('protected', array(19), array(65), '5.0', '4.4'),
+            array('public', array(20), array(66), '5.0', '4.4'),
+            array('trait', array(22), array(67), '5.4', '5.3'),
+            array('try', array(23), array(68), '5.0', '4.4'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/forbidden_names_function_invocation.php
+++ b/PHPCompatibility/Tests/sniff-examples/forbidden_names_function_invocation.php
@@ -45,3 +45,24 @@ resource();
 object();
 mixed();
 numeric();
+
+/*
+ * As of PHP 7.0, they can be used as method names.
+ * Only testing the back-compat ones with T_STRING as they are the only ones which could give a false positive.
+ */
+$myObject->abstract();
+MyClassName::callable();
+$myObject->catch();
+MyClassName::final();
+$myObject->finally();
+MyClassName::goto();
+$myObject->implements();
+MyClassName::interface();
+$myObject->instanceof();
+MyClassName::insteadof();
+$myObject->namespace();
+MyClassName::private();
+$myObject->protected();
+MyClassName::public();
+$myObject->trait();
+MyClassName::try();


### PR DESCRIPTION
How the PHP and PHPCS tokenizers tokenize the function name in a method call varies wildly across versions, sometimes its tokenized as its own token, often times its tokenized as `T_STRING`.
In practice this meant that method invocations pre-PHP 7.0 were not always caught by this sniff, while they should be.
At the same time, for PHP 7.0+, those should be exempt for the purposes of this sniff as the keyword reservation has been relaxed to allow these keywords to be used as method names.

Both these issues are fixed by this PR.

Fixes #515