### PR TITLE
PHP 5.6: New sniff to detect constant scalar expressions

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewConstantScalarExpressionsSniff.php
@@ -1,0 +1,565 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewConstantScalarExpressionsSniff.
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewConstantScalarExpressionsSniff.
+ *
+ * Since PHP 5.6, it is now possible to provide a scalar expression involving
+ * numeric and string literals and/or constants in contexts where PHP previously
+ * expected a static value, such as constant and property declarations and
+ * default function arguments.
+ *
+ * PHP version 5.6
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewConstantScalarExpressionsSniff extends Sniff
+{
+
+    /**
+     * Error message.
+     *
+     * @var string
+     */
+    const ERROR_PHRASE = 'Constant scalar expressions are not allowed %s in PHP 5.5 or earlier.';
+
+    /**
+     * Partial error phrases to be used in combination with the error message constant.
+     *
+     * @var array
+     */
+    protected $errorPhrases = array(
+        'const'     => 'when defining constants using the const keyword',
+        'property'  => 'in property declarations',
+        'staticvar' => 'in static variable declarations',
+        'default'   => 'in default function arguments',
+    );
+
+    /**
+     * Tokens which were allowed to be used in these declarations prior to PHP 5.6.
+     *
+     * This list will be enriched in the setProperties() method.
+     *
+     * @var array
+     */
+    protected $safeOperands = array(
+        T_LNUMBER                  => T_LNUMBER,
+        T_DNUMBER                  => T_DNUMBER,
+        T_CONSTANT_ENCAPSED_STRING => T_CONSTANT_ENCAPSED_STRING,
+        T_TRUE                     => T_TRUE,
+        T_FALSE                    => T_FALSE,
+        T_NULL                     => T_NULL,
+
+        T_LINE                     => T_LINE,
+        T_FILE                     => T_FILE,
+        T_DIR                      => T_DIR,
+        T_FUNC_C                   => T_FUNC_C,
+        T_CLASS_C                  => T_CLASS_C,
+        T_METHOD_C                 => T_METHOD_C,
+        T_NS_C                     => T_NS_C,
+
+        // Special cases:
+        T_NS_SEPARATOR             => T_NS_SEPARATOR,
+        /*
+         * This can be neigh anything, but for any usage except constants,
+         * the T_STRING will be combined with non-allowed tokens, so we should be good.
+         */
+        T_STRING                   => T_STRING,
+    );
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        // Set the properties up only once.
+        $this->setProperties();
+
+        return array(
+            T_CONST,
+            T_VARIABLE,
+            T_FUNCTION,
+            T_CLOSURE,
+            T_STATIC,
+        );
+    }
+
+
+    /**
+     * Make some adjustments to the $safeOperands property.
+     *
+     * @return void
+     */
+    public function setProperties()
+    {
+        /*
+         * Not available on PHPCS 1.x icw PHP 5.3.
+         * Not a problem for recognition as when the token is not available
+         * __TRAIT__ will be tokenized as T_STRING which will pass.
+         */
+        if (defined('T_TRAIT_C') === true) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_trait_cFound
+            $this->safeOperands[T_TRAIT_C] = T_TRAIT_C;
+        }
+
+        $emptyTokens   = \PHP_CodeSniffer_Tokens::$emptyTokens;
+        $heredocTokens = \PHP_CodeSniffer_Tokens::$heredocTokens;
+        if (version_compare(PHPCSHelper::getVersion(), '2.0', '<')) {
+            // PHPCS 1.x compat.
+            $emptyTokens   = array_combine($emptyTokens, $emptyTokens);
+            $heredocTokens = array_combine($heredocTokens, $heredocTokens);
+        }
+
+        $this->safeOperands = $this->safeOperands + $heredocTokens + $emptyTokens;
+    }
+
+
+    /**
+     * Do a version check to determine if this sniff needs to run at all.
+     *
+     * @return bool
+     */
+    protected function bowOutEarly()
+    {
+        return ($this->supportsBelow('5.5') !== true);
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void|int Null or integer stack pointer to skip forward.
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->bowOutEarly() === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        switch ($tokens[$stackPtr]['type']) {
+            case 'T_FUNCTION':
+            case 'T_CLOSURE':
+                $params = PHPCSHelper::getMethodParameters($phpcsFile, $stackPtr);
+                if (empty($params)) {
+                    // No parameters.
+                    return;
+                }
+
+                $funcToken = $tokens[$stackPtr];
+
+                if (isset($funcToken['parenthesis_owner'], $funcToken['parenthesis_opener'], $funcToken['parenthesis_closer']) === false
+                    || $funcToken['parenthesis_owner'] !== $stackPtr
+                    || isset($tokens[$funcToken['parenthesis_opener']], $tokens[$funcToken['parenthesis_closer']]) === false
+                ) {
+                    // Hmm.. something is going wrong as these should all be available & valid.
+                    return;
+                }
+
+                $opener = $funcToken['parenthesis_opener'];
+                $closer = $funcToken['parenthesis_closer'];
+
+                // Which nesting level is the one we are interested in ?
+                $nestedParenthesisCount = 1;
+                if (isset($tokens[$opener]['nested_parenthesis'])) {
+                    $nestedParenthesisCount += count($tokens[$opener]['nested_parenthesis']);
+                }
+
+                foreach ($params as $param) {
+                    if (isset($param['default']) === false) {
+                        continue;
+                    }
+
+                    $end = $param['token'];
+                    while (($end = $phpcsFile->findNext(array(T_COMMA, T_CLOSE_PARENTHESIS), ($end + 1), ($closer + 1))) !== false) {
+                        $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $nestedParenthesisCount);
+                        if ($maybeSkipTo !== true) {
+                            $end = $maybeSkipTo;
+                            continue;
+                        }
+
+                        // Ignore closing parenthesis/bracket if not 'ours'.
+                        if ($tokens[$end]['code'] === T_CLOSE_PARENTHESIS && $end !== $closer) {
+                            continue;
+                        }
+
+                        // Ok, we've found the end of the param default value declaration.
+                        break;
+                    }
+
+                    if ($this->isValidAssignment($phpcsFile, $param['token'], $end) === false) {
+                        $this->throwError($phpcsFile, $param['token'], 'default', $param['content']);
+                    }
+                }
+
+                /*
+                 * No need for the sniff to be triggered by the T_VARIABLEs in the function
+                 * definition as we've already examined them above, so let's skip over them.
+                 */
+                return $closer;
+
+            case 'T_VARIABLE':
+            case 'T_STATIC':
+            case 'T_CONST':
+                $type = 'const';
+
+                // Filter out non-property declarations.
+                if ($tokens[$stackPtr]['code'] === T_VARIABLE) {
+                    if ($this->isClassProperty($phpcsFile, $stackPtr) === false) {
+                        return;
+                    }
+
+                    $type = 'property';
+
+                    // Move back one token to have the same starting point as the others.
+                    $stackPtr = ($stackPtr - 1);
+                }
+
+                // Filter out late static binding and class properties.
+                if ($tokens[$stackPtr]['code'] === T_STATIC) {
+                    $next = $phpcsFile->findNext(
+                        \PHP_CodeSniffer_Tokens::$emptyTokens,
+                        ($stackPtr + 1),
+                        null,
+                        true,
+                        null,
+                        true
+                    );
+                    if ($next === false || $tokens[$next]['code'] !== T_VARIABLE) {
+                        // Late static binding.
+                        return;
+                    }
+
+                    if ($this->isClassProperty($phpcsFile, $next) === true) {
+                        // Class properties are examined based on the T_VARIABLE token.
+                        return;
+                    }
+                    unset($next);
+
+                    $type = 'staticvar';
+                }
+
+                $endOfStatement = $phpcsFile->findNext(array(T_SEMICOLON, T_CLOSE_TAG), ($stackPtr + 1));
+                if ($endOfStatement === false) {
+                    // No semi-colon - live coding.
+                    return;
+                }
+
+                $targetNestingLevel = 0;
+                if (isset($tokens[$stackPtr]['nested_parenthesis']) == true) {
+                    $targetNestingLevel = count($tokens[$stackPtr]['nested_parenthesis']);
+                }
+
+                // Examine each variable/constant in multi-declarations.
+                $start = $stackPtr;
+                $end   = $stackPtr;
+                while (($end = $phpcsFile->findNext(array(T_COMMA, T_SEMICOLON, T_OPEN_SHORT_ARRAY, T_CLOSE_TAG), ($end + 1), ($endOfStatement + 1))) !== false) {
+
+                    $maybeSkipTo = $this->isRealEndOfDeclaration($tokens, $end, $targetNestingLevel);
+                    if ($maybeSkipTo !== true) {
+                        $end = $maybeSkipTo;
+                        continue;
+                    }
+
+                    $start = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($start + 1), $end, true);
+                    if ($start === false
+                        || ($tokens[$stackPtr]['code'] === T_CONST && $tokens[$start]['code'] !== T_STRING)
+                        || ($tokens[$stackPtr]['code'] !== T_CONST && $tokens[$start]['code'] !== T_VARIABLE)
+                    ) {
+                        // Shouldn't be possible.
+                        continue;
+                    }
+
+                    if ($this->isValidAssignment($phpcsFile, $start, $end) === false) {
+                        // Create the "found" snippet.
+                        $content    = '';
+                        $tokenCount = ($end - $start);
+                        if ($tokenCount < 20) {
+                            // Prevent large arrays from being added to the error message.
+                            $content = $phpcsFile->getTokensAsString($start, ($tokenCount + 1));
+                        }
+
+                        $this->throwError($phpcsFile, $start, $type, $content);
+                    }
+
+                    $start = $end;
+                }
+
+                // Skip to the end of the statement to prevent duplicate messages for multi-declarations.
+                return $endOfStatement;
+        }
+    }
+
+
+    /**
+     * Is a value declared and is the value declared valid pre-PHP 5.6 ?
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     * @param int                   $end       The end of the value definition.
+     *                                         This will normally be a comma or semi-colon.
+     *
+     * @return bool
+     */
+    protected function isValidAssignment(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $end)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $next   = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), $end, true);
+        if ($next === false || $tokens[$next]['code'] !== T_EQUAL) {
+            // No value assigned.
+            return true;
+        }
+
+        return $this->isStaticValue($phpcsFile, $tokens, ($next + 1), ($end - 1));
+    }
+
+
+    /**
+     * Is a value declared and is the value declared constant as accepted in PHP 5.5 and lower ?
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile    The file being scanned.
+     * @param array                 $tokens       The token stack of the current file.
+     * @param int                   $start        The stackPtr from which to start examining.
+     * @param int                   $end          The end of the value definition (inclusive),
+     *                                            i.e. this token will be examined as part of
+     *                                            the snippet.
+     * @param bool                  $nestedArrays Optional. Array nesting level when examining
+     *                                            the content of an array.
+     *
+     * @return bool
+     */
+    protected function isStaticValue(\PHP_CodeSniffer_File $phpcsFile, $tokens, $start, $end, $nestedArrays = 0)
+    {
+        $nextNonSimple = $phpcsFile->findNext($this->safeOperands, $start, ($end + 1), true);
+        if ($nextNonSimple === false) {
+            return true;
+        }
+
+        /*
+         * OK, so we have at least one token which needs extra examination.
+         */
+        switch ($tokens[$nextNonSimple]['code']) {
+            case T_MINUS:
+            case T_PLUS:
+                if ($this->isNumber($phpcsFile, $start, $end, true) !== false) {
+                    // Int or float with sign.
+                    return true;
+                }
+
+                return false;
+
+            case T_NAMESPACE:
+            case T_PARENT:
+            case T_SELF:
+            case T_DOUBLE_COLON:
+                $nextNonEmpty = $phpcsFile->findNext(
+                    \PHP_CodeSniffer_Tokens::$emptyTokens,
+                    ($nextNonSimple + 1),
+                    ($end + 1),
+                    true
+                );
+
+                if ($tokens[$nextNonSimple]['code'] === T_NAMESPACE) {
+                    // Allow only `namespace\...`.
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_NS_SEPARATOR) {
+                        return false;
+                    }
+                } elseif ($tokens[$nextNonSimple]['code'] === T_PARENT
+                    || $tokens[$nextNonSimple]['code'] === T_SELF
+                ) {
+                    // Allow only `parent::` and `self::`.
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_DOUBLE_COLON) {
+                        return false;
+                    }
+                } elseif ($tokens[$nextNonSimple]['code'] === T_DOUBLE_COLON) {
+                    // Allow only `T_STRING::T_STRING`.
+                    if ($nextNonEmpty === false || $tokens[$nextNonEmpty]['code'] !== T_STRING) {
+                        return false;
+                    }
+
+                    $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonSimple - 1), null, true);
+                    // No need to worry about parent/self, that's handled above and
+                    // the double colon is skipped over in that case.
+                    if ($prevNonEmpty === false || $tokens[$prevNonEmpty]['code'] !== T_STRING) {
+                        return false;
+                    }
+                }
+
+                // Examine what comes after the namespace/parent/self/double colon, if anything.
+                return $this->isStaticValue($phpcsFile, $tokens, ($nextNonEmpty + 1), $end, $nestedArrays);
+
+            case T_ARRAY:
+            case T_OPEN_SHORT_ARRAY:
+                ++$nestedArrays;
+
+                $arrayItems = $this->getFunctionCallParameters($phpcsFile, $nextNonSimple);
+                if (empty($arrayItems) === false) {
+                    foreach ($arrayItems as $item) {
+                        // Check for a double arrow, but only if it's for this array item, not for a nested array.
+                        $doubleArrow = false;
+
+                        $maybeDoubleArrow = $phpcsFile->findNext(
+                            array(T_DOUBLE_ARROW, T_ARRAY, T_OPEN_SHORT_ARRAY),
+                            $item['start'],
+                            ($item['end'] + 1)
+                        );
+                        if ($maybeDoubleArrow !== false && $tokens[$maybeDoubleArrow]['code'] === T_DOUBLE_ARROW) {
+                            // Double arrow is for this nesting level.
+                            $doubleArrow = $maybeDoubleArrow;
+                        }
+
+                        if ($doubleArrow === false) {
+                            if ($this->isStaticValue($phpcsFile, $tokens, $item['start'], $item['end'], $nestedArrays) === false) {
+                                return false;
+                            }
+
+                        } else {
+                            // Examine array key.
+                            if ($this->isStaticValue($phpcsFile, $tokens, $item['start'], ($doubleArrow - 1), $nestedArrays) === false) {
+                                return false;
+                            }
+
+                            // Examine array value.
+                            if ($this->isStaticValue($phpcsFile, $tokens, ($doubleArrow + 1), $item['end'], $nestedArrays) === false) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+
+                --$nestedArrays;
+
+                /*
+                 * Find the end of the array.
+                 * We already know we will have a valid closer as otherwise we wouldn't have been
+                 * able to get the array items.
+                 */
+                $closer = ($nextNonSimple + 1);
+                if ($tokens[$nextNonSimple]['code'] === T_OPEN_SHORT_ARRAY
+                    && isset($tokens[$nextNonSimple]['bracket_closer']) === true
+                ) {
+                    $closer = $tokens[$nextNonSimple]['bracket_closer'];
+                } else {
+                    $maybeOpener = $phpcsFile->findNext(
+                        \PHP_CodeSniffer_Tokens::$emptyTokens,
+                        ($nextNonSimple + 1),
+                        ($end + 1),
+                        true
+                    );
+                    if ($tokens[$maybeOpener]['code'] === T_OPEN_PARENTHESIS) {
+                        $opener = $maybeOpener;
+                        if (isset($tokens[$opener]['parenthesis_closer']) === true) {
+                            $closer = $tokens[$opener]['parenthesis_closer'];
+                        }
+                    }
+                }
+
+                if ($closer === $end) {
+                    return true;
+                }
+
+                // Examine what comes after the array, if anything.
+                return $this->isStaticValue($phpcsFile, $tokens, ($closer + 1), $end, $nestedArrays);
+
+        }
+
+        // Ok, so this unsafe token was not one of the exceptions, i.e. this is a PHP 5.6+ syntax.
+        return false;
+    }
+
+
+    /**
+     * Throw an error if a scalar expression is found.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the token to link the error to.
+     * @param string                $type      Type of usage found.
+     * @param string                $content   Optional. The value for the declaration as found.
+     *
+     * @return void
+     */
+    protected function throwError(\PHP_CodeSniffer_File $phpcsFile, $stackPtr, $type, $content = '')
+    {
+        $error     = static::ERROR_PHRASE;
+        $phrase    = '';
+        $errorCode = 'Found';
+
+        if (isset($this->errorPhrases[$type]) === true) {
+            $errorCode = $this->stringToErrorCode($type) . 'Found';
+            $phrase    = $this->errorPhrases[$type];
+        }
+
+        $data = array($phrase);
+
+        if (empty($content) === false) {
+            $error .= ' Found: %s';
+            $data[] = $content;
+        }
+
+        $phpcsFile->addError($error, $stackPtr, $errorCode, $data);
+    }
+
+
+    /**
+     * Helper function to find the end of multi variable/constant declarations.
+     *
+     * Checks whether a certain part of a declaration needs to be skipped over or
+     * if it is the real end of the declaration.
+     *
+     * @param array $tokens      Token stack of the current file.
+     * @param int   $endPtr      The token to examine as a candidate end pointer.
+     * @param int   $targetLevel Target nesting level.
+     *
+     * @return bool|int True if this is the real end. Int stackPtr to skip to if not.
+     */
+    private function isRealEndOfDeclaration($tokens, $endPtr, $targetLevel)
+    {
+        // Ignore anything within short array definition brackets for now.
+        if ($tokens[$endPtr]['code'] === T_OPEN_SHORT_ARRAY
+            && (isset($tokens[$endPtr]['bracket_opener'])
+                && $tokens[$endPtr]['bracket_opener'] === $endPtr)
+            && isset($tokens[$endPtr]['bracket_closer'])
+        ) {
+            // Skip forward to the end of the short array definition.
+            return $tokens[$endPtr]['bracket_closer'];
+        }
+
+        // Skip past comma's at a lower nesting level.
+        if ($tokens[$endPtr]['code'] === T_COMMA) {
+            // Check if a comma is at the nesting level we're targetting.
+            $nestingLevel = 0;
+            if (isset($tokens[$endPtr]['nested_parenthesis']) == true) {
+                $nestingLevel = count($tokens[$endPtr]['nested_parenthesis']);
+            }
+            if ($nestingLevel > $targetLevel) {
+                return $endPtr;
+            }
+        }
+
+        return true;
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewConstantScalarExpressionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewConstantScalarExpressionsSniffTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * New constant scalar expressions sniff test file.
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * New constant scalar expressions in PHP 5.6 sniff test file.
+ *
+ * @group newConstantScalarExpressions
+ * @group constants
+ * @group variables
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\NewConstantScalarExpressionsSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewConstantScalarExpressionsSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_constant_scalar_expressions.php';
+
+    /**
+     * Error phrases.
+     *
+     * @var array
+     */
+    private $errorPhrases = array(
+        'const'    => 'when defining constants using the const keyword',
+        'property' => 'in property declarations',
+        'static'   => 'in static variable declarations',
+        'default'  => 'in default function arguments',
+    );
+
+    /**
+     * Whether or not traits will be recognized in PHPCS.
+     *
+     * @var bool
+     */
+    protected static $recognizesTraits = true;
+
+
+    /**
+     * Set up skip condition.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        $phpcsVersion = PHPCSHelper::getVersion();
+
+        // When using PHPCS 1.x combined with PHP 5.3 or lower, traits are not recognized.
+        if (version_compare($phpcsVersion, '2.0', '<') && version_compare(PHP_VERSION_ID, '50400', '<')) {
+            self::$recognizesTraits = false;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+
+    /**
+     * testNewConstantScalarExpressions
+     *
+     * @dataProvider dataNewConstantScalarExpressions
+     *
+     * @param int    $line    The line number.
+     * @param string $type    Error type.
+     * @param string $extra   Extra snippet which will be part of the error message.
+     *                        Only needed when testing several errors on the same line.
+     * @param bool   $isTrait Whether the test relates to a method in a trait.
+     *
+     * @return void
+     */
+    public function testNewConstantScalarExpressions($line, $type, $extra = '', $isTrait = false)
+    {
+        if ($isTrait === true && self::$recognizesTraits === false) {
+            $this->markTestSkipped('Traits are not recognized on PHPCS 1.5.x in combination with PHP < 5.4');
+            return;
+        }
+
+        $file    = $this->sniffFile(self::TEST_FILE, '5.5');
+        $snippet = '';
+        if (isset($this->errorPhrases[$type]) === true) {
+            $snippet = $this->errorPhrases[$type];
+        }
+
+        $error = "Constant scalar expressions are not allowed {$snippet} in PHP 5.5 or earlier.";
+        if ($extra !== '') {
+            $error .= ' Found: ' . $extra;
+        }
+
+        $this->assertError($file, $line, $error);
+    }
+
+    /**
+     * Data provider dataNewConstantScalarExpressions.
+     *
+     * @see testNewConstantScalarExpressions()
+     *
+     * @return array
+     */
+    public function dataNewConstantScalarExpressions()
+    {
+        return array(
+            array(122, 'const'),
+            array(123, 'const'),
+            array(124, 'const'),
+            array(125, 'const'),
+            array(126, 'const'),
+            array(127, 'const'),
+            array(128, 'const'),
+            array(129, 'const'),
+            array(130, 'const'),
+            array(131, 'const'),
+            array(132, 'const'),
+            array(133, 'const'),
+            array(134, 'const'),
+            array(135, 'const'),
+            array(136, 'const'),
+            array(137, 'const'),
+            array(138, 'const'),
+            array(139, 'const'),
+            array(140, 'const'),
+            array(141, 'const'),
+            array(142, 'const'),
+            array(143, 'const'),
+            array(144, 'const'),
+            array(145, 'const'),
+            array(146, 'const'),
+            array(147, 'const'),
+            array(148, 'const'),
+            array(149, 'const'),
+            array(150, 'const'),
+
+            array(153, 'const'),
+
+            array(156, 'const'),
+            array(157, 'const'),
+
+            array(161, 'const'),
+            array(162, 'const'),
+            array(163, 'const'),
+            array(165, 'property'),
+            array(166, 'property'),
+            array(171, 'property'),
+            array(173, 'default'),
+
+            array(180, 'const'),
+            array(181, 'const'),
+            array(182, 'const'),
+            array(184, 'property'),
+            array(185, 'property'),
+            array(193, 'property'),
+            array(195, 'default'),
+
+            array(202, 'property', '', true),
+            array(203, 'property', '', true),
+            array(208, 'property', '', true),
+            array(210, 'default', '', true),
+
+            array(216, 'default', '$a = 5 * MINUTEINSECONDS'),
+            array(216, 'default', '$b = [ \'a\', 1 + 2 ]'),
+            array(220, 'default', '$a = 30 / HALF'),
+            array(220, 'default', '$b = array( 1, THREE, \'string\'.\'concat\')'),
+            array(224, 'default', '$a = (1 + 1)'),
+            array(224, 'default', '$b = 2 << 3'),
+            array(224, 'default', '$c = ((BAR)?10:100)'),
+            array(224, 'default', '$f = 10 * 5'),
+
+            array(227, 'default'),
+            array(228, 'default'),
+            array(229, 'default'),
+
+            array(233, 'static'),
+            array(234, 'static'),
+            array(235, 'static'),
+            array(236, 'static', '$h = (24 and 2)'),
+            array(236, 'static', '$i = ONE * 2'),
+            array(236, 'static', '$j = \'a\' . \'b\''),
+            array(238, 'static'),
+
+            array(241, 'static'),
+            array(242, 'const'),
+            array(244, 'property'),
+            array(246, 'const'),
+            array(247, 'const'),
+            array(250, 'property'),
+
+            array(258, 'const'),
+            array(259, 'const'),
+
+            array(262, 'static'),
+            array(263, 'static'),
+            array(264, 'static'),
+            array(265, 'static'),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.5');
+
+        // No errors expected on the first 120 lines.
+        for ($line = 1; $line <= 120; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_constant_scalar_expressions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_constant_scalar_expressions.php
@@ -1,0 +1,265 @@
+<?php
+
+/*
+ * These should be ignored, not our target.
+ */
+$var_A = TWO + 1;
+$var_B = ONE / self::THREE;
+$var_C = 'The value of THREE is '.self::THREE;
+
+/*
+ * These were all fine in PHP < 5.6.
+ */
+const ONE = 1;
+const ONF = 'string';
+const ONG = -1.4;
+const ONH = false;
+const ONI = ONE;
+const ONJ = ClassName::ONE;
+const ONK = MyNS\ClassName::ONE;
+const ONL = namespace\ClassName::ONE;
+const ONN = __LINE__;
+
+static $a = 1;
+static $b = array( 'a', 'b' => 2 );
+static $c = 'string';
+static $d, $e = 0, $f = __FILE__;
+static $g = ONG, $h = ClassName::ONE;
+
+function foofoo() {
+    static $a = 1;
+    static $b = [ 'a', 'b' => 2 ];
+    static $c = 'string';
+    static $d;
+    static $e, $f, $g;
+    static $h, $i = ONI, $j = __FUNCTION__;
+}
+
+class Bar {
+    const THREE = +123.54;
+    const CANNOT_FETCH = -1;
+    const ONE_THIRD = true;
+    const SENTENCE = 'The value of THREE is ';
+    const SENTENCF = "The value of THREE is ";
+    const SENTENCG = <<<FOOBAR
+Constant example
+FOOBAR;
+    const FOUR = __CLASS__;
+    const FINE = \ReflectionMethod::IS_PUBLIC;
+
+    public $prop_A = +15;
+    public $prop_B = 'string';
+    public $prop_C = 2.5;
+    public $prop_D = FOUR;
+    public $prop_E;
+    public $prop_F = array(
+        1 => __NAMESPACE__,
+        2 => 1.3,
+    );
+    public $prop_G = [
+        'key1' => true,
+        'key2' => null,
+    ];
+    public $prop_H = <<<FOOBAR
+Property example
+FOOBAR;
+
+    public function f($a = 123, $b = false, $c = __METHOD__, $d = ['a', 'b'], $e = array('a', 'b'), $f = 1.5 )
+    {
+        static $bar = <<<LABEL
+Nothing in here...
+LABEL;
+
+        return $a;
+    }
+}
+
+// Make sure that (nested) arrays are handled correctly.
+class NestedArrays {
+	protected $table_and_column_defs = array(
+		array(
+			'definition'      => array(
+				'a' => array(
+					'( a INT, b FLOAT )',
+				),
+			),
+		),
+	);
+
+    protected $defaultAcl = [
+        [
+            'principal' => '{DAV:}authenticated',
+            'protected' => true,
+            'privilege' => '{DAV:}all',
+        ],
+    ];
+
+	var $span_gamut = array(
+		"parseSpan"    => -30,
+		-20            =>  10,
+	);
+
+	public $defaultSecondarySettings = array(
+		'options' => array(),
+		'post_type' => 'post',
+		'num' => -1,
+		'order' => 'DESC',
+	);
+
+	public static $status_map = array(-1=>'auto-draft',
+										 0=>'draft',
+										 1=>'pending',
+										 4=>'trash');
+
+	function post_data_export( $prefix = '_aioseop', $query = array( 'posts_per_page' => - 1 ) ) {}
+}
+
+trait Something {
+	protected $prop = __TRAIT__;
+}
+
+// PHP 5.6: Test throwing errors for all newly allowed operators.
+const TWOA = 1 + 2;
+const TWOB = 2 - 2;
+const TWOC = 3 * 2;
+const TWOD = 4 / 2;
+const TWOE = 5 % 2;
+const TWOF = ! 6;
+const TWOG = ~ 7;
+const TWOH = 8 | 2;
+const TWOI = 9 & 2;
+const TWOJ = 10 ^ 2;
+const TWOK = 11 << 2;
+const TWOL = 12 >> 2;
+const TWOM = 13 . 2;
+const TWON = 14 ?: 2;
+const TWOO = 15 <= 2;
+const TWOP = 16 >= 2;
+const TWOQ = 17 == 2;
+const TWOR = 18 != 2;
+const TWOS = 19 < 2;
+const TWOT = 20 > 2;
+const TWOU = 21 === 2;
+const TWOV = 22 !== 2;
+const TWOW = 23 && 2;
+const TWOX = 24 and 2;
+const TWOY = 25 || 2;
+const TWOZ = 26 or 2;
+const TWO0 = 27 xor 2;
+const TWO1 = 28 ** 2;
+const TWO2 = 29 ?? 2;
+
+// PHP 5.6: Grouping parenthesis are allowed.
+const TWO3 = (24 and 2);
+
+// PHP 5.6: Using constants in combination with operators is allowed.
+const TWO4 = ONE * 2;
+const BAZ  = GREETING." WORLD!";
+
+// PHP 5.6: Static constant expressions in class constants, properties and function param defaults.
+class FooClass {
+    const THREE = TWO + 1;
+    const ONE_THIRD = ONE / self::THREE;
+    const SENTENCE = 'The value of THREE is '.self::THREE;
+
+    public $foo = 1 + 1;
+    public $bar = [
+        1 + 1,
+        1 << 2,
+        Foo::BAZ => "foo "."bar"
+    ];
+    public $baseDir = __DIR__ . "/base";
+
+    public function f($a = ONE + static::THREE) { // Using `static::` is still not allowed, but not our concern.
+        return $a;
+    }
+}
+
+// ... and in an anonymous class...
+$a = new class {
+    const THREE = TWO + 1;
+    const ONE_THIRD = ONE / self::THREE;
+    const SENTENCE = 'The value of THREE is '.self::THREE;
+
+    public $foo = 1 + 1;
+    public $bar = [
+        1 + 1 => 'value',
+        1 << 2 => 'value',
+		// Note: Heredoc with variables is still not allowed, but not our concern.
+        Foo::BAZ => "foo ".<<<EOT
+some text with a $variable
+EOT
+    ];
+    public $baseDir = 'Line: '.__LINE__;
+
+    public function f($a = ONE + self::THREE) {
+        return $a;
+    }
+};
+
+// ... and in traits.
+trait FooTrait {
+    public $foo = 1 + 1;
+    public $bar = [
+        'a'.'b' => 'value',
+        1 - 2,
+        Foo::BAZ => "foo "."bar"
+    ];
+    public $baseDir = 'Trait: '.__TRAIT__;
+
+    public function f($a = ONE + self::THREE) {
+        return $a;
+    }
+}
+
+// PHP 5.6: Static constant expressions in function param defaults.
+function f($a = 5 * MINUTEINSECONDS, $b = [ 'a', 1 + 2 ]) {
+    return $a;
+}
+
+$closure = function ($a = 30 / HALF, $b = array( 1, THREE, 'string'.'concat') ) {
+    return $a;
+};
+
+function foo($a = (1 + 1), $b = 2 << 3, $c = ((BAR)?10:100), $d = 123, $e = array(), $f = 10 * 5) {}
+
+$closure = function (
+	$a = (1 + 1),
+	$b = 2 << 3,
+	$c = ((BAR)?10:100)
+) {};
+
+// PHP 5.6: Static constant expressions in static variable declarations.
+static $e = 1 + 1;
+static $f = [1 << 2];
+static $g = 0x01 | BAR;
+static $h = (24 and 2), $i = ONE * 2, $j = 'a' . 'b';
+
+static $i = namespace ABC\DEF; // Parse error, but testing part of the code.
+
+// PHP 5.6: Negative/Positive constants can now be used.
+static $j = - namespace\Foo::BAR;
+const ABC = + \ABC\Bar::BAR;
+class ABC {
+	public static $foo = - Foo::THREE;
+}
+const ABC = + FOOBAR;
+const ABC = - M_PI;
+
+class testThis {
+    private $oneComplexValueDataSets = [
+        [-9.8765,  +4.321,     null],
+        [0,        M_PI,       null],
+        [0,        -M_PI,      null], // Correctly identified as invalid in PHP < 5.6 :tada:.
+    ];
+}
+
+// PHP 5.6: Array unions.
+const ABC = array( 1 => 1, 2 => 2 ) + array( 3 => 3, 4 => 4 );
+const ABC = [ 1 => 1, 2 => 2 ] + [ 3 => 3, 4 => 4 ];
+
+// Still not allowed, but not our concern. These should throw errors for pre-5.6, but that's it.
+static $var = $a;
+static $callA = function($a) {};
+static $callB = strpos( $a, 'a' );
+static $interpolated = "value with $variable";


### PR DESCRIPTION
… where previously only static values were allowed.

> It is now possible to provide a scalar expression involving numeric and string literals and/or constants in contexts where PHP previously expected a static value, such as constant and property declarations and default function arguments.

Refs:
* http://php.net/manual/en/migration56.new-features.php#migration56.new-features.const-scalar-exprs
* https://wiki.php.net/rfc/const_scalar_exprs
* https://wiki.php.net/rfc/const_scalar_expressions

Includes extensive unit tests.

Notes:
* The sniff has been set up in a way that the `HeredocInitialize` sniff will be able to extend it in the near future as that sniff ought to use the same base logic as is contained in the `process()` method of this sniff (The `HeredocInitialize` sniff currently doesn't examine all possible cases to which the heredoc change applies).
* I've ran the sniff over some 200.000 files in the WP plugin & theme directory to test against false positives and I've fixed all false positives which I found, so I'm reasonably confident that it covers all exceptions.

Fixes #399