### PR TITLE
VariableVariables: improve code style independent sniffing

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/VariableVariablesSniff.php
@@ -61,13 +61,14 @@ class VariableVariablesSniff extends Sniff
             return;
         }
 
-        // The previous token has to be a $, -> or ::.
-        if (isset($tokens[($stackPtr - 1)]) === false || in_array($tokens[($stackPtr - 1)]['code'], array(T_DOLLAR, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === false) {
+        // The previous non-empty token has to be a $, -> or ::.
+        $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true, null, true);
+        if ($prevToken === false || in_array($tokens[$prevToken]['code'], array(T_DOLLAR, T_OBJECT_OPERATOR, T_DOUBLE_COLON), true) === false) {
             return;
         }
 
         // For static object calls, it only applies when this is a function call.
-        if ($tokens[($stackPtr - 1)]['code'] === T_DOUBLE_COLON) {
+        if ($tokens[$prevToken]['code'] === T_DOUBLE_COLON) {
             $hasBrackets = $tokens[$nextToken]['bracket_closer'];
             while (($hasBrackets = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($hasBrackets + 1), null, true, null, true)) !== false) {
                 if ($tokens[$hasBrackets]['code'] === T_OPEN_SQUARE_BRACKET) {
@@ -90,7 +91,7 @@ class VariableVariablesSniff extends Sniff
             }
 
             // Now let's also prevent false positives when used with self and static which still work fine.
-            $classToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 2), null, true, null, true);
+            $classToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevToken - 1), null, true, null, true);
             if ($classToken !== false) {
                 if ($tokens[$classToken]['code'] === T_STATIC || $tokens[$classToken]['code'] === T_SELF) {
                     return;

--- a/PHPCompatibility/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/VariableVariablesSniffTest.php
@@ -55,6 +55,8 @@ class VariableVariablesSniffTest extends BaseSniffTest
             array(6),
             array(7),
             array(8),
+            array(37),
+            array(38),
         );
     }
 
@@ -103,7 +105,7 @@ class VariableVariablesSniffTest extends BaseSniffTest
             array(28),
             array(29),
             array(32),
-            array(37),
+            array(42),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/variable_variables.php
+++ b/PHPCompatibility/Tests/sniff-examples/variable_variables.php
@@ -33,5 +33,10 @@ class fooBar {
     }
 }
 
+// Test code style independent sniffing.
+echo $  $var['key1']['key2']; // Bad.
+echo $obj  ->   /* comment */ $var['key']; // Bad.
+echo myClass  :: { /* comment */ $var['key']}(); // OK.
+
 // Live coding.
 echo $$var['key'


### PR DESCRIPTION
Whitespace and comments are allowed to be interspersed in variables, so the sniff should take this into account.

Includes additional unit tests.