### PR TITLE
ForbiddenGlobalVariableVariable: fix false positives and more

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenGlobalVariableVariableSniffTest.php
@@ -50,10 +50,58 @@ class ForbiddenGlobalVariableVariableSniffTest extends BaseSniffTest
     public function dataGlobalVariableVariable()
     {
         return array(
-            array(6),
-            array(9),
-            array(11),
-            array(28),
+            array(21),
+            array(22),
+            array(23),
+            array(24),
+            array(25),
+            array(29),
+            array(31),
+        );
+    }
+
+
+    /**
+     * testGlobalNonBareVariable
+     *
+     * @dataProvider dataGlobalNonBareVariable
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testGlobalNonBareVariable($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertWarning($file, $line, 'Global with anything other than bare variables is discouraged since PHP 7.0');
+    }
+
+    /**
+     * Data provider dataGlobalNonBareVariable.
+     *
+     * @see testGlobalNonBareVariable()
+     *
+     * @return array
+     */
+    public function dataGlobalNonBareVariable()
+    {
+        return array(
+            array(11), // x2
+            array(17),
+            array(18),
+            array(35),
+            array(36),
+            array(37),
+            array(38),
+            array(39),
+            array(42),
+            array(43),
+            array(44),
+            array(45),
+            array(46),
+            array(47),
+            array(51),
+            array(52),
         );
     }
 
@@ -83,14 +131,12 @@ class ForbiddenGlobalVariableVariableSniffTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return array(
-            array(19),
-            array(20),
-            array(21),
-            array(22),
-            array(23),
-            array(24),
-            array(25),
-            array(31),
+            array(8),
+            array(14),
+            array(15),
+            array(16),
+            array(50),
+            array(55),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/forbidden_global_variable_variable.php
+++ b/PHPCompatibility/Tests/sniff-examples/forbidden_global_variable_variable.php
@@ -3,20 +3,42 @@
 /*
  * Forbidden global variable variables.
  */
-global $$test;
 
-// Multi-variable and multi-line global statements.
+// OK.
+global $test;
+
+// Multiple variables on one line - should throw warnings for the last two.
 global $test, $$test, $$$test;
 
-global $test,
-    $$obj->$bar,
-    $testing,
-    $$test;
+// OK: simple variables.
+global $var,
+    $var['key'], // Always parse error, but not our concern.
+	$var->key, // Always parse error, but not our concern.
+	$$var, // Warning about using non-bare variable.
+	$$$var; // Warning about using non-bare variable.
 
-/*
- * Ok.
- */
-global $test;
+// Error: complex variables, not allowed since PHP 7.0.
+global $$var['key'],
+    $$var->key,
+	$$var->key['key'],
+    $$var::$staticvar,
+	$$var::$staticvar['key'];
+
+// Test to make sure that the sniff works code-style independently.
+// Whitespace and comments are allowed between the $ and $var.
+global $   $test->bar, $
+	// Comment.
+	$test->bar;
+
+// Complex variables using curly braces are fine in both PHP 5.x as well as PHP 7.0+.
+// These will all throw a warning about using non-bare variables.
+global ${$var['key']},
+    ${$var->key},
+	${$var->key['key']},
+    ${$var::$staticvar},
+	${$var::$staticvar['key']};
+
+// Warning for using something other than a bare variable.
 global ${$test};
 global ${"name"};
 global ${"name_$type"};
@@ -24,8 +46,10 @@ global ${$var['key1']['key2']};
 global ${$obj->$bar};
 global ${$obj->{$var['key']}};
 
-// Variant on issue #460
-global $test, $$test, $$$test ?> <?php
+// Variant on issue #460, the last two should throw a warning.
+global $test,
+    $$test,
+	$$$test ?> <?php
 
-// Live coding.
-global
+// Live coding. Ignore.
+global $$test


### PR DESCRIPTION
The `ForbiddenGlobalVariableVariable` sniff was a little overzealous and would throw errors for valid variable variables.

The sniff has now been partially refactored.

The following improvements were made:
* Don't throw errors for non-complex variable variables. Issue #537.
* Correctly handle variable variables with whitespace or comments within the variable.
* Throw an `error` for *each* forbidden variable. Previously only one error would be thrown per `global` statement.
    - The error is now thrown on the line containing the variable, not the line containing the `global` keyword.
    - The error message now shows the problem variable encountered.
* Throw a `warning` for non-bare variables encountered in a `global` statement.
    - This warning has a separate errorcode allowing for easy exclusion.
    - The warning, like the error, will show the problem variable encountered.

The unit tests have been redone to account for these changes.

Fixes #537 

@wimg If needed, the warning can be taken out quite easily. Let me know if you don't want it in the sniff.
