### PR TITLE
Build/PHPCS: improve check for superfluous whitespace in files

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniff.php
@@ -154,7 +154,6 @@ class ForbiddenCallTimePassByReferenceSniff extends Sniff
                 continue;
             }
 
-
             // Checking this: $value = my_function(...[*]$arg...).
             $tokenBefore = $phpcsFile->findPrevious(
                 \PHP_CodeSniffer_Tokens::$emptyTokens,

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenEmptyListAssignmentSniff.php
@@ -52,7 +52,6 @@ class ForbiddenEmptyListAssignmentSniff extends Sniff
         $this->ignoreTokens[T_OPEN_PARENTHESIS]  = T_OPEN_PARENTHESIS;
         $this->ignoreTokens[T_CLOSE_PARENTHESIS] = T_CLOSE_PARENTHESIS;
 
-
         return array(T_LIST);
     }
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenFunctionParametersWithSameNameSniff.php
@@ -69,7 +69,6 @@ class ForbiddenFunctionParametersWithSameNameSniff extends Sniff
             return;
         }
 
-
         $paramNames = array();
         foreach ($parameters as $param) {
             $paramNames[] = strtolower($param['name']);

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -297,7 +297,6 @@ class ForbiddenNamesSniff extends Sniff
             unset($i, $namespacePart, $partLc);
         }
 
-
         $nextContentLc = strtolower($tokens[$nextNonEmpty]['content']);
         if (isset($this->invalidNames[$nextContentLc]) === false) {
             return;

--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -248,7 +248,6 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true);
         $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-
         // Skip attempts to use keywords as functions or class names - the former
         // will be reported by ForbiddenNamesAsInvokedFunctionsSniff, whilst the
         // latter will be (partially) reported by the ForbiddenNames sniff.

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -133,10 +133,11 @@ class NonStaticMagicMethodsSniff extends Sniff
              * If no body of function (e.g. for interfaces), there is
              * no closing curly brace; advance the pointer differently.
              */
-            $scopeCloser = isset($tokens[$functionToken]['scope_closer'])
-                ? $tokens[$functionToken]['scope_closer']
-                : $functionToken + 1;
-
+            if (isset($tokens[$functionToken]['scope_closer'])) {
+                $scopeCloser = $tokens[$functionToken]['scope_closer'];
+            } else {
+                $scopeCloser = ($functionToken + 1);
+            }
 
             $methodName   = $phpcsFile->getDeclarationName($functionToken);
             $methodNameLc = strtolower($methodName);

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -122,7 +122,6 @@ class RemovedAlternativePHPTagsSniff extends Sniff
             return;
         }
 
