### PR TITLE
PHP 7.2/New Functions: add spl_object_id()

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1337,6 +1337,10 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.1' => false,
             '7.2' => true,
         ),
+        'spl_object_id' => array(
+            '7.1' => false,
+            '7.2' => true,
+        ),
         'sodium_add' => array(
             '7.1' => false,
             '7.2' => true,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -472,6 +472,7 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('sodium_memzero', '7.1', array(416), '7.2'),
             array('sodium_pad', '7.1', array(417), '7.2'),
             array('sodium_unpad', '7.1', array(418), '7.2'),
+            array('spl_object_id', '7.1', array(419), '7.2'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_functions.php
@@ -416,3 +416,4 @@ sodium_memcmp();
 sodium_memzero();
 sodium_pad();
 sodium_unpad();
+spl_object_id();


### PR DESCRIPTION
Refs:
* http://php.net/manual/en/migration72.new-functions.php#migration72.new-functions.spl
* https://github.com/php/php-src/commit/5097e2ee13de12b4445b4123e1554c0733c6853c

Note: other than in the changelog, this function is currently undocumented and not yet mentioned in the manual!
The missing documentation has been reported: https://bugs.php.net/bug.php?id=75723