### PR TITLE
New sniff : Functions inspecting arguments report the current parameter value since PHP 7.0

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ArgumentFunctionsReportCurrentValueSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ArgumentFunctionsReportCurrentValueSniff.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\ArgumentFunctionsReportCurrentValue.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Wim Godden <wim.godden@cu.be>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\ArgumentFunctionsReportCurrentValue.
+ *
+ * Functions inspecting function arguments report the current value instead of the original since PHP 7.0.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Wim Godden <wim.godden@cu.be>
+ */
+class ArgumentFunctionsReportCurrentValueSniff extends Sniff
+{
+    /**
+     * A list of functions that, when called, have a different behaviour in PHP 7 when dealing with parameters of the function they're called in.
+     * @var array(string)
+     */
+    
+    protected $changedFunctions = array(
+        'func_get_arg',
+        'func_get_args',
+        'debug_backtrace'
+    );
+    
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STRING);
+
+    }//end register()
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token
+     *                                         in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsAbove('7.0') === false) {
+            return;
+        }
+        
+        $tokens = $phpcsFile->getTokens();
+        
+        $ignore = array(
+            T_DOUBLE_COLON,
+            T_OBJECT_OPERATOR,
+            T_FUNCTION,
+            T_CLASS,
+            T_CONST,
+            T_USE,
+            T_NS_SEPARATOR,
+        );
+        
+        $prevToken = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if (in_array($tokens[$prevToken]['code'], $ignore) === true) {
+            // Not a call to a PHP function.
+            return;
+        }
+        
+        $function   = $tokens[$stackPtr]['content'];
+        $functionLc = strtolower($function);
+
+        if (in_array($functionLc, $this->changedFunctions) === false) {
+            return;
+        }
+
+        if (isset($tokens[$stackPtr]['conditions'])) {
+            foreach ($tokens[$stackPtr]['conditions'] as $condition => $notimportant) {
+                if ($tokens[$condition]['type'] == 'T_FUNCTION') {
+                    $this->addMessage($phpcsFile, 'Functions inspecting arguments report the current parameter value Function since PHP 7.0. Verify if the value is changed somewhere.', $stackPtr, false);
+                }
+            }
+        }
+    }//end process()
+
+
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/ArgumentFunctionsReportCurrentValueSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ArgumentFunctionsReportCurrentValueSniffTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Argument Functions Report Current Value sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Argument Functions Report Current Value sniff tests
+ *
+ * @group deprecatedFunctions
+ * @group functions
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\DeprecatedFunctionsSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Wim Godden <wim.godden@cu.be>
+ */
+class ArgumentFunctionsReportCurrentValueSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/argument_functions_report_current_value.php';
+
+
+    /**
+     * testDeprecatedFunction
+     *
+     * @dataProvider dataFunction
+     *
+     * @param string $functionName      Name of the function.
+     * @param string $deprecatedIn      The PHP version in which the function was deprecated.
+     * @param array  $lines             The line numbers in the test file which apply to this function.
+     * @param string $okVersion         A PHP version in which the function was still valid.
+     * @param string $deprecatedVersion Optional PHP version to test deprecation message with -
+     *                                  if different from the $deprecatedIn version.
+     *
+     * @return void
+     */
+    public function testFunction($functionName, $deprecatedIn, $lines, $okVersion, $deprecatedVersion = null)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+
+        $errorVersion = (isset($deprecatedVersion)) ? $deprecatedVersion : $deprecatedIn;
+        $file         = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error        = "Functions inspecting arguments report the current parameter value Function since PHP 7.0. Verify if the value is changed somewhere.";
+        foreach ($lines as $line) {
+            $this->assertWarning($file, $line, $error);
+        }
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testDeprecatedFunction()
+     *
+     * @return array
+     */
+    public function dataFunction()
+    {
+        return array(
+            array('func_get_arg', '7.0', array(4), '5.6'),
+            array('func_get_args', '7.0', array(5), '5.6'),
+            array('debug_backtrace', '7.0', array(6), '5.6'),
+        );
+    }
+}

--- a/PHPCompatibility/Tests/sniff-examples/argument_functions_report_current_value.php
+++ b/PHPCompatibility/Tests/sniff-examples/argument_functions_report_current_value.php
@@ -1,0 +1,8 @@
+<?php
+function foo($x) {
+    $x++;
+    var_dump(func_get_arg(0));
+    var_dump(func_get_args);
+    var_dump(debug_backtrace());
+}
+foo(1);


### PR DESCRIPTION
See http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.func-parameter-modified
