### PR TITLE
Sniff/isUseOfGlobalConstant: add unit tests covering multi-constant declarations

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/IsUseOfGlobalConstantTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsUseOfGlobalConstantTest.php
@@ -98,6 +98,7 @@ class IsUseOfGlobalConstantTest extends MethodTestFrame
             array('/* Case A7 */', true),
             array('/* Case A8 */', true),
             array('/* Case A9 */', true),
+            array('/* Case A10 */', true),
         );
     }
 }

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_use_of_global_constant.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_use_of_global_constant.php
@@ -134,3 +134,9 @@ const PHP_VERSION_ID = 'something';
 
 /* Case A9 */
 $array[PHP_VERSION_ID] = 'something';
+
+/* Case A10 */
+const ABC = '123',
+      DEF = '456',
+      PHP_VERSION_ID = 'something',
+	  GHI = 789;


### PR DESCRIPTION
Verifies and safe-guards that multi-constant declarations are handled correctly.