### PR TITLE
Tests: fix case numbering error

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
@@ -109,13 +109,12 @@ class IsClassPropertyTest extends MethodTestFrame
             array('/* Case 18 */', false),
             array('/* Case 19 */', false),
             array('/* Case 20 */', false),
-            array('/* Case 21 */', false),
+            array('/* Case 21 */', true, true),
             array('/* Case 22 */', true, true),
             array('/* Case 23 */', true, true),
             array('/* Case 24 */', true, true),
-            array('/* Case 25 */', true, true),
+            array('/* Case 25 */', false, true),
             array('/* Case 26 */', false, true),
-            array('/* Case 27 */', false, true),
         );
     }
 }

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_class_property.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_class_property.php
@@ -62,19 +62,19 @@ interface MyInterface {
 }
 
 trait MyTrait {
-	/* Case 22 */
+	/* Case 21 */
 	public $var = true;
-	/* Case 23 */
+	/* Case 22 */
 	protected $var = true;
-	/* Case 24 */
+	/* Case 23 */
 	private $var = true;
-	/* Case 25 */
+	/* Case 24 */
 	var $var = true;
 
-	/* Case 26 */
+	/* Case 25 */
 	function something($var = false)
 	{
-		/* Case 27 */
+		/* Case 26 */
 		$var = false;
 	}
 }


### PR DESCRIPTION
Case 21 didn't exist, so testing for it is useless and can lead to unpredictable results.