### PR TITLE
Add more new function parameters

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -778,6 +778,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.5.16' => true,
             ),
         ),
+        'unpack' => array(
+            2 => array(
+                'name' => 'offset',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'unserialize' => array(
             1 => array(
                 'name' => 'options',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -190,6 +190,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.4'  => true,
             ),
         ),
+        'getopt' => array(
+            2 => array(
+                'name' => 'optind',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'gettimeofday' => array(
             0 => array(
                 'name' => 'return_float',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -544,6 +544,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.1.2' => true,
             ),
         ),
+        'pg_fetch_all' => array(
+            1 => array(
+                'name' => 'result_type',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'pg_lo_create' => array(
             1 => array(
                 'name' => 'object_id',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -190,6 +190,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.4'  => true,
             ),
         ),
+        'getenv' => array(
+            1 => array(
+                'name' => 'local_only',
+                '5.5.37'  => false,
+                '5.5.38'  => true, // Also introduced in PHP 5.6.24 and 7.0.9.
+            ),
+        ),
         'getopt' => array(
             2 => array(
                 'name' => 'optind',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -534,6 +534,11 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.2'  => false,
                 '5.3'  => true,
             ),
+            5 => array(
+                'name' => 'iv',
+                '5.6'  => false,
+                '7.0'  => true,
+            ),
         ),
         'openssl_verify' => array(
             3 => array(

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -504,6 +504,18 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '7.1'  => true,
             ),
         ),
+        'openssl_open' => array(
+            4 => array(
+                'name' => 'method',
+                '5.2'  => false,
+                '5.3'  => true,
+            ),
+            5 => array(
+                'name' => 'iv',
+                '5.6'  => false,
+                '7.0'  => true,
+            ),
+        ),
         'openssl_pkcs7_verify' => array(
             5 => array(
                 'name' => 'content',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -551,6 +551,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '7.1'  => true,
             ),
         ),
+        'pg_last_notice' => array(
+            1 => array(
+                'name' => 'option',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'pg_lo_create' => array(
             1 => array(
                 'name' => 'object_id',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -596,6 +596,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '7.1'  => true,
             ),
         ),
+        'php_uname' => array(
+            0 => array(
+                'name' => 'mode',
+                '5.6'  => false,
+                '7.0'  => true,
+            ),
+        ),
         'preg_replace' => array(
             4 => array(
                 'name' => 'count',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -204,6 +204,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '7.0.15' => true,
             ),
         ),
+        'get_headers' => array(
+            2 => array(
+                'name' => 'context',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'get_html_translation_table' => array(
             2 => array(
                 'name'  => 'encoding',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -65,6 +65,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.2'  => true,
             ),
         ),
+        'bcmod' => array(
+            2 => array(
+                'name' => 'scale',
+                '7.1'  => false,
+                '7.2'  => true,
+            ),
+        ),
         'class_implements' => array(
             1 => array(
                 'name' => 'autoload',

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -651,6 +651,16 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.5.0' => false,
                 '5.5.1' => true,
             ),
+            7 => array(
+                'name'  => 'validate_sid',
+                '5.6' => false,
+                '7.0' => true,
+            ),
+            8 => array(
+                'name' => 'update_timestamp',
+                '5.6'  => false,
+                '7.0'  => true,
+            ),
         ),
         'session_start' => array(
             0 => array(

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -496,6 +496,11 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.0'  => false,
                 '5.1'  => true,
             ),
+            6 => array(
+                'name' => 'p7bfilename',
+                '7.1'  => false,
+                '7.2'  => true,
+            ),
         ),
         'openssl_seal' => array(
             4 => array(

--- a/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionParametersSniff.php
@@ -572,6 +572,13 @@ class NewFunctionParametersSniff extends AbstractNewFeatureSniff
                 '5.3'  => true,
             ),
         ),
+        'pg_select' => array(
+            4 => array(
+                'name' => 'result_type',
+                '7.0'  => false,
+                '7.1'  => true,
+            ),
+        ),
         'preg_replace' => array(
             4 => array(
                 'name' => 'count',

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -144,6 +144,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('parse_ini_file', 'scanner_mode', '5.2', array(64), '5.3'),
             array('parse_url', 'component', '5.1.1', array(65), '5.2', '5.1'),
             array('pg_fetch_all', 'result_type', '7.0', array(99), '7.1'),
+            array('pg_last_notice', 'option', '7.0', array(100), '7.1'),
             array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
             array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -89,6 +89,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('file_get_contents', 'maxlen', '5.0', array(27), '5.1'),
             array('filter_input_array', 'add_empty', '5.3', array(28), '5.4'),
             array('filter_var_array', 'add_empty', '5.3', array(29), '5.4'),
+            array('getopt', 'optind', '7.0', array(98), '7.1'),
             array('gettimeofday', 'return_float', '5.0', array(30), '5.1'),
             array('get_defined_functions', 'exclude_disabled', '7.0.14', array(95), '7.1', '7.0'),
             array('get_headers', 'context', '7.0', array(97), '7.1'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -89,6 +89,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('file_get_contents', 'maxlen', '5.0', array(27), '5.1'),
             array('filter_input_array', 'add_empty', '5.3', array(28), '5.4'),
             array('filter_var_array', 'add_empty', '5.3', array(29), '5.4'),
+            array('getenv', 'local_only', '5.5.37', array(105), '5.6', '5.5'),
             array('getopt', 'optind', '7.0', array(98), '7.1'),
             array('gettimeofday', 'return_float', '5.0', array(30), '5.1'),
             array('get_defined_functions', 'exclude_disabled', '7.0.14', array(95), '7.1', '7.0'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -70,6 +70,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('array_unique', 'sort_flags', '5.2.8', array(13), '5.3', '5.2'),
             array('assert', 'description', '5.4.7', array(14), '5.5', '5.4'),
             array('base64_decode', 'strict', '5.1', array(15), '5.2'),
+            array('bcmod', 'scale', '7.1', array(96), '7.2'),
             array('class_implements', 'autoload', '5.0', array(16), '5.1'),
             array('class_parents', 'autoload', '5.0', array(17), '5.1'),
             array('clearstatcache', 'clear_realpath_cache', '5.2', array(18), '5.3'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -141,7 +141,8 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('openssl_open', 'iv', '5.6', array(103), '7.0'),
             array('openssl_pkcs7_verify', 'content', '5.0', array(61), '7.2'), // OK version > version in which last parameter was added to the function.
             array('openssl_pkcs7_verify', 'p7bfilename', '7.1', array(61), '7.2'),
-            array('openssl_seal', 'method', '5.2', array(62), '5.3'),
+            array('openssl_seal', 'method', '5.2', array(62), '7.0'), // OK version > version in which last parameter was added to the function.
+            array('openssl_seal', 'iv', '5.6', array(62), '7.0'),
             array('openssl_verify', 'signature_alg', '5.1', array(63), '5.2'),
             array('parse_ini_file', 'scanner_mode', '5.2', array(64), '5.3'),
             array('parse_url', 'component', '5.1.1', array(65), '5.2', '5.1'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -91,6 +91,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('filter_var_array', 'add_empty', '5.3', array(29), '5.4'),
             array('gettimeofday', 'return_float', '5.0', array(30), '5.1'),
             array('get_defined_functions', 'exclude_disabled', '7.0.14', array(95), '7.1', '7.0'),
+            array('get_headers', 'context', '7.0', array(97), '7.1'),
             array('get_html_translation_table', 'encoding', '5.3.3', array(31), '5.4', '5.3'),
             array('get_loaded_extensions', 'zend_extensions', '5.2.3', array(32), '5.3', '5.2'),
             array('gzcompress', 'encoding', '5.3', array(33), '5.4'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -158,7 +158,9 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('sem_acquire', 'nowait', '5.6', array(71), '7.0'),
             array('session_regenerate_id', 'delete_old_session', '5.0', array(72), '5.1'),
             array('session_set_cookie_params', 'httponly', '5.1', array(73), '5.2'),
-            array('session_set_save_handler', 'create_sid', '5.5.0', array(74), '5.6', '5.5'),
+            array('session_set_save_handler', 'create_sid', '5.5.0', array(74), '7.0', '5.5'), // OK version > version in which last parameter was added to the function.
+            array('session_set_save_handler', 'validate_sid', '5.6', array(74), '7.0'),
+            array('session_set_save_handler', 'update_timestamp', '5.6', array(74), '7.0'),
             array('session_start', 'options', '5.6', array(75), '7.0'),
             array('setcookie', 'httponly', '5.1', array(76), '5.2'),
             array('setrawcookie', 'httponly', '5.1', array(77), '5.2'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -151,6 +151,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
             array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
             array('pg_select', 'result_type', '7.0', array(101), '7.1'),
+            array('php_uname', 'mode', '5.6', array(104), '7.0'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),
             array('preg_replace_callback', 'count', '5.0', array(69), '5.1'),
             array('round', 'mode', '5.2', array(70), '5.3'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -137,6 +137,8 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('openssl_encrypt', 'tag', '7.0', array(60), '7.1'),
             array('openssl_encrypt', 'aad', '7.0', array(60), '7.1'),
             array('openssl_encrypt', 'tag_length', '7.0', array(60), '7.1'),
+            array('openssl_open', 'method', '5.2', array(103), '7.0'), // OK version > version in which last parameter was added to the function.
+            array('openssl_open', 'iv', '5.6', array(103), '7.0'),
             array('openssl_pkcs7_verify', 'content', '5.0', array(61), '7.2'), // OK version > version in which last parameter was added to the function.
             array('openssl_pkcs7_verify', 'p7bfilename', '7.1', array(61), '7.2'),
             array('openssl_seal', 'method', '5.2', array(62), '5.3'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -135,7 +135,8 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('openssl_encrypt', 'tag', '7.0', array(60), '7.1'),
             array('openssl_encrypt', 'aad', '7.0', array(60), '7.1'),
             array('openssl_encrypt', 'tag_length', '7.0', array(60), '7.1'),
-            array('openssl_pkcs7_verify', 'content', '5.0', array(61), '5.1'),
+            array('openssl_pkcs7_verify', 'content', '5.0', array(61), '7.2'), // OK version > version in which last parameter was added to the function.
+            array('openssl_pkcs7_verify', 'p7bfilename', '7.1', array(61), '7.2'),
             array('openssl_seal', 'method', '5.2', array(62), '5.3'),
             array('openssl_verify', 'signature_alg', '5.1', array(63), '5.2'),
             array('parse_ini_file', 'scanner_mode', '5.2', array(64), '5.3'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -143,6 +143,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('openssl_verify', 'signature_alg', '5.1', array(63), '5.2'),
             array('parse_ini_file', 'scanner_mode', '5.2', array(64), '5.3'),
             array('parse_url', 'component', '5.1.1', array(65), '5.2', '5.1'),
+            array('pg_fetch_all', 'result_type', '7.0', array(99), '7.1'),
             array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
             array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -147,6 +147,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('pg_last_notice', 'option', '7.0', array(100), '7.1'),
             array('pg_lo_create', 'object_id', '5.2', array(66), '5.3'),
             array('pg_lo_import', 'object_id', '5.2', array(67), '5.3'),
+            array('pg_select', 'result_type', '7.0', array(101), '7.1'),
             array('preg_replace', 'count', '5.0', array(68), '5.1'),
             array('preg_replace_callback', 'count', '5.0', array(69), '5.1'),
             array('round', 'mode', '5.2', array(70), '5.3'),

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionParametersSniffTest.php
@@ -177,6 +177,7 @@ class NewFunctionParametersSniffTest extends BaseSniffTest
             array('timezone_identifiers_list', 'country', '5.2', array(91), '5.3'),
             array('token_get_all', 'flags', '5.6', array(92), '7.0'),
             array('ucwords', 'delimiters', '5.4.31', array(93), '5.6', '5.4'), // Function introduced in 5.4.31 and 5.5.15.
+            array('unpack', 'offset', '7.0', array(102), '7.1'),
             array('unserialize', 'options', '5.6', array(94), '7.0'),
         );
     }

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -102,3 +102,4 @@ pg_select ($connection, $table_name, $assoc_array, $options, $result_type);
 unpack($format,$data,$offset);
 openssl_open( $sealed_data, &$open_data, $env_key, $priv_key_id, $method, $iv);
 php_uname ("a");
+getenv($varname, true );

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -71,7 +71,7 @@ round(1.55, 1, PHP_ROUND_HALF_EVEN);
 sem_acquire( $sem_identifier, true );
 session_regenerate_id (true);
 session_set_cookie_params($lifetime, $path, $domain, false, true );
-session_set_save_handler( array($handler, 'open'), array($handler, 'close'), array($handler, 'read'), array($handler, 'write'), array($handler, 'destroy'), array($handler, 'gc'), array($handler, 'create_sid') );
+session_set_save_handler( array($handler, 'open'), array($handler, 'close'), array($handler, 'read'), array($handler, 'write'), array($handler, 'destroy'), array($handler, 'gc'), array($handler, 'create_sid'), array($handler, 'validate_sid'), array($handler, 'update_timestamp') );
 session_start(array('bla'));
 setcookie('TestCookie', '', time() - 3600, '/~rasmus/', 'example.com', 1, true);
 setrawcookie('TestCookie', '', time() - 3600, '/~rasmus/', 'example.com', 1, true);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -98,3 +98,4 @@ get_headers( $url, $format, $context );
 getopt($options, $longopts, $optind);
 pg_fetch_all( $result, $result_type );
 pg_last_notice( $connection, $option );
+pg_select ($connection, $table_name, $assoc_array, $options, $result_type);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -97,3 +97,4 @@ bcmod( '100', '10', '2' );
 get_headers( $url, $format, $context );
 getopt($options, $longopts, $optind);
 pg_fetch_all( $result, $result_type );
+pg_last_notice( $connection, $option );

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -58,7 +58,7 @@ mysqli_rollback( $link, $flags, $name ); // NB: 2 new params
 nl2br("Welcome\r\nThis is my HTML document", false);
 openssl_decrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv, $tag, $aad);
 openssl_encrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv, $tag, $aad, $tag_length);
-openssl_pkcs7_verify ( $filename , $flags , $outfilename , $cainfo , $extracerts , $content );
+openssl_pkcs7_verify ( $filename , $flags , $outfilename , $cainfo , $extracerts , $content, $p7bfilename );
 openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2), 'RC4');
 openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA1);
 parse_ini_file('sample.ini', true, INI_SCANNER_RAW);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -95,3 +95,4 @@ $data = unserialize($foo, ["allowed_classes" => false]);
 get_defined_functions(true);
 bcmod( '100', '10', '2' );
 get_headers( $url, $format, $context );
+getopt($options, $longopts, $optind);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -99,3 +99,4 @@ getopt($options, $longopts, $optind);
 pg_fetch_all( $result, $result_type );
 pg_last_notice( $connection, $option );
 pg_select ($connection, $table_name, $assoc_array, $options, $result_type);
+unpack($format,$data,$offset);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -100,3 +100,4 @@ pg_fetch_all( $result, $result_type );
 pg_last_notice( $connection, $option );
 pg_select ($connection, $table_name, $assoc_array, $options, $result_type);
 unpack($format,$data,$offset);
+openssl_open( $sealed_data, &$open_data, $env_key, $priv_key_id, $method, $iv);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -93,3 +93,4 @@ token_get_all('<?php echo; ?>',TOKEN_PARSE);
 ucwords($foo, '|');
 $data = unserialize($foo, ["allowed_classes" => false]);
 get_defined_functions(true);
+bcmod( '100', '10', '2' );

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -101,3 +101,4 @@ pg_last_notice( $connection, $option );
 pg_select ($connection, $table_name, $assoc_array, $options, $result_type);
 unpack($format,$data,$offset);
 openssl_open( $sealed_data, &$open_data, $env_key, $priv_key_id, $method, $iv);
+php_uname ("a");

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -94,3 +94,4 @@ ucwords($foo, '|');
 $data = unserialize($foo, ["allowed_classes" => false]);
 get_defined_functions(true);
 bcmod( '100', '10', '2' );
+get_headers( $url, $format, $context );

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -59,7 +59,7 @@ nl2br("Welcome\r\nThis is my HTML document", false);
 openssl_decrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv, $tag, $aad);
 openssl_encrypt($data, 'aes-256-cbc', $encryption_key, OPENSSL_RAW_DATA, $iv, $tag, $aad, $tag_length);
 openssl_pkcs7_verify ( $filename , $flags , $outfilename , $cainfo , $extracerts , $content, $p7bfilename );
-openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2), 'RC4');
+openssl_seal($data, $sealed, $ekeys, array($pk1, $pk2), 'RC4', 'iv');
 openssl_verify($data, $signature, $public_key_res, OPENSSL_ALGO_SHA1);
 parse_ini_file('sample.ini', true, INI_SCANNER_RAW);
 parse_url($url, PHP_URL_PATH);

--- a/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_function_parameter.php
@@ -96,3 +96,4 @@ get_defined_functions(true);
 bcmod( '100', '10', '2' );
 get_headers( $url, $format, $context );
 getopt($options, $longopts, $optind);
+pg_fetch_all( $result, $result_type );


### PR DESCRIPTION
Discovered while trolling through http://php.net/manual/en/doc.changelog.php. Most of these are not annotated in the migration or source changelogs, though they are in the function documentation changelogs.

See the individual commits for more details.