### PR TITLE
PHP 7.1: detect newly added hash algorithms

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewHashAlgorithmsSniff.php
@@ -73,6 +73,31 @@ class NewHashAlgorithmsSniff extends AbstractNewFeatureSniff
             '5.5' => false,
             '5.6' => true,
         ),
+
+        'sha512/224' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sha512/256' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sha3-224' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sha3-256' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sha3-384' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
+        'sha3-512' => array(
+            '7.0' => false,
+            '7.1' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewHashAlgorithmsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewHashAlgorithmsSniffTest.php
@@ -67,6 +67,12 @@ class NewHashAlgorithmsSniffTest extends BaseSniffTest
             array('fnv132', '5.3', 23, '5.4'),
             array('fnv164', '5.3', 24, '5.4'),
             array('gost-crypto', '5.5', 26, '5.6'),
+            array('sha512/224', '7.0', 28, '7.1'),
+            array('sha512/256', '7.0', 29, '7.1'),
+            array('sha3-224', '7.0', 30, '7.1'),
+            array('sha3-256', '7.0', 31, '7.1'),
+            array('sha3-384', '7.0', 32, '7.1'),
+            array('sha3-512', '7.0', 33, '7.1'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_hash_algorithms.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_hash_algorithms.php
@@ -24,3 +24,10 @@ hash("fnv132", "2nd param", 3, false);
 hash("fnv164");
 
 hash_pbkdf2('gost-crypto');
+
+hash_file('sha512/224');
+hash_hmac_file('sha512/256');
+hash_hmac('sha3-224');
+hash_init('sha3-256');
+hash_pbkdf2('sha3-384');
+hash('sha3-512');


### PR DESCRIPTION
> 7.1.0 	Support for sha512/224, sha512/256, sha3-224, sha3-256, sha3-384 and sha3-512 has been added.

Refs:
* http://php.net/manual/en/function.hash-algos.php
* https://github.com/php/php-src/commit/49a7be069700efbb98dbb076bb0891c748c343f4
* https://github.com/php/php-src/commit/d244b54c67cc2725283b78d4bb128501ae7910d3