### PR TITLE
PHP 7.2 / DeprecatedIniDirectives: add removed `opcache.fast_shutdown` directive

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedIniDirectivesSniff.php
@@ -213,6 +213,9 @@ class DeprecatedIniDirectivesSniff extends AbstractRemovedFeatureSniff
         'track_errors' => array(
             '7.2' => false,
         ),
+        'opcache.fast_shutdown' => array(
+            '7.2' => true,
+        ),
     );
 
     /**

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedIniDirectivesSniffTest.php
@@ -262,6 +262,7 @@ class DeprecatedIniDirectivesSniffTest extends BaseSniffTest
             array('session.hash_bits_per_character', '7.1', array(150, 151), '7.0'),
 
             array('sql.safe_mode', '7.2', array(169, 170), '7.1'),
+            array('opcache.fast_shutdown', '7.2', array(175, 176), '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
+++ b/PHPCompatibility/Tests/sniff-examples/deprecated_ini_directives.php
@@ -171,3 +171,6 @@ $a = ini_get('sql.safe_mode');
 
 ini_set('track_errors', true);
 $a = ini_get('track_errors');
+
+ini_set('opcache.fast_shutdown', true);
+$a = ini_get('opcache.fast_shutdown');


### PR DESCRIPTION
Refs:
* https://github.com/php/php-src/blob/eb5ba59ad5cd40ef47cb6bdbe8dbb15e2f4d6e42/UPGRADING#L359-L362
* https://github.com/php/php-src/pull/2591
* https://github.com/php/php-src/commit/f25ecdacf805f840f743b67b6d84485b2deceb4f