### PR TITLE
NewNullableTypes: make the return type part of the sniff more code style independent

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
@@ -129,35 +129,27 @@ class NewNullableTypesSniff extends Sniff
             return;
         }
 
-        $error = false;
+        $previous = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
 
-        // T_NULLABLE token was introduced in PHPCS 2.7.2. Before that it identified as T_INLINE_THEN.
-        if ((defined('T_NULLABLE') === true && $tokens[($stackPtr - 1)]['type'] === 'T_NULLABLE')
-            || (defined('T_NULLABLE') === false && $tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN)
-        ) {
-            $error = true;
-        }
         // Deal with namespaced class names.
-        elseif ($tokens[($stackPtr - 1)]['code'] === T_NS_SEPARATOR) {
-            $validTokens = array(
-                T_STRING,
-                T_NS_SEPARATOR,
-                T_WHITESPACE,
-            );
+        if ($tokens[$previous]['code'] === T_NS_SEPARATOR) {
+            $validTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
+            $validTokens[] = T_STRING;
+            $validTokens[] = T_NS_SEPARATOR;
+
             $stackPtr--;
 
             while (in_array($tokens[($stackPtr - 1)]['code'], $validTokens, true) === true) {
                 $stackPtr--;
             }
 
-            if ((defined('T_NULLABLE') === true && $tokens[($stackPtr - 1)]['type'] === 'T_NULLABLE')
-                || (defined('T_NULLABLE') === false && $tokens[($stackPtr - 1)]['code'] === T_INLINE_THEN)
-            ) {
-                $error = true;
-            }
+            $previous = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
         }
 
-        if ($error === true) {
+        // T_NULLABLE token was introduced in PHPCS 2.7.2. Before that it identified as T_INLINE_THEN.
+        if ((defined('T_NULLABLE') === true && $tokens[$previous]['type'] === 'T_NULLABLE')
+            || (defined('T_NULLABLE') === false && $tokens[$previous]['code'] === T_INLINE_THEN)
+        ) {
             $phpcsFile->addError(
                 'Nullable return types are not supported in PHP 7.0 or earlier.',
                 $stackPtr,

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewNullableTypesSniffTest.php
@@ -61,6 +61,7 @@ class NewNullableTypesSniffTest extends BaseSniffTest
             array(29),
 
             array(63),
+            array(77),
         );
     }
 
@@ -103,6 +104,8 @@ class NewNullableTypesSniffTest extends BaseSniffTest
             array(59), // Three errors of the same.
 
             array(64),
+            array(68),
+            array(74),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_nullable_types.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_nullable_types.php
@@ -62,3 +62,22 @@ class NullableTypes {
 // Test closures with nullable types.
 function (): ?string {}
 function(?callable $nullable) {}
+
+function testTypeDeclarationsInterspersedWithComments(
+	// This is a parameter declaration.
+	?string $nullable,
+	// phpcs:ignore Standard.Category.Sniff -- ignore something about a param type declaration.
+	?
+	/* Comment. */
+	\myNamespace\
+	// Comment.
+	Baz $nullable
+) :
+	// Comment.
+	?
+	// phpcs:ignore Standard.Category.Sniff -- ignore something about a return type declaration.
+	\myNamespace\
+	/* Comment. */
+	Baz
+{
+}


### PR DESCRIPTION
* Adds a unit test where the param and return type declarations are divvied up over several lines interspersed with comments and (new) PHPCS annotations.
* Changes the `processReturnType()` method to allow for comments interspersed in the declaration.
* Removes some duplicate code/minor code simplification.