### PR TITLE
ConstantArraysUsingConst: handle multi-constant declarations correctly

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ConstantArraysUsingConstSniff.php
@@ -52,19 +52,26 @@ class ConstantArraysUsingConstSniff extends Sniff
             return;
         }
 
-        $find = array(
+        $tokens = $phpcsFile->getTokens();
+        $find   = array(
             T_ARRAY             => T_ARRAY,
             T_OPEN_SHORT_ARRAY  => T_OPEN_SHORT_ARRAY,
-            T_CLOSE_SHORT_ARRAY => T_CLOSE_SHORT_ARRAY,
         );
 
-        $hasArray = $phpcsFile->findNext($find, ($stackPtr + 1), null, false, null, true);
-        if ($hasArray !== false) {
+        while (($hasArray = $phpcsFile->findNext($find, ($stackPtr + 1), null, false, null, true)) !== false) {
             $phpcsFile->addError(
                 'Constant arrays using the "const" keyword are not allowed in PHP 5.5 or earlier',
                 $hasArray,
                 'Found'
             );
+
+            // Skip past the content of the array.
+            $stackPtr = $hasArray;
+            if ($tokens[$hasArray]['code'] === T_OPEN_SHORT_ARRAY && isset($tokens[$hasArray]['bracket_closer'])) {
+                $stackPtr = $tokens[$hasArray]['bracket_closer'];
+            } elseif ($tokens[$hasArray]['code'] === T_ARRAY && isset($tokens[$hasArray]['parenthesis_closer'])) {
+                $stackPtr = $tokens[$hasArray]['parenthesis_closer'];
+            }
         }
     }
 }

--- a/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ConstantArraysUsingConstSniffTest.php
@@ -56,6 +56,9 @@ class ConstantArraysUsingConstSniffTest extends BaseSniffTest
             array(12),
             array(19),
             array(25),
+            array(37),
+            array(39),
+            array(41),
         );
     }
 
@@ -87,6 +90,10 @@ class ConstantArraysUsingConstSniffTest extends BaseSniffTest
         return array(
             array(31),
             array(33),
+            array(36),
+            array(38),
+            array(40),
+            array(42),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/constant_arrays_using_const.php
+++ b/PHPCompatibility/Tests/sniff-examples/constant_arrays_using_const.php
@@ -30,4 +30,14 @@ class MyClass {
  */
 const ANIMALS = 'array';
 
-const ABC; // Not an assignment. Useless, but what the heck ;-)
+const DEF; // Not an assignment. Useless, but what the heck ;-)
+
+// Multi-constant declaration.
+const MULTI_A = 1,
+    MULTI_B = array( 'a', 'b' ),
+    MULTI_C = 'string',
+    MULTI_D = ['a', 'b'],
+    MULTI_E = true,
+    MULTI_F = array(
+        ['c', 'd'],
+    );


### PR DESCRIPTION
While not all that common, multi-constant declarations are supported in PHP.

When such a declaration is encountered, the sniff should throw an error for each constant declared with an array value.

Includes additional unit test.