-
         // If we're still here, we can't be sure if what we find was really intended as ASP open tags.
         if ($openTag['code'] === T_INLINE_HTML && $this->aspTags === false) {
             if (strpos($content, '<%') !== false) {

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -50,7 +50,6 @@ class NewKeywordsSniffTest extends BaseSniffTest
         $this->assertError($file, 15, '"insteadof" keyword (for traits) is not present in PHP version 5.3 or earlier');
         $this->assertError($file, 16, '"insteadof" keyword (for traits) is not present in PHP version 5.3 or earlier');
 
-
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, 15);
         $this->assertNoViolation($file, 16);

--- a/PHPCompatibility/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ValidIntegersSniffTest.php
@@ -43,7 +43,6 @@ class ValidIntegersSniffTest extends BaseSniffTest
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertError($file, $line, "Binary integer literals were not present in PHP version 5.3 or earlier. Found: {$binary}");
 
-
         if ($testNoViolation === true) {
             $file = $this->sniffFile(self::TEST_FILE, '5.4');
             $this->assertNoViolation($file, $line);

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,75 +1,75 @@
 <?xml version="1.0"?>
 <ruleset name="PHPCS Coding Standards for PHPCompatibility">
-	<description>Check the code of the PHPCompatibility standard itself.</description>
+    <description>Check the code of the PHPCompatibility standard itself.</description>
 
-	<arg value="sp"/>
-	<arg name="extensions" value="php"/>
+    <arg value="sp"/>
+    <arg name="extensions" value="php"/>
 
-	<!-- Exclude test case code. -->
-	<exclude-pattern>*/Tests/sniff-examples/*</exclude-pattern>
+    <!-- Exclude test case code. -->
+    <exclude-pattern>*/Tests/sniff-examples/*</exclude-pattern>
 
-	<!-- Exclude Composer vendor directory. -->
-	<exclude-pattern>*/vendor/*</exclude-pattern>
+    <!-- Exclude Composer vendor directory. -->
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!--
-		PHP cross version compatibility ;-).
-	-->
-	<config name="testVersion" value="5.3-99.0"/>
-	<rule ref="PHPCompatibility"/>
+    <!--
+        PHP cross version compatibility ;-).
+    -->
+    <config name="testVersion" value="5.3-99.0"/>
+    <rule ref="PHPCompatibility"/>
 
-	<!-- Verified correct usage. -->
-	<rule ref="PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved">
-		<exclude-pattern>*/RemovedAlternativePHPTags*\.php</exclude-pattern>
-	</rule>
+    <!-- Verified correct usage. -->
+    <rule ref="PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved">
+        <exclude-pattern>*/RemovedAlternativePHPTags*\.php</exclude-pattern>
+    </rule>
 
-	<!-- Verified correct usage. -->
-	<rule ref="PHPCompatibility.PHP.NewConstants.t_finallyFound">
-		<exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.PHP.NewConstants.t_insteadofFound">
-		<exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-	</rule>
-	<rule ref="PHPCompatibility.PHP.NewConstants.t_traitFound">
-		<exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-	</rule>
+    <!-- Verified correct usage. -->
+    <rule ref="PHPCompatibility.PHP.NewConstants.t_finallyFound">
+        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.PHP.NewConstants.t_insteadofFound">
+        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.PHP.NewConstants.t_traitFound">
+        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
+    </rule>
 
-	<!--
-		Minimal code style check.
-	-->
-	<rule ref="PSR2">
-		<!-- To address at a later point in time. -->
-		<exclude name="Generic.Files.LineLength.TooLong"/>
+    <!--
+        Minimal code style check.
+    -->
+    <rule ref="PSR2">
+        <!-- To address at a later point in time. -->
+        <exclude name="Generic.Files.LineLength.TooLong"/>
 
-		<!-- Ignoring a number of whitespace issues around blank lines. -->
-		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
-		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
-	</rule>
+        <!-- Ignoring a number of whitespace issues around blank lines. -->
+        <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody"/>
+        <exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+        <exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
+    </rule>
 
-	<!-- PSR2 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-		<properties>
-			<property name="ignoreBlankLines" value="false"/>
-		</properties>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
-		<severity>5</severity>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
-		<severity>5</severity>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+    <!-- PSR2 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
         <severity>5</severity>
-	</rule>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
+        <severity>5</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>5</severity>
+    </rule>
 
 
     <!-- Use normalized array indentation. -->
     <rule ref="Generic.Arrays.ArrayIndent"/>
-	<rule ref="Squiz.Arrays.ArrayDeclaration"/>
+    <rule ref="Squiz.Arrays.ArrayDeclaration"/>
 
-	<!-- Ignoring the Squiz indentation rules as normalized arrays are preferred. -->
+    <!-- Ignoring the Squiz indentation rules as normalized arrays are preferred. -->
     <rule ref="Squiz.Arrays.ArrayDeclaration.KeyNotAligned">
         <severity>0</severity>
     </rule>
@@ -80,7 +80,7 @@
         <severity>0</severity>
     </rule>
 
-	<!-- Single and multi-line arrays are both allowed. -->
+    <!-- Single and multi-line arrays are both allowed. -->
     <rule ref="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed">
         <severity>0</severity>
     </rule>
@@ -89,41 +89,41 @@
     </rule>
 
 
-	<!--
-		Inline Documentation check.
-	-->
-	<rule ref="Generic.Commenting.DocComment">
-		<!-- Having a @see or @internal tag before the @param tags is fine. -->
-		<exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
-	</rule>
+    <!--
+        Inline Documentation check.
+    -->
+    <rule ref="Generic.Commenting.DocComment">
+        <!-- Having a @see or @internal tag before the @param tags is fine. -->
+        <exclude name="Generic.Commenting.DocComment.ParamNotFirst"/>
+    </rule>
 
-	<!-- No need to be as strict about comment punctuation for the unit tests. -->
-	<rule ref="Generic.Commenting.DocComment.ShortNotCapital">
-		<exclude-pattern>*/Tests/*\.php</exclude-pattern>
-	</rule>
+    <!-- No need to be as strict about comment punctuation for the unit tests. -->
+    <rule ref="Generic.Commenting.DocComment.ShortNotCapital">
+        <exclude-pattern>*/Tests/*\.php</exclude-pattern>
+    </rule>
 
 
-	<rule ref="PEAR.Commenting">
-		<!-- Exclude PEAR specific tag requirements. -->
-		<exclude name="PEAR.Commenting.FileComment.MissingVersion" />
-		<exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
-		<exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
-		<exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
-		<exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
+    <rule ref="PEAR.Commenting">
+        <!-- Exclude PEAR specific tag requirements. -->
+        <exclude name="PEAR.Commenting.FileComment.MissingVersion" />
+        <exclude name="PEAR.Commenting.FileComment.MissingLinkTag" />
+        <exclude name="PEAR.Commenting.FileComment.MissingLicenseTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingLicenseTag" />
+        <exclude name="PEAR.Commenting.ClassComment.MissingLinkTag" />
 
-		<!-- Having a @see or @internal tag before the @category tag is fine. -->
-		<exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
-	</rule>
+        <!-- Having a @see or @internal tag before the @category tag is fine. -->
+        <exclude name="PEAR.Commenting.ClassComment.CategoryTagOrder"/>
+    </rule>
 
-	<!-- No need to be as strict about file and class comment tags for the unit tests. -->
-	<rule ref="PEAR.Commenting.FileComment.MissingCategoryTag">
-		<exclude-pattern>*/Tests/*\.php</exclude-pattern>
-	</rule>
-	<rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
-		<exclude-pattern>*/Tests/*\.php</exclude-pattern>
-	</rule>
-	<rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
-		<exclude-pattern>*/Tests/*\.php</exclude-pattern>
-	</rule>
+    <!-- No need to be as strict about file and class comment tags for the unit tests. -->
+    <rule ref="PEAR.Commenting.FileComment.MissingCategoryTag">
+        <exclude-pattern>*/Tests/*\.php</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment.MissingAuthorTag">
+        <exclude-pattern>*/Tests/*\.php</exclude-pattern>
+    </rule>
+    <rule ref="PEAR.Commenting.ClassComment.MissingCategoryTag">
+        <exclude-pattern>*/Tests/*\.php</exclude-pattern>
+    </rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,22 @@
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace"/>
 	</rule>
 
+	<!-- PSR2 appears to ignore blank lines for superfluous whitespace and in several other places. Let's fix that. -->
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+		<properties>
+			<property name="ignoreBlankLines" value="false"/>
+		</properties>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>5</severity>
+	</rule>
+
 
     <!-- Use normalized array indentation. -->
     <rule ref="Generic.Arrays.ArrayIndent"/>


### PR DESCRIPTION
Apparently PSR2 turns a couple of the superfluous whitespace checks off.
This turns these back on.

There is one additional check turned off in PSR2 which I've left alone: the check for multiple blank lines in a row.
IMO, sometimes it's useful to use two blank lines to break up code for improved readability, so I'm quite happy to leave that one turned off.