### PR TITLE
Sniff: add three utility methods to handle number recognition

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1742,4 +1742,239 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         return true;
     }
 
+
+    /**
+     * Determine whether the tokens between $start and $end together form a positive number
+     * as recognized by PHP.
+     *
+     * The outcome of this function is reliable for `true`, `false` should be regarded as
+     * "undetermined".
+     *
+     * Note: Zero is *not* regarded as a positive number.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $start       Start of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param int                   $end         End of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param bool                  $allowFloats Whether to only consider integers, or also floats.
+     *
+     * @return bool True if PHP would evaluate the snippet as a positive number.
+     *              False if not or if it could not be reliably determined
+     *              (variable or calculations and such).
+     */
+    public function isPositiveNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
+    {
+        $number = $this->isNumber($phpcsFile, $start, $end, $allowFloats);
+
+        if ($number === false) {
+            return false;
+        }
+
+        return ($number > 0);
+    }
+
+
+    /**
+     * Determine whether the tokens between $start and $end together form a negative number
+     * as recognized by PHP.
+     *
+     * The outcome of this function is reliable for `true`, `false` should be regarded as
+     * "undetermined".
+     *
+     * Note: Zero is *not* regarded as a negative number.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $start       Start of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param int                   $end         End of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param bool                  $allowFloats Whether to only consider integers, or also floats.
+     *
+     * @return bool True if PHP would evaluate the snippet as a negative number.
+     *              False if not or if it could not be reliably determined
+     *              (variable or calculations and such).
+     */
+    public function isNegativeNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
+    {
+        $number = $this->isNumber($phpcsFile, $start, $end, $allowFloats);
+
+        if ($number === false) {
+            return false;
+        }
+
+        return ($number < 0);
+
+    }
+
+    /**
+     * Determine whether the tokens between $start and $end together form a number
+     * as recognized by PHP.
+     *
+     * The outcome of this function is reliable for "true-ish" values, `false` should
+     * be regarded as "undetermined".
+     *
+     * @link https://3v4l.org/npTeM
+     *
+     * Mainly intended for examining variable assignments, function call parameters, array values
+     * where the start and end of the snippet to examine is very clear.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $start       Start of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param int                   $end         End of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param bool                  $allowFloats Whether to only consider integers, or also floats.
+     *
+     * @return int|float|bool The number found if PHP would evaluate the snippet as a number.
+     *                        The return type will be int if $allowFloats is false, if
+     *                        $allowFloats is true, the return type will be float.
+     *                        False will be returned when the snippet does not evaluate to a
+     *                        number or if it could not be reliably determined
+     *                        (variable or calculations and such).
+     */
+    protected function isNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
+    {
+        $stringTokens  = array_flip(\PHP_CodeSniffer_Tokens::$heredocTokens); // Flipping for PHPCS 1.x compat.
+        $stringTokens += array_flip(\PHP_CodeSniffer_Tokens::$stringTokens); // Flipping for PHPCS 1.x compat.
+
+        $validTokens            = array();
+        $validTokens[T_LNUMBER] = true;
+        $validTokens[T_TRUE]    = true; // Evaluates to int 1.
+        $validTokens[T_FALSE]   = true; // Evaluates to int 0.
+
+        if ($allowFloats === true) {
+            $validTokens[T_DNUMBER] = true;
+        }
+
+        $maybeValidTokens = $stringTokens + $validTokens;
+
+        $tokens         = $phpcsFile->getTokens();
+        $searchEnd      = ($end + 1);
+        $negativeNumber = false;
+
+        if (isset($tokens[$start], $tokens[$searchEnd]) === false) {
+            return false;
+        }
+
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $start, $searchEnd, true);
+        if ($nextNonEmpty !== false
+            && ($tokens[$nextNonEmpty]['code'] === T_PLUS
+            || $tokens[$nextNonEmpty]['code'] === T_MINUS)
+        ) {
+
+            if ($tokens[$nextNonEmpty]['code'] === T_MINUS) {
+                $negativeNumber = true;
+            }
+
+            $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);
+        }
+
+        if ($nextNonEmpty === false || isset($maybeValidTokens[$tokens[$nextNonEmpty]['code']]) === false) {
+            return false;
+        }
+
+        $content = false;
+        if ($tokens[$nextNonEmpty]['code'] === T_LNUMBER
+            || $tokens[$nextNonEmpty]['code'] === T_DNUMBER
+        ) {
+            $content = (float) $tokens[$nextNonEmpty]['content'];
+        } elseif ($tokens[$nextNonEmpty]['code'] === T_TRUE) {
+            $content = 1.0;
+        } elseif ($tokens[$nextNonEmpty]['code'] === T_FALSE) {
+            $content = 0.0;
+        } elseif (isset($stringTokens[$tokens[$nextNonEmpty]['code']]) === true) {
+
+            if ($tokens[$nextNonEmpty]['code'] === T_START_HEREDOC
+                || $tokens[$nextNonEmpty]['code'] === T_START_NOWDOC
+            ) {
+                // Skip past heredoc/nowdoc opener to the first content.
+                $firstDocToken = $phpcsFile->findNext(array(T_HEREDOC, T_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
+                if ($firstDocToken === false) {
+                    // Live coding or parse error.
+                    return false;
+                }
+
+                $stringContent = $content = $tokens[$firstDocToken]['content'];
+
+                // Skip forward to the end in preparation for the next part of the examination.
+                $nextNonEmpty = $phpcsFile->findNext(array(T_END_HEREDOC, T_END_NOWDOC), ($nextNonEmpty + 1), $searchEnd);
+                if ($nextNonEmpty === false) {
+                    // Live coding or parse error.
+                    return false;
+                }
+            } else {
+                // Gather subsequent lines for a multi-line string.
+                for ($i = $nextNonEmpty; $i < $searchEnd; $i++) {
+                    if ($tokens[$i]['code'] !== $tokens[$nextNonEmpty]['code']) {
+                        break;
+                    }
+                    $content .= $tokens[$i]['content'];
+                }
+
+                $nextNonEmpty  = --$i;
+                $content       = $this->stripQuotes($content);
+                $stringContent = $content;
+            }
+
+            /*
+             * Regexes based on the formats outlined in the manual, created by JRF.
+             * @link http://php.net/manual/en/language.types.float.php
+             */
+            $regexInt   = '`^\s*[0-9]+`';
+            $regexFloat = '`^\s*(?:[+-]?(?:(?:(?P<LNUM>[0-9]+)|(?P<DNUM>([0-9]*\.(?P>LNUM)|(?P>LNUM)\.[0-9]*)))[eE][+-]?(?P>LNUM))|(?P>DNUM))`';
+
+            $intString   = preg_match($regexInt, $content, $intMatch);
+            $floatString = preg_match($regexFloat, $content, $floatMatch);
+
+            // Does the text string start with a number ? If so, PHP would juggle it and use it as a number.
+            if ($allowFloats === false) {
+                if ($intString !== 1 || $floatString === 1) {
+                    // Found non-numeric start or float. Only integers targetted.
+                    return false;
+                }
+
+                $content = (float) trim($intMatch[0]);
+            } else {
+                if ($intString !== 1 && $floatString !== 1) {
+                    return false;
+                }
+
+                $content = ($floatString === 1) ? (float) trim($floatMatch[0]) : (float) trim($intMatch[0]);
+            }
+
+            // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.
+            if ($intString === 1 && trim($intMatch[0]) === '0'
+                && preg_match('`^\s*(0x[A-Fa-f0-9]+)`', $stringContent, $hexNumberString) === 1
+                && $this->supportsBelow('5.6') === true
+            ) {
+                // The filter extension still allows for hex numeric strings in PHP 7, so
+                // use that to get the numeric value if possible.
+                // If the filter extension is not available, the value will be zero, but so be it.
+                if (function_exists('filter_var')) {
+                    $filtered = filter_var($hexNumberString[1], FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX);
+                    if ($filtered !== false) {
+                        $content = $filtered;
+                    }
+                }
+            }
+        }
+
+        // OK, so we have a number, now is there still more code after it ?
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);
+        if ($nextNonEmpty !== false) {
+            return false;
+        }
+
+        if ($negativeNumber === true) {
+            $content = -$content;
+        }
+
+        if ($allowFloats === false) {
+            return (int) $content;
+        }
+
+        return $content;
+    }
+
 }//end class

