### PR TITLE
Use new PHPCS annotations

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -656,7 +656,8 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             $validScopes[] = T_INTERFACE;
 
             if (defined('T_TRAIT')) {
-                $validScopes[] = constant('T_TRAIT');
+                // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
+                $validScopes[] = T_TRAIT;
             }
         }
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsDeclaredSniff.php
@@ -104,7 +104,8 @@ class ForbiddenNamesAsDeclaredSniff extends Sniff
         );
 
         if (defined('T_TRAIT')) {
-            $targets[] = constant('T_TRAIT');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
+            $targets[] = T_TRAIT;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesAsInvokedFunctionsSniff.php
@@ -82,12 +82,15 @@ class ForbiddenNamesAsInvokedFunctionsSniff extends Sniff
     public function register()
     {
         if (defined('T_FINALLY')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_finallyFound
             $this->targetedTokens[T_FINALLY] = '5.5';
         }
         if (defined('T_INSTEADOF')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_insteadofFound
             $this->targetedTokens[T_INSTEADOF] = '5.4';
         }
         if (defined('T_TRAIT')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
             $this->targetedTokens[T_TRAIT] = '5.4';
         }
 

--- a/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ForbiddenNamesSniff.php
@@ -151,11 +151,13 @@ class ForbiddenNamesSniff extends Sniff
         $tokens = $this->targetedTokens;
 
         if (defined('T_TRAIT')) {
-            $tokens[] = constant('T_TRAIT');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
+            $tokens[] = T_TRAIT;
         }
 
         if (defined('T_ANON_CLASS')) {
-            $tokens[] = constant('T_ANON_CLASS');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $tokens[] = T_ANON_CLASS;
         }
 
         return $tokens;

--- a/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/InternalInterfacesSniff.php
@@ -48,7 +48,8 @@ class InternalInterfacesSniff extends Sniff
         $targets = array(T_CLASS);
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = constant('T_ANON_CLASS');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $targets[] = T_ANON_CLASS;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -562,11 +562,12 @@ class NewClassesSniff extends AbstractNewFeatureSniff
         );
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = constant('T_ANON_CLASS');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $targets[] = T_ANON_CLASS;
         }
 
         if (defined('T_RETURN_TYPE')) {
-            $targets[] = constant('T_RETURN_TYPE');
+            $targets[] = T_RETURN_TYPE;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -119,11 +119,12 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
         );
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = constant('T_ANON_CLASS');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $targets[] = T_ANON_CLASS;
         }
 
         if (defined('T_RETURN_TYPE')) {
-            $targets[] = constant('T_RETURN_TYPE');
+            $targets[] = T_RETURN_TYPE;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NonStaticMagicMethodsSniff.php
@@ -88,11 +88,13 @@ class NonStaticMagicMethodsSniff extends Sniff
         );
 
         if (defined('T_TRAIT')) {
-            $targets[] = constant('T_TRAIT');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_traitFound
+            $targets[] = T_TRAIT;
         }
 
         if (defined('T_ANON_CLASS')) {
-            $targets[] = constant('T_ANON_CLASS');
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_anon_classFound
+            $targets[] = T_ANON_CLASS;
         }
 
         return $targets;

--- a/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedAlternativePHPTagsSniff.php
@@ -45,6 +45,7 @@ class RemovedAlternativePHPTagsSniff extends Sniff
     public function register()
     {
         if (version_compare(PHP_VERSION_ID, '70000', '<') === true) {
+            // phpcs:ignore PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved
             $this->aspTags = (boolean) ini_get('asp_tags');
         }
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RemovedAlternativePHPTagsSniffTest.php
@@ -40,6 +40,7 @@ class RemovedAlternativePHPTagsSniffTest extends BaseSniffTest
     public static function setUpBeforeClass()
     {
         if (version_compare(PHP_VERSION_ID, '70000', '<')) {
+            // phpcs:ignore PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved
             self::$aspTags = (boolean) ini_get('asp_tags');
         }
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,22 +19,6 @@
     <config name="testVersion" value="5.3-99.0"/>
     <rule ref="PHPCompatibility"/>
 
-    <!-- Verified correct usage. -->
-    <rule ref="PHPCompatibility.PHP.DeprecatedIniDirectives.asp_tagsRemoved">
-        <exclude-pattern>*/RemovedAlternativePHPTags*\.php</exclude-pattern>
-    </rule>
-
-    <!-- Verified correct usage. -->
-    <rule ref="PHPCompatibility.PHP.NewConstants.t_finallyFound">
-        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-    </rule>
-    <rule ref="PHPCompatibility.PHP.NewConstants.t_insteadofFound">
-        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-    </rule>
-    <rule ref="PHPCompatibility.PHP.NewConstants.t_traitFound">
-        <exclude-pattern>*/ForbiddenNamesAsInvokedFunctionsSniff\.php</exclude-pattern>
-    </rule>
-
     <!--
         Minimal code style check.
     -->


### PR DESCRIPTION
[PHPCS 3.2.x introduced new inline PHPCS annotations](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.2.0) which allow for far more selective ignores inline.

Up to now, the PHPCompatibility library used either file-based excludes from the ruleset or a work-around by using `constant()`.

Work-arounds to get round PHPCS notices is kind of counter to the whole idea.
Blanket file-based excludes are risky as they can ignore too much.

As the PHPCS check for the PHPCompatibility library is run on a high PHPCS version anyhow (the PHPCS check in Travis runs against PHPCS `master`), we can switch over and start using the new annotations.

This PR removes both the work-arounds as well as the file-based excludes, in favour of using selective inline ignores.