### PR TITLE
PHP 7.3: the `scale` parameter of bcscale() is now optional

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RequiredOptionalFunctionParametersSniff.php
@@ -32,6 +32,13 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
      * @var array
      */
     protected $functionParameters = array(
+        'bcscale' => array(
+            0 => array(
+                'name' => 'scale',
+                '7.2'  => true,
+                '7.3'  => false,
+            ),
+        ),
         'preg_match_all' => array(
             2 => array(
                 'name' => 'matches',
@@ -95,13 +102,14 @@ class RequiredOptionalFunctionParametersSniff extends AbstractComplexVersionSnif
             return;
         }
 
-        $parameterCount = $this->getFunctionCallParameterCount($phpcsFile, $stackPtr);
-        if ($parameterCount === 0) {
+        $parameterCount  = $this->getFunctionCallParameterCount($phpcsFile, $stackPtr);
+        $openParenthesis = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
+
+        // If the parameter count returned > 0, we know there will be valid open parenthesis.
+        if ($parameterCount === 0 && $tokens[$openParenthesis]['code'] !== T_OPEN_PARENTHESIS) {
             return;
         }
 
-        // If the parameter count returned > 0, we know there will be valid open parenthesis.
-        $openParenthesis      = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $stackPtr + 1, null, true, null, true);
         $parameterOffsetFound = $parameterCount - 1;
 
         foreach ($this->functionParameters[$functionLc] as $offset => $parameterDetails) {

--- a/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/RequiredOptionalFunctionParametersSniffTest.php
@@ -65,6 +65,7 @@ class RequiredOptionalFunctionParametersSniffTest extends BaseSniffTest
         return array(
             array('preg_match_all', 'matches', '5.3', array(8), '5.4'),
             array('stream_socket_enable_crypto', 'crypto_type', '5.5', array(9), '5.6'),
+            array('bcscale', 'scale', '7.2', array(12), '7.3'),
         );
     }
 
@@ -96,6 +97,7 @@ class RequiredOptionalFunctionParametersSniffTest extends BaseSniffTest
         return array(
             array(4),
             array(5),
+            array(11),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/required_optional_function_parameters.php
+++ b/PHPCompatibility/Tests/sniff-examples/required_optional_function_parameters.php
@@ -7,3 +7,6 @@ stream_socket_enable_crypto($fp, true, STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
 // These are not.
 preg_match_all('`[a-z]+`', $subject);
 stream_socket_enable_crypto($fp, true);
+
+bcscale( 10 ); // Ok.
+bcscale(); // PHP 7.3+.


### PR DESCRIPTION
> 7.3.0 	bcscale() can now be used to get the current scale factor; when used as setter, it now returns the old scale value. Formerly, scale was mandatory, and bcscale() always returned TRUE.

Ref: http://php.net/manual/en/function.bcscale.php#refsect1-function.bcscale-changelog

This includes a minor bugfix to the sniff logic as the sniff did not take into account that the first parameter of a function may become optional. This is now correctly accounted for.