### PR TITLE
Sniff: align `getReturnTypeHintToken()` bc method with PHPCS behaviour

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1063,7 +1063,11 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             return false;
         }
 
-        $hasColon = $phpcsFile->findNext(array(T_COLON, T_INLINE_ELSE), ($tokens[$stackPtr]['parenthesis_closer'] + 1), $tokens[$stackPtr]['scope_opener']);
+        $hasColon = $phpcsFile->findNext(
+            array(T_COLON, T_INLINE_ELSE),
+            ($tokens[$stackPtr]['parenthesis_closer'] + 1),
+            $tokens[$stackPtr]['scope_opener']
+        );
         if ($hasColon === false) {
             return false;
         }
@@ -1081,7 +1085,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             $unrecognizedTypes[] = T_STRING;
         }
 
-        return $phpcsFile->findNext($unrecognizedTypes, ($hasColon + 1), $tokens[$stackPtr]['scope_opener']);
+        return $phpcsFile->findPrevious($unrecognizedTypes, ($tokens[$stackPtr]['scope_opener'] - 1), $hasColon);
     }
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewReturnTypeDeclarationsSniffTest.php
@@ -68,6 +68,7 @@ class NewReturnTypeDeclarationsSniffTest extends BaseSniffTest
             array('Class name', '5.6', 13, '7.0'),
             array('Class name', '5.6', 14, '7.0'),
             array('Class name', '5.6', 15, '7.0'),
+            array('Class name', '5.6', 37, '7.0'),
 
             array('iterable', '7.0', 18, '7.1'),
             array('void', '7.0', 19, '7.1'),

--- a/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_return_type_declarations.php
@@ -27,3 +27,13 @@ function ($a) {}
 
 // PHP 7.2+
 function foo($a): object {}
+
+function fooInterspersedWithComments($a) :
+	// Comment.
+	?
+	// phpcs:ignore Standard.Category.Sniff -- ignore something about a return type declaration.
+	\myNamespace\
+	// Comment.
+	Baz
+{
+}


### PR DESCRIPTION
PHPCS will identify the last token in a namespaced class name based return type as the `T_RETURN_TYPE` token and will tokenize the preceeding namespace and namespace separator tokens as normal, i.e. `T_STRING` and `T_NS_SEPARATOR`.

This change aligns the behaviour of the `getReturnTypeHintToken()` method with PHPCS upstream, so multi-line return declarations will report on the same line across PHPCS versions.

Includes unit test covering the change in the `NewReturnTypes` sniff.