### PR TITLE
Up the version for recommended Composer plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ As the directory layout of PHPCompatibility has changed, the path previously reg
 If you use Composer, we recommend you use a Composer plugin to sort this out. In previous install instructions we recommended the SimplyAdmin plugin for this. This plugin has since been abandoned. We now recommend the DealerDirect plugin.
 ```bash
 composer remove --dev simplyadmire/composer-plugins
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.1
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3
 composer install
 composer update wimg/php-compatibility squizlabs/php_codesniffer
 vendor/bin/phpcs -i

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Installation in a Composer project (method 1)
 
        Just add the Composer plugin you prefer to the `require-dev` section of your `composer.json` file.
 
-       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.1"
+       * [DealerDirect/phpcodesniffer-composer-installer](https://github.com/DealerDirect/phpcodesniffer-composer-installer):"^0.4.3"
        * [higidi/composer-phpcodesniffer-standards-plugin](https://github.com/higidi/composer-phpcodesniffer-standards-plugin)
        * [SimplyAdmire/ComposerPlugins](https://github.com/SimplyAdmire/ComposerPlugins). This plugin *might* still work, but appears to be abandoned.
     - As a last alternative in case you use a custom ruleset, _and only if you use PHP CodeSniffer version 2.6.0 or higher_, you can tell PHP CodeSniffer the path to the PHPCompatibility standard by adding the following snippet to your custom ruleset:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "squizlabs/php_codesniffer": "2.6.2"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
   "license" : "LGPL-3.0",
   "keywords" : [ "compatibility", "phpcs", "standards" ],


### PR DESCRIPTION
The `DealerDirect/phpcodesniffer-composer-installer` Composer plugin contained code which is incompatible with PHP 5.3. This has been fixed in [version 0.4.3](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.4.3) through PR https://github.com/Dealerdirect/phpcodesniffer-composer-installer/pull/39.

By upping the recommended version we prevent issues when users still use PHPCS 1.x/2.x in combination with PHP 5.3.