### PR TITLE
Travis: More stable solution for removing Xdebug when not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ matrix:
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - if [[ $COVERALLS_VERSION == "notset" && $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
   - export XMLLINT_INDENT="    "
   # PHP 5.3+: set up test environment using Composer.
   - composer self-update


### PR DESCRIPTION
Builds onto #570

As per https://twitter.com/kelunik/status/954242454676475904

When newer images of PHP versions become available, Xdebug isn't always installed.
Using this little titbit, the builds won't break because of it.