### PR TITLE
PHP 7.2: New OptionalRequiredFunctionParameters sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/OptionalRequiredFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/OptionalRequiredFunctionParametersSniff.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\OptionalRequiredFunctionParametersSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniffs\PHP\RequiredOptionalFunctionParametersSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\OptionalRequiredFunctionParametersSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class OptionalRequiredFunctionParametersSniff extends RequiredOptionalFunctionParametersSniff
+{
+
+    /**
+     * A list of function parameters, which were optional in older versions and became required later on.
+     *
+     * The array lists : version number with true (required) and false (optional use deprecated).
+     *
+     * The index is the location of the parameter in the parameter list, starting at 0 !
+     * If's sufficient to list the last version in which the parameter was not yet required.
+     *
+     * @var array
+     */
+    protected $functionParameters = array(
+        'parse_str' => array(
+            1 => array(
+                'name' => 'result',
+                '7.2'  => false,
+            ),
+        ),
+    );
+
+
+    /**
+     * Determine whether an error/warning should be thrown for an item based on collected information.
+     *
+     * @param array $errorInfo Detail information about an item.
+     *
+     * @return bool
+     */
+    protected function shouldThrowError(array $errorInfo)
+    {
+        return ($errorInfo['optionalDeprecated'] !== '' || $errorInfo['optionalRemoved'] !== '');
+    }
+
+
+    /**
+     * Retrieve the relevant detail (version) information for use in an error message.
+     *
+     * @param array $itemArray Version and other information about the item.
+     * @param array $itemInfo  Base information about the item.
+     *
+     * @return array
+     */
+    public function getErrorInfo(array $itemArray, array $itemInfo)
+    {
+        $errorInfo = array(
+            'paramName'          => '',
+            'optionalDeprecated' => '',
+            'optionalRemoved'    => '',
+            'error'              => false,
+        );
+
+        $versionArray = $this->getVersionArray($itemArray);
+
+        if (empty($versionArray) === false) {
+            foreach ($versionArray as $version => $required) {
+                if ($this->supportsAbove($version) === true) {
+                    if ($required === true && $errorInfo['optionalRemoved'] === '') {
+                        $errorInfo['optionalRemoved'] = $version;
+                        $errorInfo['error']           = true;
+                    } elseif ($errorInfo['optionalDeprecated'] === '') {
+                        $errorInfo['optionalDeprecated'] = $version;
+                    }
+                }
+            }
+        }
+
+        $errorInfo['paramName'] = $itemArray['name'];
+
+        return $errorInfo;
+
+    }//end getErrorInfo()
+
+
+    /**
+     * Get the error message template for this sniff.
+     *
+     * @return string
+     */
+    protected function getErrorMsgTemplate()
+    {
+        return 'The "%s" parameter for function %s() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is ';
+    }
+
+
+    /**
+     * Generates the error or warning for this item.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the relevant token in
+     *                                         the stack.
+     * @param array                 $itemInfo  Base information about the item.
+     * @param array                 $errorInfo Array with detail (version) information
+     *                                         relevant to the item.
+     *
+     * @return void
+     */
+    public function addError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $itemInfo, array $errorInfo)
+    {
+        $error     = $this->getErrorMsgTemplate();
+        $errorCode = $this->stringToErrorCode($itemInfo['name'].'_'.$errorInfo['paramName']);
+        $data      = array(
+            $errorInfo['paramName'],
+            $itemInfo['name'],
+        );
+
+        if ($errorInfo['optionalDeprecated'] !== '') {
+            $error     .= 'deprecated since PHP %s and ';
+            $errorCode .= 'Soft';
+            $data[]     = $errorInfo['optionalDeprecated'];
+        }
+
+        if ($errorInfo['optionalRemoved'] !== '') {
+            $error     .= 'removed since PHP %s and ';
+            $errorCode .= 'Hard';
+            $data[]     = $errorInfo['optionalRemoved'];
+        }
+
+        // Remove the last 'and' from the message.
+        $error      = substr($error, 0, (strlen($error) - 5));
+        $errorCode .= 'Required';
+
+        $this->addMessage($phpcsFile, $error, $stackPtr, $errorInfo['error'], $errorCode, $data);
+
+    }//end addError()
+
+
+}//end class

--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -172,9 +172,11 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
 
         $versionArray = $this->getVersionArray($itemArray);
 
