### PR TITLE
DeprecatedTypeCasts: minor simplification

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedTypeCastsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedTypeCastsSniff.php
@@ -68,10 +68,6 @@ class DeprecatedTypeCastsSniff extends AbstractRemovedFeatureSniff
         $tokens    = $phpcsFile->getTokens();
         $tokenType = $tokens[$stackPtr]['type'];
 
-        if (isset($this->deprecatedTypeCasts[$tokenType]) === false) {
-            return;
-        }
-
         $itemInfo = array(
             'name'        => $tokenType,
             'description' => $this->deprecatedTypeCasts[$tokenType]['description'],


### PR DESCRIPTION
Remove superfluous check.

At this time, the sniff only registers the exact tokens needed - i.e. there are no work-arounds in place for cross-PHPCS version compatibility -, so there is no chance that the tokenType would not be one of the target token types.