### PR TITLE
ForbiddenCallTimePassByReference: fix false positive for "bitwise and" preceded by global constant

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenCallTimePassByReferenceSniffTest.php
@@ -102,7 +102,7 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
             array(24),
             array(39),
             array(40),
-            //array(41), // Currently not yet covered.
+            array(41),
 
             array(51), // OK: No variables.
             array(53), // OK: Outside scope of this sniff.
@@ -126,6 +126,11 @@ class ForbiddenCallTimePassByReferenceSniffTest extends BaseSniffTest
             // Comparison with reference.
             array(74),
             array(75),
+
+            // Issue #39 - Bitwise operations with (class) constants.
+            array(78),
+            array(79),
+            array(80),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/call_time_pass_by_reference.php
+++ b/PHPCompatibility/Tests/sniff-examples/call_time_pass_by_reference.php
@@ -73,3 +73,8 @@ def( &$dummy .= $b ); // Bad: pass by reference.
 // Ok: Comparisons passed as function parameter.
 efg( true == &$b );
 efg( true === &$b );
+
+// Issue https://github.com/wimg/PHPCompatibility/issues/39
+foo(Bar::FOO & $a);
+$foo = self::FLAG_GETDATA & $flags ? 'SQL_CALC_FOUND_ROWS' : '';
+$handler->throwAt(E_ALL & $handler->thrownErrors, true);


### PR DESCRIPTION
This was a known false positive and annotated as such in the unit test files.

Simplified the `isCallTimePassByReferenceParam()` method by using the upstream `isReference()` function to determine whether a _bitwise and_ is a reference or not.
The upstream method has [some issues pre PHPCS 3.1.1](https://github.com/squizlabs/PHP_CodeSniffer/pull/1609), but none which impact this sniff.

 Fixes #39