### PR TITLE
PHP 7.0: New sniff to detect generator return expressions

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewGeneratorReturnSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewGeneratorReturnSniff.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewGeneratorReturnSniff.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+use PHPCompatibility\PHPCSHelper;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewGeneratorReturnSniff.
+ *
+ * As of PHP 7.0, a return statement can be used within a generator for a final expression to be returned.
+ *
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewGeneratorReturnSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        $targets = array();
+
+        /*
+         * The `yield` keyword was introduced in PHP 5.5 with the token T_YIELD.
+         * The `yield from` keyword was introduced in PHP 7.0 and tokenizes as
+         * "T_YIELD T_WHITESPACE T_STRING".
+         *
+         * Pre-PHPCS 3.1.0, the T_YIELD token was not back-filled for PHP < 5.5.
+         * Also, as of PHPCS 3.1.0, the PHPCS tokenizer adds a new T_YIELD_FROM
+         * token.
+         *
+         * So for PHP 5.3-5.4 icw PHPCS < 3.1.0, we need to look for T_STRING with content "yield".
+         * For PHP 5.5+ we need to look for T_YIELD.
+         * For PHPCS 3.1.0+, we also need to look for T_YIELD_FROM.
+         */
+        if (version_compare(PHP_VERSION_ID, '50500', '<') === true
+            && version_compare(PHPCSHelper::getVersion(), '3.1.0', '<') === true
+        ) {
+            $targets[] = T_STRING;
+        }
+
+        if (defined('T_YIELD')) {
+            // phpcs:ignore PHPCompatibility.PHP.NewConstants.t_yieldFound
+            $targets[] = T_YIELD;
+        }
+
+        if (defined('T_YIELD_FROM')) {
+            $targets[] = T_YIELD_FROM;
+        }
+
+        return $targets;
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void|int Void or a stack pointer to skip forward.
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('5.6') !== true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_STRING
+            && $tokens[$stackPtr]['content'] !== 'yield'
+        ) {
+            return;
+        }
+
+        $function = $phpcsFile->getCondition($stackPtr, T_FUNCTION);
+        if ($function === false) {
+            // Try again, but now for a closure.
+            $function = $phpcsFile->getCondition($stackPtr, T_CLOSURE);
+        }
+
+        if ($function === false) {
+            // Yield outside function scope, fatal error, but not our concern.
+            return;
+        }
+
+        if (isset($tokens[$function]['scope_opener'], $tokens[$function]['scope_closer']) === false) {
+            // Can't reliably determine start/end of function scope.
+            return;
+        }
+
+        $hasReturn = $phpcsFile->findNext(T_RETURN, ($tokens[$function]['scope_opener'] + 1), $tokens[$function]['scope_closer']);
+        if ($hasReturn === false) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'Returning a final expression from a generator was not supported in PHP 5.6 or earlier',
+            $hasReturn,
+            'ReturnFound'
+        );
+
+        // Don't examine this function again.
+        return $tokens[$function]['scope_closer'];
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewGeneratorReturnSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewGeneratorReturnSniffTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * New generator return expressions sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New generator return expressions in PHP 7.0 sniff test file
+ *
+ * @group newGeneratorReturn
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\NewGeneratorReturnSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewGeneratorReturnSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_generator_return.php';
+
+    /**
+     * testNewGeneratorReturn
+     *
+     * @dataProvider dataNewGeneratorReturn
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewGeneratorReturn($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertError($file, $line, 'Returning a final expression from a generator was not supported in PHP 5.6 or earlier');
+    }
+
+    /**
+     * Data provider dataNewGeneratorReturn.
+     *
+     * @see testNewGeneratorReturn()
+     *
+     * @return array
+     */
+    public function dataNewGeneratorReturn()
+    {
+        return array(
+            array(30),
+            array(35),
+            array(39),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(15),
+            array(21),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_generator_return.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_generator_return.php
@@ -1,0 +1,41 @@
+<?php
+
+// OK.
+function gen_one_to_three() {
+    for ($i = 1; $i <= 3; $i++) {
+        yield $i;
+    }
+}
+
+function gen_one_to_three() {
+	$a = array();
+    for ($i = 1; $i <= 3; $i++) {
+        $a[] = 'yield'.$i;
+    }
+    return $a;
+}
+
+$gen = function {
+    $foo = yield myAsyncFoo();
+    $bar = yield myAsyncBar($foo);
+    yield "return" => $bar + 42;
+};
+
+
+// PHP 7.0+
+function foo() {
+    yield 0;
+    yield 1;
+
+    return 42;
+}
+
+$generator = function () {
+    yield 1;
+    return yield from bar();
+}
+
+function gen() {
+    return $foo;
+    yield;
+}


### PR DESCRIPTION
> Generator Return Expressions
>
> This feature builds upon the generator functionality introduced into PHP 5.5. It enables for a `return` statement to be used within a generator to enable for a final expression to be returned (return by reference is not allowed). > This value can be fetched using the new `Generator::getReturn()` method, which may only be used once the generator has finished yielding values.

Refs:
* http://php.net/manual/en/migration70.new-features.php#migration70.new-features.generator-return-expressions
* https://wiki.php.net/rfc/generator-return-expressions
* https://github.com/php/php-src/commit/5c230baf75fb17d1d0b8ec407a7479d02b25068a

The new sniff checks for and reports on `return` statements being found in generator functions.

Includes unit tests.