### PR TITLE
PHP 5.3: New `DynamicAccessToStatic` sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DynamicAccessToStaticSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DynamicAccessToStaticSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\DynamicAccessToStaticSniff.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+use PHP_CodeSniffer_Tokens as Tokens;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\DynamicAccessToStaticSniff.
+ *
+ * As of PHP 5.3, static properties and methods as well as class constants
+ * can be accessed using a dynamic (variable) class name.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DynamicAccessToStaticSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_DOUBLE_COLON,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.2') === false) {
+            return;
+        }
+
+        $tokens       = $phpcsFile->getTokens();
+        $prevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        // Disregard `static::` as well. Late static binding is reported by another sniff.
+        if ($tokens[$prevNonEmpty]['code'] === T_SELF
+            || $tokens[$prevNonEmpty]['code'] === T_PARENT
+            || $tokens[$prevNonEmpty]['code'] === T_STATIC
+        ) {
+            return;
+        }
+
+        if ($tokens[$prevNonEmpty]['code'] === T_STRING) {
+            $prevPrevNonEmpty = $phpcsFile->findPrevious(Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+
+            if ($tokens[$prevPrevNonEmpty]['code'] !== T_OBJECT_OPERATOR) {
+                return;
+            }
+        }
+
+        $phpcsFile->addError(
+            'Static class properties and methods, as well as class constants, could not be accessed using a dynamic (variable) classname in PHP 5.2 or earlier.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/DynamicAccessToStaticSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DynamicAccessToStaticSniffTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Dynamic access to static methods and properties sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Dynamic access to static methods and properties sniff test file
+ *
+ * @group dynamicAccessStatic
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\DynamicAccessToStaticSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class DynamicAccessToStaticSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/dynamic_access_to_static.php';
+
+    /**
+     * testDynamicAccessToStatic
+     *
+     * @dataProvider dataDynamicAccessToStatic
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testDynamicAccessToStatic($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertError($file, $line, 'Static class properties and methods, as well as class constants, could not be accessed using a dynamic (variable) classname in PHP 5.2 or earlier.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDynamicAccessToStatic()
+     *
+     * @return array
+     */
+    public function dataDynamicAccessToStatic()
+    {
+        return array(
+            array(20),
+            array(21),
+            array(22),
+            array(25),
+            array(26),
+            array(27),
+            array(32),
+            array(34),
+            array(35),
+            array(41),
+            array(42),
+            array(43),
+            array(61),
+            array(62),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(14),
+            array(15),
+            array(16),
+            array(50),
+            array(51),
+            array(53),
+            array(54),
+            array(57),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/dynamic_access_to_static.php
+++ b/PHPCompatibility/Tests/sniff-examples/dynamic_access_to_static.php
@@ -1,0 +1,64 @@
+<?php
+
+class StaticAllThings {
+	const BAR = 'xyz';
+
+    public static $foo = 123;
+
+    public static function test() {
+        return 'abc';
+    }
+}
+
+// OK in PHP < 5.3.
+echo StaticAllThings::BAR;
+echo StaticAllThings :: $foo;
+echo StaticAllThings::test();
+
+// Not OK in PHP < 5.3.
+$object = new StaticAllThings();
+echo $object::BAR;
+echo $object :: $foo;
+echo $object::test();
+
+$a = 'StaticAllThings';
+echo $a::BAR;
+echo $a::$foo;
+echo $a :: test();
+
+$b = array(
+    'abc' => 'StaticAllThings',
+);
+echo $b['abc']::BAR;
+echo $b['abc']
+     :: $foo;
+echo $b['abc']::test();
+
+// PHP 7.0+
+$c = new stdClass();
+$c->name = 'StaticAllThings';
+
+echo $c->name::BAR;
+echo $c->name::$foo;
+echo $c->name::test();
+
+class TestKeyword extends StaticAllThings {
+    public static $bar = 456;
+
+    public function testIt() {
+        // OK in PHP < 5.3.
+        echo TestKeyword::$bar;
+        echo StaticAllThings::$foo;
+
+        echo self::$bar;
+        echo parent::$foo;
+        // Not OK, but this is because of late static binding not being supported in PHP 5.2,
+        // which is reported by another sniff, so no need to report here.
+        echo static::$foo;
+
+        // Not OK in PHP < 5.3.
+        $name = __CLASS__;
+        echo $name::$bar;
+        echo $name::$foo;
+    }
+}


### PR DESCRIPTION
New sniff to detect dynamic access to static methods and properties, as well as class constants, prior to PHP 5.3.

Includes unit tests.

We may run into some false positives, though I've done due diligence and ran the sniff over a couple of semi-large PHP projects with various minimum PHP requirements (WordPress (5.2), PHP_CodeSniffer (5.4), PHPUnit 6.x (7.0) ) to see if could find any and so far, I haven't.

Fixes #534