--- a/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Will a certain token combination be recognized as a number by PHP ?
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\BaseClass;
+
+/**
+ * isNumber(), isPositiveNumber() and isNegativeNumber() function tests
+ *
+ * @group utilityIsNumber
+ * @group utilityFunctions
+ *
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class IsNumberTest extends MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'is_number.php';
+
+    /**
+     * testIsNumber
+     *
+     * @dataProvider dataIsNumber
+     *
+     * @covers \PHPCompatibility\Sniff::isNumber
+     * @covers \PHPCompatibility\Sniff::isPositiveNumber
+     * @covers \PHPCompatibility\Sniff::isNegativeNumber
+     *
+     * @param string     $commentString    The commentwhich prefaces the target snippet in the test file.
+     * @param bool       $allowFloats      Testing the snippets for integers only or floats as well ?
+     * @param float|bool $isNumber         The expected return value for isNumber().
+     * @param bool       $isPositiveNumber The expected return value for isPositiveNumber().
+     * @param bool       $isNegativeNumber The expected return value for isNegativeNumber().
+     *
+     * @return void
+     */
+    public function testIsNumber($commentString, $allowFloats, $isNumber, $isPositiveNumber, $isNegativeNumber)
+    {
+        $start = ($this->getTargetToken($commentString, T_EQUAL) + 1);
+        $end   = ($this->getTargetToken($commentString, T_SEMICOLON) - 1);
+
+        $result = $this->helperClass->isNumber($this->phpcsFile, $start, $end, $allowFloats);
+        $this->assertSame($isNumber, $result);
+
+        $result = $this->helperClass->isPositiveNumber($this->phpcsFile, $start, $end, $allowFloats);
+        $this->assertSame($isPositiveNumber, $result);
+
+        $result = $this->helperClass->isNegativeNumber($this->phpcsFile, $start, $end, $allowFloats);
+        $this->assertSame($isNegativeNumber, $result);
+    }
+
+    /**
+     * dataIsNumber
+     *
+     * @see testIsNumber()
+     *
+     * {@internal Case I13 is not tested here on purpose as the result depends on the
+     * `testVersion` which we don't use in the utility tests.
+     * For a `testVersion` with a minimum of PHP 7.0, the result will be false.
+     * For a `testVersion` which includes any PHP 5 version, the result will be true.}}
+     *
+     * @return array
+     */
+    public function dataIsNumber()
+    {
+        return array(
+            array('/* Case 1 */', true, false, false, false),
+            array('/* Case 2 */', true, false, false, false),
+            array('/* Case 3 */', true, false, false, false),
+            array('/* Case 4 */', true, false, false, false),
+            array('/* Case 5 */', true, false, false, false),
+            array('/* Case 6 */', true, false, false, false),
+            array('/* Case 7 */', true, false, false, false),
+            array('/* Case 8 */', true, false, false, false),
+            array('/* Case 9 */', true, false, false, false),
+            array('/* Case 10 */', true, false, false, false),
+
+            array('/* Case ZI1 */', false, 0, false, false),
+            array('/* Case ZI2 */', false, 0, false, false),
+            array('/* Case ZI3 */', false, -0, false, false),
+            array('/* Case ZI4 */', false, 0, false, false),
+            array('/* Case ZI5 */', false, -0, false, false),
+
+            array('/* Case ZI1 */', true, 0.0, false, false),
+            array('/* Case ZI2 */', true, 0.0, false, false),
+            array('/* Case ZI3 */', true, -0.0, false, false),
+            array('/* Case ZI4 */', true, 0.0, false, false),
+            array('/* Case ZI5 */', true, -0.0, false, false),
+
+            array('/* Case ZF1 */', false, false, false, false),
+            array('/* Case ZF2 */', false, false, false, false),
+
+            array('/* Case ZF1 */', true, 0.0, false, false),
+            array('/* Case ZF2 */', true, -0.0, false, false),
+
+            array('/* Case I1 */', false, 1, true, false),
+            array('/* Case I2 */', false, -10, false, true),
+            array('/* Case I3 */', false, 10, true, false),
+            array('/* Case I4 */', false, -10, false, true),
+            array('/* Case I5 */', false, 10, true, false),
+            array('/* Case I6 */', false, 10, true, false),
+            array('/* Case I7 */', false, 10, true, false),
+            array('/* Case I8 */', false, -10, false, true),
+            array('/* Case I9 */', false, 10, true, false),
+            array('/* Case I10 */', false, -1, false, true),
+            array('/* Case I11 */', false, 10, true, false),
+            array('/* Case I12 */', false, 10, true, false),
+            array('/* Case I14 */', false, -1, false, true),
+            array('/* Case I15 */', false, 123, true, false),
+
+            array('/* Case I1 */', true, 1.0, true, false),
+            array('/* Case I2 */', true, -10.0, false, true),
+            array('/* Case I3 */', true, 10.0, true, false),
+            array('/* Case I4 */', true, -10.0, false, true),
+            array('/* Case I5 */', true, 10.0, true, false),
+            array('/* Case I6 */', true, 10.0, true, false),
+            array('/* Case I7 */', true, 10.0, true, false),
+            array('/* Case I8 */', true, -10.0, false, true),
+            array('/* Case I9 */', true, 10.0, true, false),
+            array('/* Case I10 */', true, -1.0, false, true),
+            array('/* Case I11 */', true, 10.0, true, false),
+            array('/* Case I12 */', true, 10.0, true, false),
+            array('/* Case I14 */', true, -1.0, false, true),
+            array('/* Case I15 */', true, 123.0, true, false),
+
+            array('/* Case F1 */', false, false, false, false),
+            array('/* Case F2 */', false, false, false, false),
+            array('/* Case F3 */', false, false, false, false),
+            array('/* Case F4 */', false, false, false, false),
+            array('/* Case F5 */', false, false, false, false),
+            array('/* Case F6 */', false, false, false, false),
+            array('/* Case F7 */', false, false, false, false),
+            array('/* Case F8 */', false, false, false, false),
+            array('/* Case F9 */', false, false, false, false),
+            array('/* Case F10 */', false, false, false, false),
+            array('/* Case F11 */', false, false, false, false),
+
+            array('/* Case F1 */', true, 1.23, true, false),
+            array('/* Case F2 */', true, -10.123, false, true),
+            array('/* Case F3 */', true, 10.123, true, false),
+            array('/* Case F4 */', true, -10.123, false, true),
+            array('/* Case F5 */', true, 10.123, true, false),
+            array('/* Case F6 */', true, 10.123, true, false),
+            array('/* Case F7 */', true, 10.123, true, false),
+            array('/* Case F8 */', true, -10E3, false, true),
+            array('/* Case F9 */', true, -10e8, false, true),
+            array('/* Case F10 */', true, 10.123, true, false),
+            array('/* Case F11 */', true, 0.123, true, false),
+        );
+    }
+}

