### PR TITLE
PHP 5.3: New ArgumentFunctionsUsage sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/ArgumentFunctionsUsageSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/ArgumentFunctionsUsageSniff.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\ArgumentFunctionsUsageSniff.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\ArgumentFunctionsUsageSniff.
+ *
+ * - Prior to PHP 5.3, these functions could not be used as a function call parameter.
+ *
+ * - Calling these functions from the outermost scope of a file which has been included by
+ *   calling `include` or `require` from within a function in the calling file, worked
+ *   prior to PHP 5.3. As of PHP 5.3, this will generate a warning and will always return false/-1.
+ *   If the file was called directly or included in the global scope, calls to these
+ *   functions would already generate a warning prior to PHP 5.3.
+ *
+ * PHP version 5.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ArgumentFunctionsUsageSniff extends Sniff
+{
+
+    /**
+     * The target functions for this sniff.
+     *
+     * @var array
+     */
+    protected $targetFunctions = array(
+        'func_get_args' => true,
+        'func_get_arg'  => true,
+        'func_num_args' => true,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_STRING);
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens     = $phpcsFile->getTokens();
+        $functionLc = strtolower($tokens[$stackPtr]['content']);
+        if (isset($this->targetFunctions[$functionLc]) === false) {
+            return;
+        }
+
+        // Next non-empty token should be the open parenthesis.
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true, null, true);
+        if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $ignore = array(
+            T_DOUBLE_COLON    => true,
+            T_OBJECT_OPERATOR => true,
+            T_FUNCTION        => true,
+            T_NEW             => true,
+        );
+
+        $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+        if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
+            // Not a call to a PHP function.
+            return;
+        } elseif ($tokens[$prevNonEmpty]['code'] === T_NS_SEPARATOR && $tokens[$prevNonEmpty - 1]['code'] === T_STRING) {
+            // Namespaced function.
+            return;
+        }
+
+        $data = $tokens[$stackPtr]['content'];
+
+        /*
+         * Check for usage of the functions in the global scope.
+         *
+         * As PHPCS can not determine whether a file is included from within a function in
+         * another file, so always throw a warning/error.
+         */
+        if ($phpcsFile->hasCondition($stackPtr, array(T_FUNCTION, T_CLOSURE)) === false) {
+            $isError = false;
+            $message = 'Use of %s() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3.';
+
+            if ($this->supportsAbove('5.3') === true) {
+                $isError  = true;
+                $message .= ' As of PHP 5.3, it is no longer supported at all.';
+            }
+
+            $this->addMessage($phpcsFile, $message, $stackPtr, $isError, 'OutsideFunctionScope', $data);
+        }
+
+        /*
+         * Check for usage of the functions as a parameter in a function call.
+         */
+        if ($this->supportsBelow('5.2') === false) {
+            return;
+        }
+
+        if (isset($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            return;
+        }
+
+        $throwError = false;
+
+        $closer = end($tokens[$stackPtr]['nested_parenthesis']);
+        if (isset($tokens[$closer]['parenthesis_owner'])
+            && $tokens[$tokens[$closer]['parenthesis_owner']]['type'] === 'T_CLOSURE'
+        ) {
+            $throwError = true;
+        } else {
+            $opener       = key($tokens[$stackPtr]['nested_parenthesis']);
+            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($opener - 1), null, true);
+            if ($tokens[$prevNonEmpty]['code'] !== T_STRING) {
+                return;
+            }
+
+            $prevPrevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($prevNonEmpty - 1), null, true);
+            if ($tokens[$prevPrevNonEmpty]['code'] === T_FUNCTION) {
+                return;
+            }
+
+            $throwError = true;
+        }
+
+        if ($throwError === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            '%s() could not be used in parameter lists prior to PHP 5.3.',
+            $stackPtr,
+            'InParameterList',
+            $data
+        );
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/ArgumentFunctionsUsageSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ArgumentFunctionsUsageSniffTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Check for the PHP 5.3 changes in allowed usage of the argument functions.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * Check for the PHP 5.3 changes in allowed usage of the argument functions.
+ *
+ * @group argumentFunctions
+ * @group functions
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\ArgumentFunctionsUsageSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class ArgumentFunctionsUsageSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/argument_functions_usage.php';
+
+    /**
+     * testArgumentFunctionsUseAsParameter
+     *
+     * @dataProvider dataArgumentFunctionsUseAsParameter
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testArgumentFunctionsUseAsParameter($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertError($file, $line, '() could not be used in parameter lists prior to PHP 5.3.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider dataArgumentFunctionsUseAsParameter.
+     *
+     * @see testArgumentFunctionsUseAsParameter()
+     *
+     * @return array
+     */
+    public function dataArgumentFunctionsUseAsParameter()
+    {
+        return array(
+            array(7),
+            array(8),
+            array(12),
+            array(17),
+            array(18),
+            array(19),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesUseAsParameter
+     *
+     * @dataProvider dataNoFalsePositivesUseAsParameter
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesUseAsParameter($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesUseAsParameter()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesUseAsParameter()
+    {
+        return array(
+            array(25),
+            array(26),
+            array(27),
+            array(29),
+            array(30),
+            array(31),
+            array(32),
+            array(35),
+        );
+    }
+
+
+    /**
+     * testArgumentFunctionsUseOutsideFunctionScope
+     *
+     * @dataProvider dataArgumentFunctionsUseOutsideFunctionScope
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testArgumentFunctionsUseOutsideFunctionScope($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.0');
+        $this->assertWarning($file, $line, '() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3.');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, '() outside of a user-defined function is only supported if the file is included from within a user-defined function in another file prior to PHP 5.3. As of PHP 5.3, it is no longer supported at all.');
+    }
+
+    /**
+     * Data provider dataArgumentFunctionsUseOutsideFunctionScope.
+     *
+     * @see testArgumentFunctionsUseOutsideFunctionScope()
+     *
+     * @return array
+     */
+    public function dataArgumentFunctionsUseOutsideFunctionScope()
+    {
+        return array(
+            array(43),
+            array(44),
+            array(45),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositivesUseOutsideFunctionScope
+     *
+     * @dataProvider dataNoFalsePositivesUseOutsideFunctionScope
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesUseOutsideFunctionScope($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE);
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesUseOutsideFunctionScope()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesUseOutsideFunctionScope()
+    {
+        return array(
+            array(48),
+            array(49),
+            array(50),
+        );
+    }
+
+
+    /*
+     * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
+     * about the use of these functions in the global scope independently of the PHP version.
+     */
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/argument_functions_usage.php
+++ b/PHPCompatibility/Tests/sniff-examples/argument_functions_usage.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Test pre-PHP 5.3: these functions could not be used in parameter lists.
+ */
+function Foo() {
+	echo Foo(func_get_args());
+	$closure = function( \func_get_args() ) {}; // Parse error, but not our concern.
+}
+
+$closure = function ( $param ) {
+	echo $this->Foo(func_get_args());
+};
+
+class ABC {
+	public function foo() {
+		echo MyNS\Bar(func_get_arg(1));
+		if ( func_num_args() > 0 &&  self::baz( \func_num_args() ) ) {}
+		$b = new MyClass(func_get_args());
+	}
+}
+
+// Test against false positives.
+function Foo() {
+    $a = func_get_args();
+    echo func_get_arg(1);
+    if ( func_num_args() > 0 ) {}
+
+	$d = Baz(Bar::func_get_args());
+	$e = Baz($object->func_get_args());
+	$f = Baz(\Bar\func_get_args());
+	$g = Baz( new Func_Get_Args());
+
+	if ( !function_exists('func_get_args')) {
+		function func_get_args() {}
+	}
+}
+
+
+/*
+ * Test PHP 5.0+: these functions can only be used within a user-defined function.
+ */
+$a = func_get_args();
+echo Bar(func_get_arg(1));
+if ( \func_num_args() > 0 &&  baz( func_num_args() ) ) {} // x 2 (+ 1 x use in param list) .
+
+// Test against false positives.
+$d = Baz(Bar::func_get_args());
+$e = Baz($object->func_get_args());
+$f = Baz(\Bar\func_get_args());


### PR DESCRIPTION
Add a sniff which checks for usage of the `func_get_args()`, `func_get_arg()` and `func_num_args()` functions and the changes regarding these function in PHP 5.3.

Covers:

>  func_get_arg(), func_get_args() and func_num_args() can no longer be called from the outermost scope of a file that has been included by calling include or require from within a function in the calling file.

Ref: http://php.net/manual/en/migration53.incompatible.php

> PHP 5.3.0 This function can now be used in parameter lists.

Refs:
* http://php.net/manual/en/function.func-get-args.php#refsect1-function.func-get-args-changelog
* http://php.net/manual/en/function.func-get-arg.php#refsect1-function.func-get-arg-changelog
* http://php.net/manual/en/function.func-num-args.php#refsect1-function.func-num-args-changelog

Fixes #372