### PR TITLE
Minor performance optimization

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/RemovedGlobalVariablesSniff.php
@@ -210,7 +210,8 @@ class RemovedGlobalVariablesSniff extends AbstractRemovedFeatureSniff
 
         // It could also be a function param, which is not in the function scope.
         if ($function === false && isset($tokens[$stackPtr]['nested_parenthesis']) === true) {
-            $parenthesisCloser = end($tokens[$stackPtr]['nested_parenthesis']);
+            $nestedParentheses = $tokens[$stackPtr]['nested_parenthesis'];
+            $parenthesisCloser = end($nestedParentheses);
             if (isset($tokens[$parenthesisCloser]['parenthesis_owner'])
                 && ($tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_FUNCTION
                     || $tokens[$tokens[$parenthesisCloser]['parenthesis_owner']]['code'] === T_CLOSURE)


### PR DESCRIPTION
Turns out that using `end()` on a nested array in a (very) large array such as the `$tokens` array can be with large files, is significantly slower than copying the nested array to a local variable and using `end()` on that.

See: https://github.com/squizlabs/PHP_CodeSniffer/commit/6d15547ed874d0061c83e380496162e2ec2020c8#r28189947