### PR TITLE
NewLanguageConstructs: Update the version number for T_COALESCE_EQUAL

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewLanguageConstructsSniff.php
@@ -62,9 +62,13 @@ class NewLanguageConstructsSniff extends AbstractNewFeatureSniff
             '7.0' => true,
             'description' => 'null coalescing operator (??)',
         ), // Identified in PHPCS 1.5 as T_INLINE_THEN + T_INLINE_THEN.
+        /*
+         * Was slated for 7.2, but still not implemented. PHPCS however does already tokenize it.
+         * @link https://wiki.php.net/rfc/null_coalesce_equal_operator
+         */
         'T_COALESCE_EQUAL' => array(
-            '7.1' => false,
-            '7.2' => true,
+            '7.2' => false,
+            '7.3' => true,
             'description' => 'null coalesce equal operator (??=)',
         ), // Identified in PHPCS 1.5 as T_INLINE_THEN + T_INLINE_THEN + T_EQUAL and pre-PHPCS 2.8.1 as T_COALESCE + T_EQUAL.
     );

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewLanguageConstructsSniffTest.php
@@ -101,10 +101,10 @@ class NewLanguageConstructsSniffTest extends BaseSniffTest
      */
     public function testCoalesceEquals()
     {
-        $file = $this->sniffFile(self::TEST_FILE, '7.1');
-        $this->assertError($file, 10, 'null coalesce equal operator (??=) is not present in PHP version 7.1 or earlier');
-
         $file = $this->sniffFile(self::TEST_FILE, '7.2');
+        $this->assertError($file, 10, 'null coalesce equal operator (??=) is not present in PHP version 7.2 or earlier');
+
+        $file = $this->sniffFile(self::TEST_FILE, '7.3');
         $this->assertNoViolation($file, 10);
     }
 


### PR DESCRIPTION
While this language construct is already tokenized correctly in PHPCS, PHP itself has not yet implemented it.

The RFC has been approved a while back and it was slated to go into PHP 7.2, but as of PHP 7.2 RC4 no implementation has been merged and it is not expected to go into PHP 7.2 anymore.

As PHPCS already recognized the token, it was already added to the `NewLanguageConstructs` sniff a while back.

All this PR does is up the PHP version number used for the compares.