### PR TITLE
Sniff/isClassProperty: add unit tests covering multi-property definitions

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsClassPropertyTest.php
@@ -115,6 +115,12 @@ class IsClassPropertyTest extends MethodTestFrame
             array('/* Case 24 */', true, true),
             array('/* Case 25 */', false, true),
             array('/* Case 26 */', false, true),
+            array('/* Case 27 */', true),
+            array('/* Case 28 */', true),
+            array('/* Case 29 */', true),
+            array('/* Case 30 */', true),
+            array('/* Case 31 */', true),
+            array('/* Case 32 */', true),
         );
     }
 }

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_class_property.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_class_property.php
@@ -78,3 +78,20 @@ trait MyTrait {
 		$var = false;
 	}
 }
+
+// Multi-property declarations.
+class MyClass {
+	/* Case 27 */
+	public $varA = true,
+		/* Case 28 */
+		$varB = false,
+		/* Case 29 */
+		$varC = 'string';
+
+	/* Case 30 */
+	private $varD = true,
+		/* Case 31 */
+		$varE = false,
+		/* Case 32 */
+		$varF = 'string';
+}


### PR DESCRIPTION
Verifies and safe-guards that multi-property definitions are handled correctly.

------
~~**Note**: the build is currently not passing for the PHPCS check on the PHPCompatibility files because of a known upstream bug.
See https://github.com/squizlabs/PHP_CodeSniffer/issues/1898 and https://github.com/squizlabs/PHP_CodeSniffer/pull/1899 for more details.
This is expected to be fixed soon.~~

The fix for the upstream issue has been merged, so the builds are passing again.