### PR TITLE
DeprecatedNewReference: "removed" not forbidden

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/DeprecatedNewReferenceSniff.php
@@ -66,9 +66,9 @@ class DeprecatedNewReferenceSniff extends Sniff
         $errorCode = 'Deprecated';
 
         if ($this->supportsAbove('7.0') === true) {
-            $error    .= ' and forbidden in PHP 7.0';
+            $error    .= ' and has been removed in PHP 7.0';
             $isError   = true;
-            $errorCode = 'Forbidden';
+            $errorCode = 'Removed';
         }
 
         $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode);

--- a/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/DeprecatedNewReferenceSniffTest.php
@@ -40,7 +40,7 @@ class DeprecatedNewReferenceSniffTest extends BaseSniffTest
         $this->assertWarning($file, $line, 'Assigning the return value of new by reference is deprecated in PHP 5.3');
 
         $file = $this->sniffFile(self::TEST_FILE, '7.0');
-        $this->assertError($file, $line, 'Assigning the return value of new by reference is deprecated in PHP 5.3 and forbidden in PHP 7.0');
+        $this->assertError($file, $line, 'Assigning the return value of new by reference is deprecated in PHP 5.3 and has been removed in PHP 7.0');
 
     }
 


### PR DESCRIPTION
Minor textual change to the error message + error code in line with previous changes to other sniffs.

The change in the errorcode can be considered a BC break, but only for people explicitly excluding the errorcode or ignoring it using the new PHPCS annotations.