### PR TITLE
Build/PHPCS: check array indentation

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1506,10 +1506,10 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         }
 
         $find = array(
-                 T_NS_SEPARATOR,
-                 T_STRING,
-                 T_WHITESPACE,
-                );
+            T_NS_SEPARATOR,
+            T_STRING,
+            T_WHITESPACE,
+        );
 
         $end  = $phpcsFile->findNext($find, ($extendsIndex + 1), $classCloserIndex, true);
         $name = $phpcsFile->getTokensAsString(($extendsIndex + 1), ($end - $extendsIndex - 1));

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,17 +48,30 @@
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 	</rule>
 
-	<rule ref="Squiz.Arrays.ArrayDeclaration">
-		<!-- Ignoring the Squiz indentation rules as normalized arrays are preferred.
-		     Unfortunately there is currently no upstream sniff to check for this. -->
-		<exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/>
-		<exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/>
-		<exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
 
-		<!-- Single and multi-line arrays are both allowed. -->
-		<exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
-		<exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
-	</rule>
+    <!-- Use normalized array indentation. -->
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+	<rule ref="Squiz.Arrays.ArrayDeclaration"/>
+
+	<!-- Ignoring the Squiz indentation rules as normalized arrays are preferred. -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration.ValueNotAligned">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned">
+        <severity>0</severity>
+    </rule>
+
+	<!-- Single and multi-line arrays are both allowed. -->
+    <rule ref="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
+        <severity>0</severity>
+    </rule>
+
 
 	<!--
 		Inline Documentation check.


### PR DESCRIPTION
PHPCS upstream has added a new sniff to verify normalized array indentation.
As the PHPCS build check for the PHPCompatibility standard is run against `master`, we can start taken advantage of that.

This commit adds the relevant changes to the PHPCompatibility own ruleset to do so and fixes the one instance where the code did not yet comply with this.