-        foreach ($versionArray as $version => $required) {
-            if ($version !== 'name' && $required === true && $this->supportsBelow($version) === true) {
-                $errorInfo['requiredVersion'] = $version;
+        if (empty($versionArray) === false) {
+            foreach ($versionArray as $version => $required) {
+                if ($required === true && $this->supportsBelow($version) === true) {
+                    $errorInfo['requiredVersion'] = $version;
+                }
             }
         }
 
@@ -192,7 +194,7 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
      */
     protected function getErrorMsgTemplate()
     {
-        return 'The "%s" parameter for function %s is missing, but was required for PHP version %s and lower';
+        return 'The "%s" parameter for function %s() is missing, but was required for PHP version %s and lower';
     }
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/OptionalRequiredFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/OptionalRequiredFunctionParametersSniffTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Optional Required Functions Parameter Sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Optional Required Parameter Sniff test file
+ *
+ * @group optionalRequiredFunctionParameters
+ * @group functionParameters
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\OptionalRequiredFunctionParametersSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class OptionalRequiredFunctionParametersSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/optional_required_function_parameters.php';
+
+    /**
+     * testOptionalRequiredParameterDeprecated
+     *
+     * @dataProvider dataOptionalRequiredParameterDeprecated
+     *
+     * @param string $functionName     Function name.
+     * @param string $parameterName    Parameter name.
+     * @param string $softRequiredFrom The last PHP version in which the parameter was still optional.
+     * @param array  $lines            The line numbers in the test file which apply to this class.
+     * @param string $okVersion        A PHP version in which to test for no violation.
+     *
+     * @return void
+     */
+    public function testOptionalRequiredParameterDeprecated($functionName, $parameterName, $softRequiredFrom, $lines, $okVersion)
+    {
+        $file  = $this->sniffFile(self::TEST_FILE, $softRequiredFrom);
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing. Passing this parameter is no longer optional. The optional nature of the parameter is deprecated since PHP {$softRequiredFrom}";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testOptionalRequiredParameterDeprecated()
+     *
+     * @return array
+     */
+    public function dataOptionalRequiredParameterDeprecated()
+    {
+        return array(
+            array('parse_str', 'result', '7.2', array(7), '7.1'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '99.0'); // High version beyond latest required/optional change.
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(4),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1'); // Version before earliest required/optional change.
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
@@ -42,7 +42,7 @@ class RequiredOptionalFunctionParametersSniffTest extends BaseSniffTest
     public function testRequiredOptionalParameter($functionName, $parameterName, $requiredUpTo, $lines, $okVersion)
     {
         $file  = $this->sniffFile(self::TEST_FILE, $requiredUpTo);
-        $error = "The \"{$parameterName}\" parameter for function {$functionName} is missing, but was required for PHP version {$requiredUpTo} and lower";
+        $error = "The \"{$parameterName}\" parameter for function {$functionName}() is missing, but was required for PHP version {$requiredUpTo} and lower";
         foreach ($lines as $line) {
             $this->assertError($file, $line, $error);
         }

--- a/PHPCompatibility/Tests/sniff-examples/optional_required_function_parameters.php
+++ b/PHPCompatibility/Tests/sniff-examples/optional_required_function_parameters.php
@@ -1,0 +1,7 @@
+<?php
+
+// These are ok.
+parse_str($str, $output);
+
+// These are not.
+parse_str($str);


### PR DESCRIPTION
Previously a `RequiredOptionalFunctionParameters` sniff has been added which checks for missing function call parameters which were required and only became optional in a later PHP version.

This PR adds a sister-sniff which checks for missing function call parameters which originally were optional, but later became required.

Initially this sniff checks for the `$results` parameter for the `parse_str()` function for which the optional nature of the parameter became deprecated in PHP 7.2 (soft required).
It is expected that the parameter will become hard required in PHP 8.0.

Refs:
* http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.parse_str-no-second-arg
* https://wiki.php.net/rfc/deprecations_php_7_2#parse_str_without_second_argument
* http://php.net/parse_str
* https://github.com/php/php-src/commit/2634b13e88e1b2be91cb06d041be15814b2b6082

Includes unit tests.

Notes:
The commit contains a few minor changes to the `RequiredOptionalFunctionParameters` sniff to bring both sniffs in line with each other.