### PR TITLE
New `ReservedFunctionNames`sniff

### DIFF
--- a/PHPCSAliases.php
+++ b/PHPCSAliases.php
@@ -36,6 +36,12 @@ if (defined('PHPCOMPATIBILITY_PHPCS_ALIASES_SET') === false) {
     if (class_exists('\PHP_CodeSniffer_Exception') === false) {
         class_alias('PHP_CodeSniffer\Exceptions\RuntimeException', '\PHP_CodeSniffer_Exception');
     }
+    if (class_exists('\PHP_CodeSniffer_Standards_AbstractScopeSniff') === false) {
+        class_alias('PHP_CodeSniffer\Sniffs\AbstractScopeSniff', '\PHP_CodeSniffer_Standards_AbstractScopeSniff');
+    }
+    if (class_exists('\Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff') === false) {
+        class_alias('PHP_CodeSniffer\Standards\Generic\Sniffs\NamingConventions\CamelCapsFunctionNameSniff', '\Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff');
+    }
 
     define('PHPCOMPATIBILITY_PHPCS_ALIASES_SET', true);
 

--- a/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ReservedFunctionNamesSniff.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\ReservedFunctionNamesSniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\ReservedFunctionNamesSniff.
+ *
+ * All function and method names starting with double underscore are reserved by PHP.
+ *
+ * {@internal Extends an upstream sniff to benefit from the properties contained therein.
+ *            The properties are lists of valid PHP magic function and method names, which
+ *            should be ignored for the purposes of this sniff.
+ *            As this sniff is not PHP version specific, we don't need access to the utility
+ *            methods in the PHPCompatibility\Sniff, so extending the upstream sniff is fine.
+ *            As the upstream sniff checks the same (and more, but we don't need the rest),
+ *            the logic in this sniff is largely the same as used upstream.
+ *            Extending the upstream sniff instead of including it via the ruleset, however,
+ *            prevents hard to debug issues of errors not being reported from the upstream sniff
+ *            if this library is used in combination with other rulesets.}}
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ReservedFunctionNamesSniff extends \Generic_Sniffs_NamingConventions_CamelCapsFunctionNameSniff
+{
+
+    /**
+     * Overload the constructor to work round various PHPCS cross-version compatibility issues.
+     */
+    public function __construct()
+    {
+        $scopeTokens = array(T_CLASS, T_INTERFACE);
+        if (defined('T_TRAIT')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
+            $scopeTokens[] = T_TRAIT;
+        }
+        if (defined('T_ANON_CLASS')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $scopeTokens[] = T_ANON_CLASS;
+        }
+
+        // Call the grand-parent constructor directly.
+        \PHP_CodeSniffer_Standards_AbstractScopeSniff::__construct($scopeTokens, array(T_FUNCTION), true);
+
+        $phpcsVersion = PHPCSHelper::getVersion();
+
+        if (version_compare($phpcsVersion, '2.0.0', '<') === true) {
+            $this->magicMethods            = array_flip($this->magicMethods);
+            $this->methodsDoubleUnderscore = array_flip($this->methodsDoubleUnderscore);
+            $this->magicFunctions          = array_flip($this->magicFunctions);
+        }
+
+        // Make sure debuginfo is included in the array. Upstream only includes it since 2.5.1.
+        $this->magicMethods['debuginfo'] = true;
+    }
+
+
+    /**
+     * Processes the tokens within the scope.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being processed.
+     * @param int                   $stackPtr  The position where this token was
+     *                                         found.
+     * @param int                   $currScope The position of the current scope.
+     *
+     * @return void
+     */
+    protected function processTokenWithinScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $currScope)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $methodName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($methodName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        // Is this a magic method. i.e., is prefixed with "__" ?
+        if (preg_match('|^__[^_]|', $methodName) > 0) {
+            $magicPart = strtolower(substr($methodName, 2));
+            if (isset($this->magicMethods[$magicPart]) === false
+                && isset($this->methodsDoubleUnderscore[$magicPart]) === false
+            ) {
+                $className = '[anonymous class]';
+                if (defined('T_ANON_CLASS') === false || $tokens[$currScope]['type'] !== 'T_ANON_CLASS') {
+                    $className = $phpcsFile->getDeclarationName($currScope);
+                }
+
+                $phpcsFile->addWarning(
+                    'Method name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.',
+                    $stackPtr,
+                    'MethodDoubleUnderscore',
+                    array($className.'::'.$methodName)
+                );
+            }
+        }
+    }
+
+
+    /**
+     * Processes the tokens outside the scope.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being processed.
+     * @param int                   $stackPtr  The position where this token was
+     *                                         found.
+     *
+     * @return void
+     */
+    protected function processTokenOutsideScope(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $functionName = $phpcsFile->getDeclarationName($stackPtr);
+        if ($functionName === null) {
+            // Ignore closures.
+            return;
+        }
+
+        // Is this a magic function. i.e., it is prefixed with "__".
+        if (preg_match('|^__[^_]|', $functionName) > 0) {
+            $magicPart = strtolower(substr($functionName, 2));
+            if (isset($this->magicFunctions[$magicPart]) === false) {
+                $phpcsFile->addWarning(
+                    'Function name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use.',
+                    $stackPtr,
+                    'FunctionDoubleUnderscore',
+                    array($functionName)
+                );
+            }
+        }
+    }
+
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/ReservedFunctionNamesSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ReservedFunctionNamesSniffTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Reserved function names sniff test.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Reserved function names sniff test.
+ *
+ * @group reservedFunctionNames
+ * @group reservedKeywords
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\ReservedFunctionNamesSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ReservedFunctionNamesSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/reserved_function_names.php';
+
+    /**
+     * testReservedFunctionNames
+     *
+     * @dataProvider dataReservedFunctionNames
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testReservedFunctionNames($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertWarning($file, $line, ' is discouraged; PHP has reserved all method names with a double underscore prefix for future use.');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testReservedFunctionNames()
+     *
+     * @return array
+     */
+    public function dataReservedFunctionNames()
+    {
+        return array(
+            array(20),
+            array(21),
+            array(22),
+
+            array(25),
+            array(26),
+            array(27),
+            array(28),
+            array(29),
+            array(30),
+            array(31),
+            array(32),
+            array(33),
+            array(34),
+            array(35),
+            array(37),
+            array(38),
+            array(39),
+            array(41),
+            array(42),
+
+            array(92),
+            array(93),
+            array(94),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(5),
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(10),
+            array(11),
+            array(12),
+            array(13),
+            array(14),
+            array(15),
+            array(16),
+            array(17),
+            array(18),
+            array(19),
+
+            array(40),
+            array(50),
+            array(51),
+            array(52),
+            array(54),
+
+            array(58),
+            array(63),
+            array(66),
+            array(69),
+            array(72),
+
+            array(77),
+            array(78),
+            array(79),
+            array(80),
+            array(81),
+            array(82),
+            array(83),
+            array(84),
+            array(85),
+            array(86),
+            array(87),
+            array(88),
+            array(89),
+            array(90),
+            array(91),
+
+            array(98),
+            array(101),
+            array(102),
+        );
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff operates
+     *  independently of the testVersion.
+     */
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/reserved_function_names.php
+++ b/PHPCompatibility/Tests/sniff-examples/reserved_function_names.php
@@ -1,0 +1,104 @@
+<?php
+
+/* Test for magic functions */
+class Magic_Test {
+    function __construct() {}
+    function __destruct() {}
+    function __call() {}
+    function __callStatic() {}
+    function __get() {}
+    function __set() {}
+    function __isset() {}
+    function __unset() {}
+    function __sleep() {}
+    function __wakeup() {}
+    function __toString() {}
+    function __set_state() {}
+    function __clone() {}
+    function __invoke() {}
+    function __debugInfo() {}
+    function __autoload() {}
+    function __myFunction() {}
+    function __my_function() {}
+}
+
+function __construct() {}
+function __destruct() {}
+function __call() {}
+function __callStatic() {}
+function __get() {}
+function __set() {}
+function __isset() {}
+function __unset() {}
+function __sleep() {}
+function __wakeup() {}
+function __toString() {}
+function __set_state() {}
+function __clone() {}
+function __invoke() {}
+function __debugInfo() {}
+function __autoload() {}
+function __myFunction() {}
+function __my_function() {}
+
+interface Foo
+{
+    function __call() {}
+}
+
+class Magic_Case_Test {
+    function __Construct() {}
+    function __isSet() {}
+    function __tostring() {}
+}
+function __autoLoad() {}
+
+class Foo extends \SoapClient
+{
+    public function __soapCall() {
+        // body
+    }
+}
+
+function _singleUnderscore() {} // Ok.
+
+class single {
+    public function _singleUnderscore() {} // Ok.
+}
+
+function ___tripleUnderscore() {} // Ok.
+
+class triple {
+    public function ___tripleUnderscore() {} // Ok.
+}
+
+/* Magic methods in anonymous classes. */
+$a = new class {
+    function __construct() {}
+    function __destruct() {}
+    function __call() {}
+    function __callStatic() {}
+    function __get() {}
+    function __set() {}
+    function __isset() {}
+    function __unset() {}
+    function __sleep() {}
+    function __wakeup() {}
+    function __toString() {}
+    function __set_state() {}
+    function __clone() {}
+    function __invoke() {}
+    function __debugInfo() {}
+    function __autoload() {}
+    function __myFunction() {}
+    function __my_function() {}
+}
+
+// Closures shouldn't trigger any errors.
+$b = function ($a) {};
+
+class ClassContainingClosure {
+	public function methodContainingClosure() {
+		$a = function($c) {};
+	}
+}

--- a/PHPCompatibility/ruleset.xml
+++ b/PHPCompatibility/ruleset.xml
@@ -1,25 +1,7 @@
 <?xml version="1.0"?>
-
 <ruleset name="PHPCompatibility">
     <description>Coding Standard that checks for PHP version compatibility.</description>
 
     <autoload>./../PHPCSAliases.php</autoload>
-
-    <!-- This rule covers checking for non-magic methods using __ prefix. -->
-    <!-- Covers part 2 of issue 64: https://github.com/wimg/PHPCompatibility/issues/64 -->
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
-        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.NotCamelCaps"/>
-        <exclude name="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps"/>
-    </rule>
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.MethodDoubleUnderscore">
-        <type>warning</type>
-        <!-- Original message: Method name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore -->
-        <message>Method name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use</message>
-    </rule>
-    <rule ref="Generic.NamingConventions.CamelCapsFunctionName.FunctionDoubleUnderscore">
-        <type>warning</type>
-        <!-- Original message: Function name "%s" is invalid; only PHP magic methods should be prefixed with a double underscore -->
-        <message>Function name "%s" is discouraged; PHP has reserved all method names with a double underscore prefix for future use</message>
-    </rule>
 
 </ruleset>


### PR DESCRIPTION
This was previously handled by an upstream sniff - see PR #173 -.

The "problem" with the previous implementation is that when PHPCompatibility is used in a custom ruleset which also includes sniffs from other rulesets, a "conflict" would be created if another ruleset included the `Generic.NamingConventions.CamelCapsFunctionName` sniff as well.

PHPCompatibility silenced two of the error messages from that sniff and unless you are actually aware of that and know how to re-enable those, chances are that this will go unnoticed and non-camelCaps function and method name issues would go unreported because of it.
This breaking of other rulesets, is, of course, undesired.

This is now solved by the introduction of a new sniff which extends the upstream sniff to allow it to benefit from the upstream properties and logic.
The upstream sniff is no longer included via the ruleset, the superfluous error messages are no longer excluded, which effectively prevents the above described issue.

Included unit tests.

Side-note: as this introduces a new sniff, should the next version be called `8.2.0` instead of `8.1.1` ? If so, let's rename the milestone to reflect this.