### PR TITLE
Composer: allow for PHPUnit 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "squizlabs/php_codesniffer" : "^2.2 || ^3.0.2"
   },
   "require-dev" : {
-    "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
+    "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
   },
   "conflict": {
     "squizlabs/php_codesniffer": "2.6.2"


### PR DESCRIPTION
PHPUnit 7.x has come out in the mean time and is already in use on some of the Travis images (notably the images for PHP 7.2 and nightly).

Looks like the current unit test suite will work on PHPUnit 7.x without issues, so let's indicate that.

Also makes sure that if PHPUnit 4.x is used, it will get a compatible version as per https://github.com/wimg/PHPCompatibility/pull/511#issuecomment-335676926.