### PR TITLE
README: remove PHP "not tested" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ PHP Compatibility Coding Standard for PHP CodeSniffer
 [![Dependency Status](https://www.versioneye.com/php/wimg:php-compatibility/badge)](https://www.versioneye.com/php/wimg:php-compatibility)
 
 [![Tested Runtime Badge](http://php-eye.com/badge/wimg/php-compatibility/tested.svg?branch=dev-master)](http://php-eye.com/package/wimg/php-compatibility)
-[![Not Tested Runtime Badge](http://php-eye.com/badge/wimg/php-compatibility/not-tested.svg?branch=dev-master)](http://php-eye.com/package/wimg/php-compatibility)
 
 
 This is a set of sniffs for [PHP CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that checks for PHP version compatibility.


### PR DESCRIPTION
As PHP 5.2 is not supported anymore anyway, it is confusing and misleading to display it as being "not tested".

Other than that, the current "tested" badge does not reflect that the library is tested against PHP 7.2 (and nightly and HHVM).

I've [asked the maintainer of PHP-Eye a question about this on Twitter](https://twitter.com/jrf_nl/status/972472140913049600). Hopefully that will be fixed soon.

[skip ci]