### PR TITLE
NewClosures: downgrade "$this found in closure outside class" to warning

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClosureSniff.php
@@ -113,8 +113,8 @@ class NewClosureSniff extends Sniff
                  * Closures only have access to $this if used within a class context.
                  */
                 elseif ($this->inClassScope($phpcsFile, $stackPtr, false) === false) {
-                    $phpcsFile->addError(
-                        'Closures / anonymous functions only have access to $this if used within a class',
+                    $phpcsFile->addWarning(
+                        'Closures / anonymous functions only have access to $this if used within a class or when bound to an object using bindTo(). Please verify.',
                         $thisFound,
                         'ThisFoundOutsideClass'
                     );

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -60,7 +60,7 @@ class NewClosureSniffTest extends BaseSniffTest
             array(40),
             array(47),
             array(52),
-            array(57),
+            array(59),
         );
     }
 
@@ -201,7 +201,7 @@ class NewClosureSniffTest extends BaseSniffTest
     public function testThisInClosureOutsideClass()
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
-        $this->assertError($file, 53, 'Closures / anonymous functions only have access to $this if used within a class');
+        $this->assertWarning($file, 53, 'Closures / anonymous functions only have access to $this if used within a class or when bound to an object using bindTo(). Please verify.');
     }
 
 
@@ -231,7 +231,7 @@ class NewClosureSniffTest extends BaseSniffTest
     {
         return array(
             array(48),
-            array(58),
+            array(60),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_closure.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_closure.php
@@ -48,10 +48,12 @@ static function() {
     var_dump($something);
 }
 
-// Invalid: Using $this outside of a class context.
-function() {
+// Warning: Using $this outside of a class context.
+$closure = function() {
    var_dump($this);
 }
+$foo = new stdClass();
+$closure = $closure->bindTo($foo);
 
 // Valid: using a variable - not $this - in a closure.
 function() {


### PR DESCRIPTION
... and adjust the error message to mention `bindTo()`.

Includes slight adjustments to the unit tests to document why this change was made.

This is an implementation of option 2 as mentioned in https://github.com/wimg/PHPCompatibility/issues/527#issuecomment-344348068

Fixes #527