--- a/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
+++ b/PHPCompatibility/Tests/BaseClass/TestHelperPHPCompatibility.php
@@ -39,4 +39,23 @@ class TestHelperPHPCompatibility extends Sniff
     public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
     }
+
+    /**
+     * Wrapper to make the protected parent::isNumber() method testable.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile   The file being scanned.
+     * @param int                   $start       Start of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param int                   $end         End of the snippet (inclusive), i.e. this
+     *                                           token will be examined as part of the snippet.
+     * @param bool                  $allowFloats Whether to only consider integers, or also floats.
+     *
+     * @return float|bool The number found if PHP would evaluate the snippet as a number.
+     *                    False if not or if it could not be reliably determined
+     *                    (variable or calculations and such).
+     */
+    public function isNumber(\PHP_CodeSniffer_File $phpcsFile, $start, $end, $allowFloats = false)
+    {
+        return parent::isNumber($phpcsFile, $start, $end, $allowFloats);
+    }
 }

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * Make sure that numbers are correctly identified.
+ *
+ * The below should *NOT* be recognized as numbers.
+ */
+ 
+/* Case 1 */
+$a = [];
+
+/* Case 2 */
+$a = - $b;
+
+/* Case 3 */
+$a = - 'not a numeric string';
+
+/* Case 4 */
+$a = +;
+
+/* Case 5 */
+$a = new SomeClass;
+
+/* Case 6 */
+$a = 1-;
+
+/* Case 7 */
+$a = 1.23-;
+
+/* Case 8 */
+$a = 1.23 - 1;
+
+/* Case 9 */
+$a = 5 * 8;
+
+/* Case 10 */
+$a = '10 things' . ' or nothing';
+
+/*
+ * Make sure that zeo numbers are correctly identified.
+ *
+ * The below should be recognized as numbers (integers).
+ */
+
+/* Case ZI1 */
+$a = 0;
+
+/* Case ZI2 */
+$a = +0;
+
+/* Case ZI3 */
+$a = - false;
+
+/* Case ZI4 */
+$a = '0';
+
+/* Case ZI5 */
+$a = - '        0 things';
+
+/*
+ * Make sure that zero numbers are correctly identified.
+ *
+ * The below should be recognized as numbers (integers).
+ */
+
+/* Case ZF1 */
+$a = 0.0;
+
+/* Case ZF2 */
+$a = - 0.0000000000;
+
+
+/*
+ * Make sure that negative numbers are correctly identified.
+ *
+ * The below should be recognized as negative numbers (integers).
+ */
+
+/* Case I1 */
+$a = 1;
+
+/* Case I2 */
+$a = -10;
+
+/* Case I3 */
+$a = /* */     +          10;
+
+/* Case I4 */
+$a = - /* comment */ 10;
+
+/* Case I5 */
+$a = +
+    // comment
+	10;
+
+/* Case I6 */
+$a = '10';
+
+/* Case I7 */
+$a = +  /* comment */ "10";
+
+/* Case I8 */
+$a = - '10 barbary lane'; // PHP 7.1+: Non well-formed numeric value, but will still work.
+
+/* Case I9 */
+$a = <<<EOT
+10
+EOT;
+
+/* Case I10 */
+// PHP will only look at the first line!
+$a = - <<<'EOT'
+1
+0
+EOT;
+
+/* Case I11 */
+$a = '        10 barbary lane';
+
+/* Case I12 */
+$a = + '
+        10 barbary lane';
+
+/* Case I13 */
+$a = - '0xCC00F9'; // Though the behaviour is different between PHP 5 vs PHP 7.
+
+/* Case I14 */
+$a = - true;
+
+/* Case I15 */
+$a = + '  0123 things';
+
+
+/*
+ * Make sure that numbers are correctly identified.
+ *
+ * The below should be recognized as numbers (floats).
+ */
+
+/* Case F1 */
+$a = 1.23;
+
+/* Case F2 */
+$a = -10.123;
+
+/* Case F3 */
+$a = +          10.123;
+
+/* Case F4 */
+$a = - /* comment */ 10.123;
+
+/* Case F5 */
+$a = +
+    // phpcs:ignore Standard.Category.Sniff -- testing handling of PHPCS annotations.
+	10.123;
+
+/* Case F6 */
+$a = '10.123';
+
+/* Case F7 */
+$a = +  /* comment */ "10.123";
+
+/* Case F8 */
+$a = - '10E3 barbary lane'; // PHP 7.1+: Non well-formed numeric value, but will still work.
+
+/* Case F9 */
+$a = - '10e8 barbary lane'; // PHP 7.1+: Non well-formed numeric value, but will still work.
+
+/* Case F10 */
+$a = <<<EOT
+10.123
+EOT;
+
+/* Case F11 */
+$a = +'0.123';


### PR DESCRIPTION
These methods can be used to determine if variable assignments, function call parameters or array values would be regarded as a (positive/negative) number by PHP.

The `isNumber()` method is used to determine whether something would be regarded as a number by PHP.
This method takes type juggling from string and boolean to integer/float into account.

The method will return `false` if something isn't a number as well as when it couldn't be reliably determined, so should only be used for testing whether something definitely *is* a number (well, that is _would be regarded as a number by PHP_).

The method will return `false` when it encounters calculations, even when all parts of the calculation are numbers. Handling this even better, is something which could possibly be added later (in a future PR). For now, number recognition will already be greatly improved when using these utility methods.

The additional utility methods `isPositiveNumber()` and `isNegativeNumber()` are mostly there to prevent duplicate code in individual sniffs.

Includes extensive unit tests.

N.B.: There are two new sniffs upcoming in which these methods will be used, aside from the bugfix for the negative bitshift sniff.

----

Note: the build containing the CS check will currently fail due to an upstream change (new sniff introduced into PSR2). I will send in a separate PR to deal with that.