### PR TITLE
Add a WordPress specific PHPCompatibility ruleset

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,27 @@ Please make sure that your pull request contains unit tests covering what's bein
 * All code should comply with the PHPCompatibility coding standards.
     The ruleset used by PHPCompatibility is largely based on PSR-2 with minor variations and some additional checks for documentation and such.
 
+### Framework/CMS specific rulesets
+
+As of PHPCompatibility 8.2.0, framework/CMS specific rulesets will be accepted to be hosted from within this repository.
+
+A framework/CMS specific ruleset will generally contain `<exclude ...>` directives for backfills provided by the framework/CMS to prevent false positives.
+
+> A backfill is a function/constant/class (etc) which has been added to PHP in a later version than the minimum supported version of the framework/CMS and for which a function/constant/class of the same name is included in the framework/CMS when a PHP version is detected in which the function/constant/class did not yet exist.
+
+These rulesets will not be actively maintained by the maintainers of PHPCompatibility.
+
+The communities behind these PHP frameworks/CMSes are strongly encouraged to maintain these rulesets and pull requests with updates will be accepted gladly.
+
+**Note:**
+* It is recommended to include a link to the framework/CMS source file where the backfill is declared when sending in a pull request adding a new backfill for one of these rulesets.
+* If the backfills provided by different major versions of frameworks/CMSes are signficantly different, separate rulesets for the relevant major versions of frameworks/CMSes will be accepted.
+* Framework/CMS specific rulesets should always contain the `<autoload>` directive as included in the [PHPCompatibility ruleset](https://github.com/wimg/PHPCompatibility/blob/master/PHPCompatibility/ruleset.xml#L5).
+* Framework/CMS specific ruleset should **_not_** contain a `<config name="testVersion" value="..."/>` directive.
+
+    While a framework/CMS may have a certain minimum PHP version, projects based on the framework/CMS might have a different (higher) minimum PHP version.
+    As support for overruling a `<config>` directive [is patchy](https://github.com/squizlabs/PHP_CodeSniffer/issues/1821), it should be recommended to set the desired `testVersion` either from the command line or in a project-specific custom ruleset.
+
 
 Running the Sniff Tests
 -----------------------

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ Sniffing your code for compatibility with specific PHP version(s)
 
 More information can be found on Wim Godden's [blog](http://techblog.wimgodden.be/tag/codesniffer).
 
+
+### Using a framework/CMS specific ruleset
+
+As of PHPCompatibility 8.2.0, this library ships with a [limited set of framework/CMS specific ruleset(s)](https://github.com/wimg/PHPCompatibility/tree/master/framework-rulesets).
+
+Framework/CMS specific ruleset do not set the minimum PHP version for your project, so you will still need to pass a `testVersion` to get the most accurate results.
+
+* To use a framework/CMS specific ruleset from the command-line:
+    ```bash
+    phpcs -p . --standard=path/to/PHPCompatibility/framework-rulesets/framework-name.xml --runtime-set testVersion 5.5-
+    ```
+
+* To use a framework/CMS specific ruleset from within a custom ruleset - more about those below -, it is **strongly** recommended to use a Composer-based install so the path to PHPCompatibility will be predictable and the same for all users of the custom ruleset.
+    ```xml
+    <config name="testVersion" value="5.5-"/>
+    <rule ref="./vendor/wimg/php-compatibility/framework-rulesets/framework-name.xml"/>
+    ```
+    The path should be an absolute path or the path relative to the final ruleset in the root of a project.
+
+
 Using a custom ruleset
 ------------------------------
 Like with any PHP CodeSniffer standard, you can add PHPCompatibility to a custom PHP CodeSniffer ruleset.

--- a/framework-rulesets/wordpress.xml
+++ b/framework-rulesets/wordpress.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<ruleset name="PHPCompatibility-WP">
+    <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+
+    <autoload>./../PHPCSAliases.php</autoload>
+
+    <!--
+    The WordPress minimum PHP requirement is PHP 5.2.4.
+    Add the following in your project PHPCS ruleset to enforce this:
+    <config name="testVersion" value="5.2-"/>
+    
+    This directive is not included in this ruleset as individual projects may use
+    a different (higher) minimum PHP version.
+    -->
+
+    <rule ref="PHPCompatibility">
+        <!-- Whitelist PHP native classes, interfaces, functions and constants which
+             are back-filled by WP.
+
+             Based on:
+             * /wp-includes/compat.php
+             * /wp-includes/random_compat/random.php
+        -->
+        <exclude name="PHPCompatibility.PHP.NewClasses.errorFound"/>
+        <exclude name="PHPCompatibility.PHP.NewClasses.typeerrorFound"/>
+
+        <exclude name="PHPCompatibility.PHP.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.PHP.NewConstants.php_version_idFound"/>
+
+        <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_intFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.random_bytesFound"/>
+        <exclude name="PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound"/>
+
+        <exclude name="PHPCompatibility.PHP.NewInterfaces.jsonserializableFound"/>
+    </rule>
+
+    <!-- Whitelist the WP Core mysql_to_rfc3339() function. -->
+    <rule ref="PHPCompatibility.PHP.RemovedExtensions">
+        <properties>
+            <property name="functionWhitelist" type="array" value="mysql_to_rfc3339"/>
+        </properties>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
Frameworks/CMSes often provide backfills for PHP native functionality which is not available in the minimum PHP version supported by the framework/CMS.

As suggested in #530, this is a first PR adding a framework specific ruleset to PHPCompatibility.

To give some context:
In the WordPress community, there is currently a project under way called [Tide](https://make.wordpress.org/tide/).
This project uses the PHPCompatibility library to analyse all the plugins (50.000+) and themes (3.000+) hosted on wordpress.org and will in the near future be used to start displaying PHP compatibility information for each of them on the wordpress.org website.

With that in mind, I expect a significant number of developers in the WordPress community will want to start using PHPCompatibility as part of their QA process.

WordPress provides a number of backfills. Now if each of these developers needs to figure out the backfills in WP themselves, I expect we'll see a significant number of support requests related to this while our time is better spend on writing/improving sniffs.

So providing a ready to use framework specific ruleset will make life easier both for the WP devs who want to start using PHPCompatibility as well as for ourselves.

Notes:
* Adds a new dedicated subdirectory `framework-rulesets` with initially a `wordpress.xml` ruleset.
* Adds a new section to the `README` which explains how projects can use framework/CMS specific rulesets as hosted in this repository.
    The instructions included have been tested in a project using both a company based ruleset as well as a project ruleset, i.e. the following ruleset logic has been tested and found working based on the included instructions:
    * project ruleset in project root -> PHPCompatibility in `vendor/wimg/php-compatibility`.
    * project ruleset in project root -> Company ruleset in `vendor/company/companyCS` -> PHPCompatibility in `vendor/wimg/php-compatibility`.
* Adds a new section to the `CONTRIBUTING` document with some basic guidelines for adding/contributing to these type of rulesets.

Related to #530. I suggest leaving the issue open for now until at least a second framework/CMS specific ruleset has been added.

-----

Additional considerations:

As the path to these custom rulesets will - depending on the chosen installation method - not always be predictable, using these custom rulesets will not be so easy for non-Composer users of PHPCompatibility.
And even from Composer users, I expect we'll see some support requests.

The alternative would have been to add a `PHPCompatibility-WP` directory with a `ruleset.xml` file which would allow the ruleset to be registered with PHPCS under its own name and used as `--standard=PHPCompatibility-WP`.

The reasons I did not do so at this time, is that - if a lot of different framework specific ruleset are added -, this would mean that the PHPCompatibility repository would add a lot of named rulesets to a PHPCS install making the list of installed standards huge.

If/when more framework/CMS specific rulesets are added and they prove popular, I would suggest to consider moving the PHPCompatibility repository to a dedicated organisation.
This will then allow for more repositories to be added to the organisation, opening the way for `PHPCompatibility-WP`, `PHPCompatibility-Drupal`, `PHPCompatibility-Laraval` (etc) repositories which *would* add named rulesets for their respective frameworks.