### PR TITLE
PHP 7.2: RemovedGlobalVariables: add detection for use of $php_errormsg

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -73,6 +73,11 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
             '7.0' => true,
             'alternative' => 'php://input',
         ),
+
+        'php_errormsg' => array(
+            '7.2' => false,
+            'alternative' => 'error_get_last()',
+        ),
     );
 
 
@@ -123,6 +128,13 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
             }
         }
 
+        // Do some additional checks for the $php_errormsg variable.
+        if ($varName === 'php_errormsg'
+            && $this->isTargetPHPErrormsgVar($phpcsFile, $stackPtr, $tokens) === false
+        ) {
+            return;
+        }
+
         // Still here, so throw an error/warning.
         $itemInfo = array(
             'name' => $varName,
@@ -153,6 +165,138 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
     protected function getErrorMsgTemplate()
     {
         return "Global variable '\$%s' is ";
+    }
+
+
+    /**
+     * Filter the error message before it's passed to PHPCS.
+     *
+     * @param string $error     The error message which was created.
+     * @param array  $itemInfo  Base information about the item this error message applied to.
+     * @param array  $errorInfo Detail information about an item this error message applied to.
+     *
+     * @return string
+     */
+    protected function filterErrorMsg($error, array $itemInfo, array $errorInfo)
+    {
+        if ($itemInfo['name'] === 'php_errormsg') {
+            $error = str_replace('Global', 'The', $error);
+        }
+        return $error;
+    }
+
+    /**
+     * Run some additional checks for the `$php_errormsg` variable.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     * @param array                 $tokens    Token array of the current file.
+     *
+     * @return bool
+     */
+    private function isTargetPHPErrormsgVar(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, array $tokens)
+    {
+        $scopeStart = 0;
+
+        /*
+         * If the variable is detected within the scope of a function/closure, limit the checking.
+         */
+        $function = $phpcsFile->getCondition($stackPtr, T_CLOSURE);
+        if ($function === false) {
+            $function = $phpcsFile->getCondition($stackPtr, T_FUNCTION);
+        }
+
+        // It could also be a function param, which is not in the function scope.
+        if ($function === false && isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
+            $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
+            if (isset($tokens[$parenthesisCloser]['parenthesis_owner'])
+                && ( $tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_FUNCTION
+                    || $tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_CLOSURE)
+            ) {
+                $function = $tokens[$parenthesisCloser]['parenthesis_owner'];
+            }
+        }
+
+        if ($function !== false) {
+            $scopeStart = $tokens[$function]['scope_opener'];
+        }
+
+        /*
+         * Now, let's do some additional checks.
+         */
+        $nextNonEmpty = $phpcsFile->findNext(
+            \PHP_CodeSniffer_Tokens::$emptyTokens,
+            ($stackPtr + 1),
+            null,
+            true
+        );
+
+        // Is the variable being used as an array ?
+        if ($nextNonEmpty !== false && $tokens[$nextNonEmpty]['code'] === T_OPEN_SQUARE_BRACKET) {
+            // The PHP native variable is a string, so this is probably not it
+            // (except for array access to string, but why would you in this case ?).
+            return false;
+        }
+
+        // Is this a variable assignment ?
+        if ($nextNonEmpty !== false
+            && in_array($tokens[$nextNonEmpty]['code'], \PHP_CodeSniffer_Tokens::$assignmentTokens, true)
+        ) {
+            return false;
+        }
+
+        // Is this a function param shadowing the PHP native one ?
+        if ($function !== false) {
+            $parameters = $this->getMethodParameters($phpcsFile, $function);
+            if (is_array($parameters) === true && empty($parameters) === false) {
+                foreach ($parameters as $param) {
+                    if ($param['name'] === '$php_errormsg') {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        $skipPast = array(
+            'T_CLASS'      => true,
+            'T_ANON_CLASS' => true,
+            'T_INTERFACE'  => true,
+            'T_TRAIT'      => true,
+            'T_FUNCTION'   => true,
+            'T_CLOSURE'    => true,
+        );
+
+        // Walk back and see if there is an assignment to the variable within the same scope.
+        for ($i = ($stackPtr - 1); $i >= $scopeStart; $i--) {
+            if ($tokens[$i]['code'] === T_CLOSE_CURLY_BRACKET
+                && isset($tokens[$i]['scope_condition'])
+                && isset($skipPast[$tokens[$tokens[$i]['scope_condition']]['type']])
+            ) {
+                // Skip past functions, classes etc.
+                $i = $tokens[$i]['scope_condition'];
+                continue;
+            }
+
+            if ($tokens[$i]['code'] !== T_VARIABLE || $tokens[$i]['content'] !== '$php_errormsg') {
+                continue;
+            }
+
+            $nextNonEmpty = $phpcsFile->findNext(
+                \PHP_CodeSniffer_Tokens::$emptyTokens,
+                ($i + 1),
+                null,
+                true
+            );
+
+            if ($nextNonEmpty !== false
+                && in_array($tokens[$nextNonEmpty]['code'], \PHP_CodeSniffer_Tokens::$assignmentTokens, true)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedGlobalVariablesSniffTest.php
@@ -83,6 +83,48 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
 
 
     /**
+     * testDeprecatedPHPErrorMsg
+     *
+     * @dataProvider dataDeprecatedPHPErrorMsg
+     *
+     * @param array $line The line number in the test file where a warning is expected.
+     *
+     * @return void
+     */
+    public function testDeprecatedPHPErrorMsg($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+
+        $file  = $this->sniffFile(self::TEST_FILE, '7.2');
+        $error = 'The variable \'$php_errormsg\' is deprecated since PHP 7.2; Use error_get_last() instead';
+        $this->assertWarning($file, $line, $error);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedPHPErrorMsg()
+     *
+     * @return array
+     */
+    public function dataDeprecatedPHPErrorMsg()
+    {
+        return array(
+            array(101),
+            array(110),
+            array(111),
+            array(126),
+            array(127),
+            array(140),
+            array(141),
+            array(151), // False positive!
+            array(156),
+        );
+    }
+
+
+    /**
      * testNoFalsePositives
      *
      * @dataProvider dataNoFalsePositives
@@ -148,6 +190,26 @@ class RemovedGlobalVariablesSniffTest extends BaseSniffTest
             array(86),
             array(87),
             array(88),
+
+            // PHP 7.2 deprecated $php_errormsg.
+            array(106),
+            array(114),
+            array(116),
+            array(118),
+            array(121),
+            array(123),
+            array(130),
+            array(132),
+            array(133),
+            array(134),
+            array(143),
+            array(145),
+            array(146),
+            array(147),
+            array(150),
+            array(165),
+            array(169),
+
         );
     }
 


### PR DESCRIPTION
> `track_errors` ini setting and `$php_errormsg` variable
>
> When the `track_errors` ini setting is enabled, a `$php_errormsg` variable is created in the local scope when a non-fatal error occurs. Given that the preferred way of retrieving such error information is by using `error_get_last()`, this feature has been deprecated.

Refs:
* http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.track_errors-and-php_errormsg
* https://wiki.php.net/rfc/deprecations_php_7_2#create_function
* http://php.net/manual/en/reserved.variables.phperrormsg.php

**Implementation notes:**

As the `$php_errormsg` variable is not a superglobal, quite some extra checks are needed.

All the same, adding it to the `RemovedGlobalVariables` sniff seemed like the most logical place for this variable deprecation.

I could, however, split it off into a separate sniff if so preferred.

**Sniff notes:**

The sniff does not take the value of the `track_errors` ini setting into account as the scan is often run on a different system than the one on which the software is deployed, so taking it into account would make the sniff unreliable.

The sniff _does_ check for a variable of the same name being assigned a value within the same scope as the `$php_errormsg` variable is used. This should prevent most false positives.

Based on the current tests, there is one false positive at this moment and that is when a closure imports the `$php_errormsg` variable by reference and the `$php_errormsg` variable has been assigned a value within the scope from which the closure is importing it.
This is such a specific case and would require quite some extra code to check for, that I deemed this unnecessary as the chances of this throwing a false positive in real life code are minuscule.
If this false positive is at some point reported, the additional code could still be added.