### PR TITLE
Travis: Use stable versions of Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ before_install:
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
   - composer self-update
-  - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require --dev php-coveralls/php-coveralls:${COVERALLS_VERSION}; fi
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require php-coveralls/php-coveralls:${COVERALLS_VERSION}; fi
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - if [[ $PHPUNIT_VERSION != "travis" ]]; then composer require phpunit/phpunit:${PHPUNIT_VERSION}; fi
   # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,21 +38,21 @@ matrix:
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
 
     - php: 7.1
-      env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="^2.0"
       addons:
         apt:
           packages:
             - libxml2-utils
     - php: 7.1
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="^2.0"
 
     # PHPCS 3.x cannot be run on PHP 5.3.
     - php: 5.3
       dist: precise
-      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="~1.0" PHPUNIT_VERSION="~4.5"
+      env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="^1.0" PHPUNIT_VERSION="~4.5"
     - php: 5.3
       dist: precise
-      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="~1.0" PHPUNIT_VERSION="~4.5"
+      env: PHPCS_VERSION=">=2.0,<3.0" LINT=1 COVERALLS_VERSION="^1.0" PHPUNIT_VERSION="~4.5"
 
     # PHP 5.4 with low PHPCS needs "precise" + one build with Coveralls.
     - php: 5.4
@@ -60,7 +60,7 @@ matrix:
     - php: 5.4
       env: PHPCS_VERSION="2.2.*" PHPUNIT_VERSION="~4.5"
     - php: 5.4
-      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="~1.0"
+      env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
 
     # Test against a variation of PHPCS 2.x versions.
     - php: 5.5
@@ -70,7 +70,7 @@ matrix:
     - php: 7.0
       env: PHPCS_VERSION="2.6.*"
     - php: 7.1
-      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="dev-master"
+      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="^2.0"
     - php: 7.2
       env: PHPCS_VERSION="2.7.*"
     - php: nightly
@@ -92,7 +92,7 @@ before_install:
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
   - composer self-update
-  - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require --dev satooshi/php-coveralls:${COVERALLS_VERSION}; fi
+  - if [[ $COVERALLS_VERSION != "notset" ]]; then composer require --dev php-coveralls/php-coveralls:${COVERALLS_VERSION}; fi
   - composer require squizlabs/php_codesniffer:${PHPCS_VERSION}
   - if [[ $PHPUNIT_VERSION != "travis" ]]; then composer require phpunit/phpunit:${PHPUNIT_VERSION}; fi
   # --no-dev makes sure the Travis provided version of PHPUnit is used for better stability.
@@ -120,4 +120,5 @@ script:
   - if [[ "$SNIFF" == "1" ]]; then diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml"); fi
 
 after_success:
-  - if [[ $COVERALLS_VERSION != "notset" ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi
+  - if [[ $COVERALLS_VERSION == "^1.0" ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi
+  - if [[ $COVERALLS_VERSION == "^2.0" ]]; then php vendor/bin/php-coveralls -v -x build/logs/clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - 7.2
+  - 7.1
   - nightly
 
 env:
@@ -37,13 +37,13 @@ matrix:
   include:
     # N.B.: Coverage is only checked on the lowest and highest stable PHP versions for all PHPCS versions.
 
-    - php: 7.1
+    - php: 7.2
       env: PHPCS_VERSION="dev-master" LINT=1 SNIFF=1 COVERALLS_VERSION="^2.0"
       addons:
         apt:
           packages:
             - libxml2-utils
-    - php: 7.1
+    - php: 7.2
       env: PHPCS_VERSION=">=1.5.1,<2.0" COVERALLS_VERSION="^2.0"
 
     # PHPCS 3.x cannot be run on PHP 5.3.
@@ -70,9 +70,9 @@ matrix:
     - php: 7.0
       env: PHPCS_VERSION="2.6.*"
     - php: 7.1
-      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="^2.0"
-    - php: 7.2
       env: PHPCS_VERSION="2.7.*"
+    - php: 7.2
+      env: PHPCS_VERSION="2.3.*" COVERALLS_VERSION="^2.0"
     - php: nightly
       env: PHPCS_VERSION=">=2.0,<3.0"
 


### PR DESCRIPTION
The PHP-Coveralls project has *finally* tagged [some releases](https://github.com/php-coveralls/php-coveralls/issues/203). Using the tagged versions allows Travis to cache the package download which should hopefully make the builds a little faster.

The minimum PHP version for v 2.x is PHP 5.5, for the 1.x branch, it's PHP 5.3.3, so depending on the build, different versions are being used.

Other notes:
* The repository has moved from `satooshi/php-coveralls` to `php-coveralls/php-coveralls`.
* As of PHPCoveralls 2.x, the command to call coveralls has changed from `coveralls` to `php-coveralls`

This PR takes all of the above into account. Keeping my fingers crossed that the build will pass & coverage will be reported correctly (again).

Fixes #549 (hopefully... let's see if it really did after the build has run)