### PR TITLE
NewInterfaces/Classes: add recognition of return type declarations

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClassesSniffTest.php
@@ -95,7 +95,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('SplFileInfo', '5.1.1', array(303), '5.2', '5.1'),
             array('SplTempFileObject', '5.1.1', array(304), '5.2', '5.1'),
             array('XMLWriter', '5.1.1', array(313), '5.2', '5.1'),
-            array('DateTime', '5.1', array(25, 65, 105, 151), '5.2'),
+            array('DateTime', '5.1', array(25, 65, 105, 151, 318, 319, 321), '5.2'),
             array('DateTimeZone', '5.1', array(26, 66, 106, 162), '5.2'),
             array('RegexIterator', '5.1', array(27, 67, 107, 163), '5.2'),
             array('RecursiveRegexIterator', '5.1', array(28, 68, 108), '5.2'),
@@ -152,7 +152,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('ReflectionClassConstant', '7.0', array(306), '7.1'),
 
             array('DATETIME', '5.1', array(146), '5.2'),
-            array('datetime', '5.1', array(147), '5.2'),
+            array('datetime', '5.1', array(147, 320), '5.2'),
             array('dATeTiMe', '5.1', array(148), '5.2'),
 
             array('Exception', '4.4', array(190, 217), '5.0'),
@@ -184,7 +184,7 @@ class NewClassesSniffTest extends BaseSniffTest
             array('DivisionByZeroError', '5.6', array(203, 243), '7.0'),
             array('ParseError', '5.6', array(244), '7.0'),
             array('TypeError', '5.6', array(245), '7.0'),
-            array('UI\Exception\InvalidArgumentException', '5.6', array(192, 210, 246), '7.0'),
+            array('UI\Exception\InvalidArgumentException', '5.6', array(192, 210, 246, 322), '7.0'),
             array('UI\Exception\RuntimeException', '5.6', array(188, 199, 247), '7.0'),
             array('ArgumentCountError', '7.0', array(248), '7.1'),
         );
@@ -226,6 +226,9 @@ class NewClassesSniffTest extends BaseSniffTest
             array(170),
             array(181),
             array(265),
+            array(325),
+            array(326),
+            array(327),
         );
     }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewInterfacesSniffTest.php
@@ -71,8 +71,8 @@ class NewInterfacesSniffTest extends BaseSniffTest
             array('SplSubject', '5.0', array(12, 17, 47, 69), '5.1'),
             array('JsonSerializable', '5.3', array(13, 48), '5.4'),
             array('SessionHandlerInterface', '5.3', array(14, 49), '5.4'),
-            array('Traversable', '4.4', array(35, 50, 60, 71), '5.0'),
-            array('DateTimeInterface', '5.4', array(36, 51, 61), '5.5'),
+            array('Traversable', '4.4', array(35, 50, 60, 71, 79), '5.0'),
+            array('DateTimeInterface', '5.4', array(36, 51, 61, 80), '5.5'),
             array('Throwable', '5.6', array(37, 52, 62), '7.0'),
             array('Reflector', '4.4', array(75), '5.0'),
         );
@@ -122,6 +122,8 @@ class NewInterfacesSniffTest extends BaseSniffTest
         $file = $this->sniffFile(self::TEST_FILE, '5.0');
         $this->assertError($file, 20, 'The built-in interface COUNTABLE is not present in PHP version 5.0 or earlier');
         $this->assertError($file, 21, 'The built-in interface countable is not present in PHP version 5.0 or earlier');
+        $this->assertError($file, 78, 'The built-in interface COUNTABLE is not present in PHP version 5.0 or earlier');
+        $this->assertError($file, 81, 'The built-in interface throwable is not present in PHP version 5.6 or earlier');
     }
 
 
@@ -136,7 +138,7 @@ class NewInterfacesSniffTest extends BaseSniffTest
      */
     public function testNoFalsePositives($line)
     {
-        $file = $this->sniffFile(self::TEST_FILE, '5.0'); // Low version below the first addition.
+        $file = $this->sniffFile(self::TEST_FILE, '4.4'); // Low version below the first addition.
         $this->assertNoViolation($file, $line);
     }
 
@@ -155,6 +157,9 @@ class NewInterfacesSniffTest extends BaseSniffTest
             array(56),
             array(57),
             array(72),
+            array(84),
+            array(85),
+            array(86),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_classes.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_classes.php
@@ -313,3 +313,15 @@ $test = new XMLReader();
 $test = new XMLWriter();
 $test = new PDO();
 class MyPDOStatement extends PDOStatement {}
+
+// Test recognition of return type declarations.
+function DateTimeReturnTypeHint( $a ) : DateTime {}
+function DateTimeNullableReturnTypeHint( $a ) : ?DateTime {}
+function GlobalNSLcDateTimeReturnTypeHint( $a ) : \datetime {}
+function GlobalNSDateTimeNullableReturnTypeHint( $a ) : ?\DateTime {}
+function UIExceptionReturnTypeHint( $e ): UI\Exception\InvalidArgumentException {}
+
+// Test against false positives for return type declarations.
+function NsDateTimeReturnTypeHint( $a ) : \SomeNamespace\DateTime {}
+function NsNullDateTimeReturnTypeHint( $a ) : ?SomeNamespace\DateTime {}
+function NoDateTimeReturnTypeHint( $a ) : \SomeNamespace\DateTime\RealClass {}

--- a/PHPCompatibility/Tests/sniff-examples/new_interfaces.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_interfaces.php
@@ -73,3 +73,14 @@ function(myNameSpace\SplObserver $a) {} // Ok.
 
 // Additional new interfaces.
 class MyReflector implements Reflector {}
+
+// Test recognition of return type declarations.
+function CountableReturnTypeHint( $a ) : COUNTABLE {}
+function TraversableReturnTypeHint( $a ) : ?Traversable {}
+function DateTimeInterfaceReturnTypeHint( $a ) : \DateTimeInterface {}
+function($a):throwable {}
+
+// Test against false positives for return type declarations.
+function SeekableIteratorReturnTypeHint( $a ) : SomeNS\SeekableIterator {}
+function SessionHandlerInterfaceReturnTypeHint( $a ) : ?\MyNS\SessionHandlerInterface {}
+function SplSubjectReturnTypeHint( $a ) : \MyNS\SplSubject\AnotherInterface {}


### PR DESCRIPTION
Verification whether interfaces/classes added in newer PHP versions were being used as return type declarations was missing from the sniffs.
This fixes that.

Uses the new `Sniff::getReturnTypeHintName()` method which has been added to the `Sniff` class in a separate commit.

Includes unit tests.