### PR TITLE
PHP 7.2: DeprecatedFunctions: add read_exif_data()

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedFunctionsSniff.php
@@ -777,6 +777,10 @@ class DeprecatedFunctionsSniff extends AbstractRemovedFeatureSniff
             '7.2' => false,
             'alternative' => 'gmp_random_bits() or gmp_random_range()',
         ),
+        'read_exif_data' => array(
+            '7.2' => false,
+            'alternative' => 'exif_read_data()',
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedFunctionsSniffTest.php
@@ -200,6 +200,7 @@ class DeprecatedFunctionsSniffTest extends BaseSniffTest
             array('create_function', '7.2', 'an anonymous function', array(146), '7.1'),
             array('each', '7.2', 'a foreach loop', array(147), '7.1'),
             array('gmp_random', '7.2', 'gmp_random_bits() or gmp_random_range()', array(148), '7.1'),
+            array('read_exif_data', '7.2', 'exif_read_data()', array(149), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_functions.php
@@ -146,3 +146,4 @@ png2wbmp();
 create_function();
 while (list($key, $val) = each($array)) {}
 gmp_random(2);
+read_exif_data();


### PR DESCRIPTION
Refs:
* http://php.net/manual/en/migration72.deprecated.php#migration72.deprecated.read_exif_data-function
* https://github.com/php/php-src/commit/ba28d75c2c72bc17841dbc410496e8d62e139681