### PR TITLE
PHP 5.4/7.0: New sniff to detect class member access on object instantiation/cloning

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewClassMemberAccessSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassMemberAccessSniff.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewClassMemberAccessSniff.
+ *
+ * PHP version 5.4
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewClassMemberAccessSniff.
+ *
+ * PHP 5.4: Class member access on instantiation has been added, e.g. (new Foo)->bar().
+ * PHP 7.0: Class member access on cloning has been added, e.g. (clone $foo)->bar().
+ *
+ * PHP version 5.4
+ * PHP version 7.0
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewClassMemberAccessSniff extends Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_NEW,
+            T_CLONE,
+        );
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in the
+     *                                         stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[$stackPtr]['code'] === T_NEW && $this->supportsBelow('5.3') !== true) {
+            return;
+        } elseif ($tokens[$stackPtr]['code'] === T_CLONE && $this->supportsBelow('5.6') !== true) {
+            return;
+        }
+
+        if (isset($tokens[$stackPtr]['nested_parenthesis']) === false) {
+            // The `new className/clone $a` has to be in parentheses, without is not supported.
+            return;
+        }
+
+        $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
+        $parenthesisOpener = key($tokens[$stackPtr]['nested_parenthesis']);
+
+        if (isset($tokens[$parenthesisOpener]['parenthesis_owner']) === true) {
+            // If there is an owner, these parentheses are for a different purpose.
+            return;
+        }
+
+        $prevBeforeParenthesis = $phpcsFile->findPrevious(
+            \PHP_CodeSniffer_Tokens::$emptyTokens,
+            ($parenthesisOpener - 1),
+            null,
+            true
+        );
+        if ($prevBeforeParenthesis !== false && $tokens[$prevBeforeParenthesis]['code'] === T_STRING) {
+            // This is most likely a function call with the new/cloned object as a parameter.
+            return;
+        }
+
+        $nextAfterParenthesis = $phpcsFile->findNext(
+            \PHP_CodeSniffer_Tokens::$emptyTokens,
+            ($parenthesisCloser + 1),
+            null,
+            true
+        );
+        if ($nextAfterParenthesis === false) {
+            // Live coding.
+            return;
+        }
+
+        if ($tokens[$nextAfterParenthesis]['code'] !== T_OBJECT_OPERATOR
+            && $tokens[$nextAfterParenthesis]['code'] !== T_OPEN_SQUARE_BRACKET
+        ) {
+            return;
+        }
+
+        $data      = array('instantiation', '5.3');
+        $errorCode = 'OnNewFound';
+
+        if ($tokens[$stackPtr]['code'] === T_CLONE) {
+            $data      = array('cloning', '5.6');
+            $errorCode = 'OnCloneFound';
+        }
+
+        $phpcsFile->addError(
+            'Class member access on object %s was not supported in PHP %s or earlier',
+            $parenthesisCloser,
+            $errorCode,
+            $data
+        );
+    }
+}

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClassMemberAccessSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClassMemberAccessSniffTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * New class member access on instantiation/cloning sniff test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New class member access on instantiation in PHP 5.4 and on closing in PHP 7.0 sniff test file
+ *
+ * @group newClassMemberAccess
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\NewClassMemberAccessSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewClassMemberAccessSniffTest extends BaseSniffTest
+{
+    const TEST_FILE = 'sniff-examples/new_class_member_access.php';
+
+    /**
+     * testNewClassMemberAccess
+     *
+     * @dataProvider dataNewClassMemberAccess
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNewClassMemberAccess($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Class member access on object instantiation was not supported in PHP 5.3 or earlier');
+    }
+
+    /**
+     * Data provider dataNewClassMemberAccess.
+     *
+     * @see testNewClassMemberAccess()
+     *
+     * @return array
+     */
+    public function dataNewClassMemberAccess()
+    {
+        return array(
+            array(41),
+            array(42),
+            array(43),
+            array(45),
+            array(47),
+            array(48),
+            array(49),
+            array(51),
+            array(52),
+            array(54),
+            array(57),
+            array(60),
+            array(61),
+            array(62),
+            array(65),
+            array(70),
+            array(76),
+            array(79),
+            array(82),
+            array(86),
+            array(91),
+            array(96),
+        );
+    }
+
+    /**
+     * testCloneClassMemberAccess
+     *
+     * @dataProvider dataCloneClassMemberAccess
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testCloneClassMemberAccess($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.6');
+        $this->assertError($file, $line, 'Class member access on object cloning was not supported in PHP 5.6 or earlier');
+    }
+
+    /**
+     * Data provider dataCloneClassMemberAccess.
+     *
+     * @see testCloneClassMemberAccess()
+     *
+     * @return array
+     */
+    public function dataCloneClassMemberAccess()
+    {
+        return array(
+            array(101),
+            array(103),
+            array(105),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @return void
+     */
+    public function testNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+
+        // No errors expected on the first 37 lines.
+        for ($line = 1; $line <= 37; $line++) {
+            $this->assertNoViolation($file, $line);
+        }
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.0');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_class_member_access.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_class_member_access.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This is fine pre-PHP 5.4.
+ */
+$a = new Bar;
+$a = new Bar();
+$a = (new Bar());
+
+// Deprecated new by reference but not our concern.
+$a = &new Bar();
+$a = (&new Bar());
+
+$b = $a->foo();
+
+function_call( new Bar(), $b->something, $c->method(), $d['a']);
+
+$container->register('foo', 'FooClass')->addArgument(new \stdClass())->setPublic(true);
+
+$c = clone $a;
+$d = (clone $a);
+$date1 = clone ($_date1 <= $_date2 ? $_date1 : $_date2);
+
+// Still not supported:
+$X = new foo->setX(10)->getX();
+var_dump(new foo()->bar());
+var_dump(new foo()->baz()->x);
+var_dump(new foo()->baz()->baz()->bar());
+var_dump(new foo()->xyz());
+
+try {
+	$X = new foo->Inexistent(3);
+} catch (Exception $e) {
+	var_dump($e->getMessage());
+}
+
+
+/*
+ * PHP 5.4: class member access on instantiation.
+ */
+(new foo())->bar();
+(new $foo())->bar;
+(new foo)[0];
+
+$a = (new Foo( array(1, array(4, 5), 3) ))[1][0];
+
+var_dump((new Bar)->y);
+$closure = function() {return (new $x)->y;};
+$foo = (new $bar->y)->x);
+
+return clone (new bar)->z;
+$clone = clone (new bar)->getZ();
+
+$X = (new foo)->setX(10)->getX();
+
+var_dump(
+	(new foo())
+		-> bar()
+);
+var_dump((new foo())->baz()->x);
+var_dump((new foo())->baz()->baz()->bar());
+var_dump((new foo())->xyz());
+
+try {
+	$X = (new foo)->Inexistent(3);
+} catch (Exception $e) {
+	var_dump($e->getMessage());
+}
+
+        $container->setDefinition('child', (new ChildDefinition('parent'))->setArguments(array(
+            1,
+            'index_0' => 2,
+            'foo' => 3,
+        )));
+
+        $factory->setFactory(array((new Definition('Baz\Qux'))->setFactory(array(null, 'getInstance')), 'create'));
+
+        $def->setInstanceofConditionals(array(
+            parent::class => (new ChildDefinition(''))->addMethodCall('foo', array('bar')),
+        ));
+
+        $def = (new ChildDefinition('parent'))->setClass(self::class);
+
+        $container->register('foo', 'Class1')
+            ->setPublic(true)
+            ->addArgument((new Definition('Class2'))
+                ->addArgument(new Definition('Class2'))
+            )
+        ;
+
+        return $this->services['service_from_anonymous_factory'] = (new \Bar\FooClass())->getInstance();
+
+/*
+ * As of PHP 7.0, the new object can be assigned to a variable within the parentheses.
+ */
+$b = ($a = new foo())->bar();
+
+/*
+ * PHP 7.0: class member access on object cloning.
+ */
+$b = (clone $foo)->bar();
+
+echo (clone $iterable)[20];
+
+$date1 = (clone ($_date1 <= $_date2 ? $_date1 : $_date2))->format('Y');


### PR DESCRIPTION
> Class member access on instantiation has been added, e.g. (new Foo)->bar().

Refs:
* http://php.net/manual/en/migration54.new-features.php#migration54.new-features
* https://wiki.php.net/rfc/instance-method-call

> Class member access on cloning has been added, e.g. (clone $foo)->bar().

Ref: http://php.net/manual/en/migration70.new-features.php#migration70.new-features.others

Includes unit tests.

I've ran the sniff against a couple of code bases to test against false positives and fixed the ones I found.
I've coded the sniff to err on the side of caution, but I will not be surprised if some false positive/negatives will be reported once this sniff is active.
If they are, I will of course fix them.

Fixes #53