### PR TITLE
NewScalarTypeDeclarations: fix incorrect results

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1407,7 +1407,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
                 case 'T_SELF':
                 case 'T_PARENT':
                 case 'T_STATIC':
-                    // Self is valid, the others invalid, but were probably intended as type hints.
+                    // Self and parent are valid, static invalid, but was probably intended as type hint.
                     if (isset($defaultStart) === false) {
                         $typeHint .= $tokens[$i]['content'];
                     }

--- a/PHPCompatibility/Tests/sniff-examples/new_scalar_type_declarations.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_scalar_type_declarations.php
@@ -21,7 +21,7 @@ function foo(boolean $a) {}
 function foo(integer $a) {}
 
 class MyOtherClass extends MyClass {
-    function foo(parent $a) {}
+    function foo(parent $a) {} // Correction: Valid as of PHP 5.2+.
     function bar(static $a) {}
 }
 
@@ -29,7 +29,7 @@ class MyOtherClass extends MyClass {
 function foo(stdClass $a) {}
 
 
-// Class/interface type declaration with self keyword - PHP 5.0+
+// Class/interface type declaration with self keyword - PHP 5.2+
 class MyClass {
     function foo(self $a) {}
 }
@@ -58,3 +58,10 @@ function foo(?int $a) {}
 
 // Object type declaration - PHP 7.2+
 function foo(object $a) {}
+
+// Use of "parent" outside class scope.
+function foo(parent $a) {} // Invalid - not within a class.
+
+namespace test {
+    function foo(parent $a) {} // Invalid - not within a class.
+}


### PR DESCRIPTION
Based on a variety of tests run on 3v4l, I've come to the conclusion that this sniff needs adjusting.

* `parent` is a valid parameter type declaration.
* `self` and `parent` were not recognized properly until PHP 5.2. Before that, they would be treated as class names.

This PR adjusts the sniff to deal correctly with this, based on these finding.

Includes adjusted unit tests.

N.B.: While there has previously been discussion on whether or not the "debug"-type errors like `self used outside of class scope` - introduced in #168 - are warranted, the above mentioned tests showed that as of PHP 7.0, using `self`/`parent` as a type declaration outside class scope results in a fatal error.
I've documented this inline.