### PR TITLE
NewKeywords: fix too aggressive accounting for PHPCS cross-compat

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewKeywordsSniff.php
@@ -204,6 +204,10 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
         // Translate T_STRING token if necessary.
         if ($tokens[$stackPtr]['type'] === 'T_STRING') {
             $content = $tokens[$stackPtr]['content'];
+            if (strpos($content, '__') !== 0) {
+                $content = strtolower($tokens[$stackPtr]['content']);
+            }
+
             if (isset($this->translateContentToToken[$content]) === false) {
                 // Not one of the tokens we're looking for.
                 return;
@@ -247,6 +251,14 @@ class NewKeywordsSniff extends AbstractNewFeatureSniff
 
         $nextToken = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($end + 1), null, true);
         $prevToken = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+
+        if ($prevToken !== false
+            && ($tokens[$prevToken]['code'] === T_DOUBLE_COLON
+            || $tokens[$prevToken]['code'] === T_OBJECT_OPERATOR)
+        ) {
+            // Class property of the same name as one of the keywords. Ignore.
+            return;
+        }
 
         // Skip attempts to use keywords as functions or class names - the former
         // will be reported by ForbiddenNamesAsInvokedFunctionsSniff, whilst the

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewKeywordsSniffTest.php
@@ -70,6 +70,17 @@ class NewKeywordsSniffTest extends BaseSniffTest
     }
 
     /**
+     * Test against false positives for the namespace keyword.
+     *
+     * @return void
+     */
+    public function testNamespaceNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.2');
+        $this->assertNoViolation($file, 117);
+    }
+
+    /**
      * testNamespaceConstant
      *
      * @return void
@@ -92,9 +103,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.3');
         $this->assertError($file, 24, '"trait" keyword is not present in PHP version 5.3 or earlier');
+        $this->assertError($file, 105, '"trait" keyword is not present in PHP version 5.3 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertNoViolation($file, 24);
+        $this->assertNoViolation($file, 105);
     }
 
     /**
@@ -159,6 +172,17 @@ class NewKeywordsSniffTest extends BaseSniffTest
     }
 
     /**
+     * Test against false positives for the yield keyword.
+     *
+     * @return void
+     */
+    public function testYieldNoFalsePositives()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, 120);
+    }
+
+    /**
      * Test yield from
      *
      * @dataProvider dataYieldFrom
@@ -200,9 +224,11 @@ class NewKeywordsSniffTest extends BaseSniffTest
     {
         $file = $this->sniffFile(self::TEST_FILE, '5.4');
         $this->assertError($file, 9, '"finally" keyword (in exception handling) is not present in PHP version 5.4 or earlier');
+        $this->assertError($file, 108, '"finally" keyword (in exception handling) is not present in PHP version 5.4 or earlier');
 
         $file = $this->sniffFile(self::TEST_FILE, '5.5');
         $this->assertNoViolation($file, 9);
+        $this->assertNoViolation($file, 108);
     }
 
     /**
@@ -355,7 +381,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
         if (PHP_MAJOR_VERSION === 5 && PHP_MINOR_VERSION === 3) {
             // PHP 5.3 actually shows the warning.
             $file = $this->sniffFile(self::TEST_FILE, '5.0');
-            $this->assertError($file, 102, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');
+            $this->assertError($file, 122, '"__halt_compiler" keyword is not present in PHP version 5.0 or earlier');
         } else {
             /*
              * Usage of `__halt_compiler()` cannot be tested on its own token as the compiler
@@ -364,7 +390,7 @@ class NewKeywordsSniffTest extends BaseSniffTest
              * not be reported.
              */
             $file = $this->sniffFile(self::TEST_FILE, '5.2');
-            $this->assertNoViolation($file, 105);
+            $this->assertNoViolation($file, 125);
         }
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_keywords.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_keywords.php
@@ -99,6 +99,26 @@ spanning multiple lines
 using nowdoc syntax.
 LABEL;
 
+/*
+ * Test case-insensitive matching of the PHPCS cross-version compat layer.
+ */
+TRAIT MyFoobarTrait {}
+
+try {
+} FINALLY {
+}
+
+/*
+ * Check against false positives/correct PHPCS cross-version compat layer.
+ * The fact that these keywords are reserved, is not our concern. That is handled by the forbiddenNames sniff.
+ */
+
+// "namespace" is a property (allowed use, though confusing), not the keyword.
+$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $id ) ) );
+
+// yield used as a class constant.
+echo MyClass::yield;
+
 __halt_compiler();
 
 bla();


### PR DESCRIPTION
A number of tokens are not correctly back-filled across PHP versions by various PHPCS versions.
To that end, a _token translation table_ is used to recognize tokens tokenized as `T_STRING` as the keyword anyway.

At the same time, PHPCS sometimes retokenizes too aggressively, changing `T_STRING` tokens to a keyword token when it shouldn't.

Most PHP keywords can be safely used as variable (and property) names and as of PHP 7, as the name of class constants.

> Using them as variable names is generally OK, but could lead to confusion. 

Ref: http://php.net/manual/en/reserved.keywords.php

As property names when referenced and class constant names, both when referenced as well as when declared, are tokenized as `T_STRING`, this leads to false positives from this sniff.

At the same time, keywords in PHP are case-insensitive, so the cross-compat layer should allow for mixed case / uppercase use of the (non magic-constant) keywords as well.

This commit fixes both.
Includes unit tests.