### PR TITLE
PHP 7.2: New PCRENewModifiers sniff

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/PCRENewModifiersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/PCRENewModifiersSniff.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\PCRENewModifiers.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniffs\PHP\PregReplaceEModifierSniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\PCRENewModifiers.
+ *
+ * Check for usage of newly added regex modifiers for PCRE functions.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PCRENewModifiersSniff extends PregReplaceEModifierSniff
+{
+
+    /**
+     * Functions to check for.
+     *
+     * @var array
+     */
+    protected $functions = array(
+        'preg_replace'                => true,
+        'preg_filter'                 => true,
+        'preg_grep'                   => true,
+        'preg_match_all'              => true,
+        'preg_match'                  => true,
+        'preg_replace_callback_array' => true,
+        'preg_replace_callback'       => true,
+        'preg_replace'                => true,
+        'preg_split'                  => true,
+    );
+
+    /**
+     * Array listing newly introduced regex modifiers.
+     *
+     * The key should be the modifier (case-sensitive!).
+     * The value should be the PHP version in which the modifier was introduced.
+     *
+     * @var array
+     */
+    protected $newModifiers = array(
+        'J' => array(
+            '7.1' => false,
+            '7.2' => true,
+        ),
+    );
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        // Version used here should be the highest version from the `$newModifiers` array,
+        // i.e. the last PHP version in which a new modifier was introduced.
+        return ($this->supportsBelow('7.2') === false);
+    }
+
+
+    /**
+     * Examine the regex modifier string.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the
+     *                                            stack passed in $tokens.
+     * @param string                $functionName The function which contained the pattern.
+     * @param string                $modifiers    The regex modifiers found.
+     *
+     * @return void
+     */
+    protected function examineModifiers(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $modifiers)
+    {
+        $error = 'The PCRE regex modifier "%s" is not present in PHP version %s or earlier';
+
+        foreach ($this->newModifiers as $modifier => $versionArray) {
+            if (strpos($modifiers, $modifier) === false) {
+                continue;
+            }
+
+            $notInVersion = '';
+            foreach ($versionArray as $version => $present) {
+                if ($notInVersion === '' && $present === false
+                    && $this->supportsBelow($version) === true
+                ) {
+                    $notInVersion = $version;
+                }
+            }
+
+            if ($notInVersion === '') {
+                continue;
+            }
+
+            $errorCode = $modifier . 'ModifierFound';
+            $data      = array(
+                $modifier,
+                $notInVersion,
+            );
+
+            $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+        }
+    }
+
+}//end class

--- a/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/PregReplaceEModifierSniff.php
@@ -73,7 +73,7 @@ class PregReplaceEModifierSniff extends Sniff
      */
     public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        if ($this->supportsAbove('5.5') === false) {
+        if ($this->bowOutEarly() === true) {
             return;
         }
 
@@ -111,6 +111,17 @@ class PregReplaceEModifierSniff extends Sniff
         }
 
     }//end process()
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsAbove('5.5') === false);
+    }
 
 
     /**
@@ -172,22 +183,38 @@ class PregReplaceEModifierSniff extends Sniff
 
         if ($regexEndPos !== false) {
             $modifiers = substr($regex, $regexEndPos + 1);
-
-            if (strpos($modifiers, 'e') !== false) {
-                $error     = '%s() - /e modifier is deprecated since PHP 5.5';
-                $isError   = false;
-                $errorCode = 'Deprecated';
-                $data      = array($functionName);
-
-                if ($this->supportsAbove('7.0')) {
-                    $error    .= ' and removed since PHP 7.0';
-                    $isError   = true;
-                    $errorCode = 'Removed';
-                }
-
-                $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
-            }
+            $this->examineModifiers($phpcsFile, $stackPtr, $functionName, $modifiers);
         }
     }//end processRegexPattern()
+
+
+    /**
+     * Examine the regex modifier string.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param int                   $stackPtr     The position of the current token in the
+     *                                            stack passed in $tokens.
+     * @param string                $functionName The function which contained the pattern.
+     * @param string                $modifiers    The regex modifiers found.
+     *
+     * @return void
+     */
+    protected function examineModifiers(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $functionName, $modifiers)
+    {
+        if (strpos($modifiers, 'e') !== false) {
+            $error     = '%s() - /e modifier is deprecated since PHP 5.5';
+            $isError   = false;
+            $errorCode = 'Deprecated';
+            $data      = array($functionName);
+
+            if ($this->supportsAbove('7.0')) {
+                $error    .= ' and removed since PHP 7.0';
+                $isError   = true;
+                $errorCode = 'Removed';
+            }
+
+            $this->addMessage($phpcsFile, $error, $stackPtr, $isError, $errorCode, $data);
+        }
+    }
 
 }//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/MbstringReplaceEModifierSniffTest.php
