### PR TITLE
Travis/Build: validate the composer.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,9 @@ script:
   - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./PHPCompatibility/ruleset.xml; fi
   # Check the code-style consistency of the xml files.
   - if [[ "$SNIFF" == "1" ]]; then diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml"); fi
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all; fi
 
 after_success:
   - if [[ $COVERALLS_VERSION == "^1.0" ]]; then php vendor/bin/coveralls -v -x build/logs/clover.xml; fi

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "suggest" : {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
-  "license" : "LGPL-3.0",
+  "license" : "LGPL-3.0-or-later",
   "keywords" : [ "compatibility", "phpcs", "standards" ],
   "autoload" : {
     "psr-4" : {


### PR DESCRIPTION
Validate the composer.json file on each build.
Ref: https://getcomposer.org/doc/03-cli.md#validate

Also updates the license identifier in the `composer.json` file to `LGPL-3.0-or-later` (see more about this below).

The license could also be limited to just LGPL 3.0 by using `LGPL-3.0-only`.
@wimg Let me know if that's would be preferred.

Notes:
* This check has not been restricted to a specific PHP version as there may be different versions of Composer being run on different Travis PHP images, so validating the file once against each PHP/Composer combi should make sure the file is properly validated.
* `--strict` checking is disabled with reason. As of Composer 1.6.0, the SPDX license identifiers v3.0 for GPL/LGPL/AGPL are supported and the old license identifiers are deprecated.
    So using the "new" license identifier would fail the validation for Composer < 1.6.0, using the old license identifier would fail the validation for Composer 1.6.0+. By ignoring warnings, this issue is bypassed.

Refs:
* https://github.com/composer/composer/releases/tag/1.6.0
* https://spdx.org/news/news/2018/01/license-list-30-released