### PR TITLE
Composer: suggest Roave/SecurityAdvisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "squizlabs/php_codesniffer": "2.6.2"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
+    "roave/security-advisories": "dev-master"
   },
   "autoload" : {
     "psr-4" : {


### PR DESCRIPTION
This dependency will prevent packages with known security issues from being installed through Composer.
The package will always have to be at `dev-master` to make sure that the latest security information available will be used.

Unfortunately, we can't add it as a `dev` dependency to PHPCompatibility itself as it would prevent us from testing on PHPCS 1.x and most of the 2.x range, which contain a known security vulnerability.

We can, however, support the project and try to help spread it by suggesting it to the users of PHPCompatibility.

Refs:
* https://github.com/Roave/SecurityAdvisories
* https://www.bleepingcomputer.com/news/security/php-community-takes-steps-to-stop-installation-of-libraries-with-unpatched-bugs/
* https://websec.io/2018/03/10/Package-Protection-Roave-SecurityAdvisories.html