@@ -13,7 +13,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * Deprecated Mbstring regex replace e modifier test file.
  *
  * @group mbstringReplaceEModifier
- * @group regexEModifier
+ * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\PHP\MbstringReplaceEModifierSniff
  *

--- a/PHPCompatibility/Tests/Sniffs/PHP/PCRENewModifiersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/PCRENewModifiersSniffTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * New PCRE regex modifiers sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New PCRE regex modifiers sniff tests.
+ *
+ * @group PCRENewModifiers
+ * @group regexModifiers
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\PCRENewModifiersSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class PCRENewModifiersSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/pcre_new_modifiers.php';
+
+    /**
+     * testPCRENewModifier
+     *
+     * @dataProvider dataPCRENewModifier
+     *
+     * @param string $modifier          Regex modifier.
+     * @param string $lastVersionBefore The PHP version just *before* the modifier was introduced.
+     * @param array  $lines             The line numbers in the test file which apply to this modifier.
+     * @param string $okVersion         A PHP version in which the modifier was ok to be used.
+     * @param string $testVersion       Optional PHP version to use for testing the flagged case.
+     *
+     * @return void
+     */
+    public function testPCRENewModifier($modifier, $lastVersionBefore, $lines, $okVersion, $testVersion = null)
+    {
+        $errorVersion = (isset($testVersion)) ? $testVersion : $lastVersionBefore;
+        $file         = $this->sniffFile(self::TEST_FILE, $errorVersion);
+        $error        = "The PCRE regex modifier \"{$modifier}\" is not present in PHP version {$lastVersionBefore} or earlier";
+        foreach ($lines as $line) {
+            $this->assertError($file, $line, $error);
+        }
+
+        $file = $this->sniffFile(self::TEST_FILE, $okVersion);
+        foreach ($lines as $line) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+    /**
+     * dataPCRENewModifier
+     *
+     * @see testPCRENewModifier()
+     *
+     * @return array
+     */
+    public function dataPCRENewModifier()
+    {
+        return array(
+            array('J', '7.1', array(3, 4, 6, 17, 19, 25), '7.2'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line Line number where no error should occur.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.1');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * dataNoFalsePositives
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(18),
+            array(28),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '99.0');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/PregReplaceEModifierSniffTest.php
@@ -13,7 +13,7 @@ use PHPCompatibility\Tests\BaseSniffTest;
  * preg_replace() /e modifier sniff tests
  *
  * @group pregReplaceEModifier
- * @group regexEModifier
+ * @group regexModifiers
  *
  * @covers \PHPCompatibility\Sniffs\PHP\PregReplaceEModifierSniff
  *

--- a/PHPCompatibility/Tests/sniff-examples/pcre_new_modifiers.php
+++ b/PHPCompatibility/Tests/sniff-examples/pcre_new_modifiers.php
@@ -1,0 +1,33 @@
+<?php
+
+preg_match('/some text/mJ', $subject);
+preg_grep('#some text#Ji', $input, $flags);
+
+$text = preg_match_all(
+    '/(?<!\\\\)     # not preceded by a backslash
+      <             # an open bracket
+      >             # close bracket
+    /iJx',
+    '[$1]',
+    $text
+  );
+
+preg_split(
+    [
+        'be' => '/single-quoted/J',
+        'ce' => '#hash-chars (common)#j',
+        'de' => '!exclamations (why not?!eJs',
+    ], $subject, 2
+);
+
+preg_replace_callback_array(
+    [
+        '~[a]+~J' => function ($match) {
+            echo strlen($match[0]), ' matches for "a" found', PHP_EOL;
+        },
+        '~[b]+~i' => function ($match) {
+            echo strlen($match[0]), ' matches for "b" found', PHP_EOL;
+        }
+    ],
+    $subject
+);


### PR DESCRIPTION
... which will initially sniff just for the new `J` modifier which was added in PHP 7.2.

Fixes #556

As the logic needed to retrieve the regex modifiers was already available in the `PregReplaceEModifier` sniff, I've made some small adjustments to that sniff to make it more easily extendable and feature complete.

The new sniff is - of course - accompanied by unit tests, but only cursory as the main logic behind the sniff is already tested extensively in the unit tests for the `PregReplaceEModifier` sniff.
