### PR TITLE
Adding ignore for docblock indent

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -79,6 +79,8 @@
 	<rule ref="Generic.Commenting.DocComment">
 		<!-- Having a @see or @internal tag before the @param tags is fine. -->
 		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
+		<!-- We prefer seeing nicely looking docblock comments -->
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
 	</rule>
 
 	<!-- No need to be as strict about comment punctuation for the unit tests. -->


### PR DESCRIPTION
We prefer seeing nicely formatted docblock comments. PHPCS seems to complain about this.