### PR TITLE
MethodTestFrame: minor fix

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
+++ b/PHPCompatibility/Tests/BaseClass/MethodTestFrame.php
@@ -147,13 +147,13 @@ abstract class MethodTestFrame extends \PHPUnit_Framework_TestCase
         $end    = $start;
 
         // Limit the token finding to between this and the next case comment.
-        for ($i = ($comment + 1); $i < $start; $i++) {
+        for ($i = ($comment + 1); $i < $end; $i++) {
             if ($tokens[$i]['code'] !== T_COMMENT) {
                 continue;
             }
 
             if (stripos($tokens[$i]['content'], '/* Case') === 0) {
-                $end = ($i - 1);
+                $end = $i;
                 break;
             }
         }


### PR DESCRIPTION
As `$end` is used in a `findNext()` and the `$end` parameter of `findNext()` is _EX_clusive, rather than inclusive - in contrast to `findPrevious()` - see upstream issue squizlabs/PHP_CodeSniffer#1319 -, the `$i - 1` is wrong.

Wasn't causing any issues (yet) as the `Case` comments used so far were always preceded by a T_WHITESPACE anyway, but the code should be correct.