### PR TITLE
Travis/CS/QA: lint CMS/framework ruleset and check codestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,8 +118,10 @@ script:
   # Validate the xml file.
   # @link http://xmlsoft.org/xmllint.html
   - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./PHPCompatibility/ruleset.xml; fi
+  - if [[ "$SNIFF" == "1" ]]; then xmllint --noout ./framework-rulesets/*.xml; fi
   # Check the code-style consistency of the xml files.
   - if [[ "$SNIFF" == "1" ]]; then diff -B ./PHPCompatibility/ruleset.xml <(xmllint --format "./PHPCompatibility/ruleset.xml"); fi
+  - if [[ "$SNIFF" == "1" ]]; then diff -B ./framework-rulesets/wordpress.xml <(xmllint --format "./framework-rulesets/wordpress.xml"); fi
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate
   - if [[ "$LINT" == "1" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
Now the `framework-rulesets` directory and the first framework/CMS ruleset has been added, it seems like a good idea to make sure that those rulesets are also verified during the Travis run:
* Lint each ruleset in that directory for valid XML
* Check the codestyle of the ruleset which has been added - this second check will need to be added for each individual ruleset