### PR TITLE
Travis: speed up build times by disabling Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ matrix:
     - php: hhvm
 
 before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" && $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
   - composer self-update


### PR DESCRIPTION
As suggested by @johnbillion in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/ , when not creating code coverage reports, Xdebug is not needed and disabling it will speed up the build.

Based on the build times for this PR, the difference is significant (on builds not creating code coverage).