### PR TITLE
ForbiddenNegativeBitshift: fix false positive and underreporting

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1631,5 +1631,4 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
 
         return $content;
     }
-
 }//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/ForbiddenNegativeBitshiftSniffTest.php
@@ -51,6 +51,9 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
         return array(
             array(3),
             array(4),
+            array(5),
+            array(7),
+            array(8),
         );
     }
 
@@ -80,11 +83,12 @@ class ForbiddenNegativeBitshiftSniffTest extends BaseSniffTest
     public function dataNoFalsePositives()
     {
         return array(
-            array(6),
-            array(7),
-            array(8),
-            //array(9), - currently gives a false positive, @todo: uncomment when fixed.
+            array(10),
+            array(11),
             array(12),
+            array(13),
+            array(16),
+            array(19),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/forbidden_negative_bitshift.php
+++ b/PHPCompatibility/Tests/sniff-examples/forbidden_negative_bitshift.php
@@ -2,11 +2,18 @@
 
 var_dump(1 >> -1); // Bad.
 var_dump(1 >> - 1); // Bad.
+var_dump(1 << -2); // Bad.
+$a = 1;
+$a >>= -2; // Bad;
+$a <<= -1; // Bad;
 
 var_dump(1 >> 1); // Ok.
 var_dump(1 >> $variable); // Ok.
 var_dump(1 >> - $variable); // Ok - as we don't know whether the contents of $variable is positive or negative.
 var_dump(1 >> ($variable - 1)); // Ok - as we don't know whether the contents of $variable is positive or negative.
+
+// Issue #294/#466.
+return ($a >> $b) & ~(1 << (8 * PHP_INT_SIZE - 1) >> ($b - 1));
 
 // Don't throw errors on live code review.
 var_dump(1 >>


### PR DESCRIPTION
### Fix underreporting

The `ForbiddenNegativeBitshift` was only listening to "bitshift right", while the change made in PHP 7.0 also affects:
* bitshift left
* bitshift left assignments
* bitshift right assignments

These tokens have now been added to the array to listen to and negative bitshifting for these will now also be reported.

Refs:
* http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.integers.negative-bitshift
* https://wiki.php.net/rfc/integer_semantics

### Fix false positives as reported in #294 and #466

The sniff should err on the side of caution and only report when it can be determined with some form of certainty that the operand is a negative number.

I.e. calculations with variables which may or may not result in a negative number should not be reported.

To this end, the new `isNegativeNumber()` utility method is used to better determine whether the operand to the right of the operator is a negative number.

### Other

* Includes a minor improvement to the error message, which will now actually show the right operand as used to determine that the bitshift was done by a negative number.
*  This PR also adds a duplicate of the upstream `findEndOfStatement()` method to the `PHPCSHelper` class as that method is not available in PHPCS 1.x.
    I haven't checked whether other sniffs could also benefit from using the upstream method now it's available, if so, that's for a future PR.

Includes additional unit tests.

Fixes #294
Fixes #466
