### PR TITLE
PHP 7.3: new sniff to detect trailing comma's in function calls, isset() and unset()

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewTrailingCommaSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewTrailingCommaSniff.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * \PHPCompatibility\Sniffs\PHP\TrailingCommaSniff.
+ *
+ * PHP version 7.3
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+
+namespace PHPCompatibility\Sniffs\PHP;
+
+use PHPCompatibility\Sniff;
+
+/**
+ * \PHPCompatibility\Sniffs\PHP\NewTrailingCommaSniff.
+ *
+ * PHP version 7.3
+ *
+ * Note: trailing comma's in group use statements as introduced in PHP 7.2 is covered
+ * by the `NewGroupUseDeclaration` sniff.
+ *
+ * @category PHP
+ * @package  PHPCompatibility
+ * @author   Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewTrailingCommaSniff extends Sniff
+{
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+            T_STRING,
+            T_VARIABLE,
+            T_ISSET,
+            T_UNSET,
+        );
+    }
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                   $stackPtr  The position of the current token in
+     *                                         the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(\PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        if ($this->supportsBelow('7.2') === false) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+
+        $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr + 1), null, true);
+        if ($tokens[$nextNonEmpty]['code'] !== T_OPEN_PARENTHESIS
+            || isset($tokens[$nextNonEmpty]['parenthesis_closer']) === false
+        ) {
+            return;
+        }
+
+        if ($tokens[$stackPtr]['code'] === T_STRING) {
+            $ignore = array(
+                T_FUNCTION        => true,
+                T_CONST           => true,
+                T_USE             => true,
+            );
+
+            $prevNonEmpty = $phpcsFile->findPrevious(\PHP_CodeSniffer_Tokens::$emptyTokens, ($stackPtr - 1), null, true);
+            if (isset($ignore[$tokens[$prevNonEmpty]['code']]) === true) {
+                // Not a function call.
+                return;
+            }
+        }
+
+        $closer            = $tokens[$nextNonEmpty]['parenthesis_closer'];
+        $lastInParenthesis = $phpcsFile->findPrevious(
+            \PHP_CodeSniffer_Tokens::$emptyTokens,
+            ($closer - 1),
+            $nextNonEmpty,
+            true
+        );
+
+        if ($tokens[$lastInParenthesis]['code'] !== T_COMMA) {
+            return;
+        }
+
+        $data = array();
+        switch ($tokens[$stackPtr]['code']) {
+            case T_ISSET:
+                $data[]    = 'calls to isset()';
+                $errorCode = 'FoundInIsset';
+                break;
+
+            case T_UNSET:
+                $data[]    = 'calls to unset()';
+                $errorCode = 'FoundInUnset';
+                break;
+
+            default:
+                $data[]    = 'function calls';
+                $errorCode = 'FoundInFunctionCall';
+                break;
+        }
+
+        $phpcsFile->addError(
+            'Trailing comma\'s are not allowed in %s in PHP 7.2 or earlier',
+            $lastInParenthesis,
+            $errorCode,
+            $data
+        );
+
+    }//end process()
+
+}//end class

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewTrailingCommaSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewTrailingCommaSniffTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * New function call trailing comma sniff tests
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\Sniffs\PHP;
+
+use PHPCompatibility\Tests\BaseSniffTest;
+
+/**
+ * New function call trailing comma sniff tests
+ *
+ * @group newTrailingComma
+ *
+ * @covers \PHPCompatibility\Sniffs\PHP\NewTrailingCommaSniff
+ *
+ * @uses    \PHPCompatibility\Tests\BaseSniffTest
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class NewTrailingCommaSniffTest extends BaseSniffTest
+{
+
+    const TEST_FILE = 'sniff-examples/new_trailing_comma.php';
+
+
+    /**
+     * testTrailingComma
+     *
+     * @dataProvider dataTrailingComma
+     *
+     * @param int    $line The line number.
+     * @param string $type The type detected.
+     *
+     * @return void
+     */
+    public function testTrailingComma($line, $type = 'function calls')
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
+        $this->assertError($file, $line, "Trailing comma's are not allowed in {$type} in PHP 7.2 or earlier");
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testTrailingComma()
+     *
+     * @return array
+     */
+    public function dataTrailingComma()
+    {
+        return array(
+            array(15, 'calls to unset()'),
+            array(16, 'calls to isset()'),
+            array(21, 'calls to unset()'),
+            array(27), // x2.
+            array(33),
+            array(36),
+            array(38),
+            array(40),
+            array(44),
+            array(47),
+            array(49),
+            array(52),
+            array(62),
+            array(65),
+        );
+    }
+
+
+    /**
+     * testNoFalsePositives
+     *
+     * @dataProvider dataNoFalsePositives
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositives($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.2');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositives()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositives()
+    {
+        return array(
+            array(6),
+            array(7),
+            array(8),
+            array(9),
+            array(51),
+            array(58),
+            array(59),
+            array(68),
+            array(71),
+        );
+    }
+
+
+    /**
+     * Verify no notices are thrown at all.
+     *
+     * @return void
+     */
+    public function testNoViolationsInFileOnValidVersion()
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '7.3');
+        $this->assertNoViolation($file);
+    }
+
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_trailing_comma.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_trailing_comma.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Allowed pre-PHP 7.3.
+ */
+isset($foo, $bar, $baz);
+unset($foo, $bar, $baz);
+myFunction($foo, $bar);
+$myClosure($foo, $bar);
+
+/*
+ * PHP 7.3 trailing comma's in function calls + isset + unset.
+ */
+// Isset & unset.
+unset($foo, $bar,);
+var_dump(isset($foo, $bar,));
+
+unset(
+    $foo,
+    $bar,
+    $baz,
+);
+
+// Function calls, including calls to methods and closures.
+echo $twig->render(
+    'index.html',
+    compact('title', 'body', 'comments',), // x2.
+);
+
+$newArray = \array_merge(
+    $arrayOne,
+    $arrayTwo,
+    ['foo', 'bar'],
+);
+
+var_dump($whatIsInThere, $probablyABugInThisOne, $oneMoreToCheck,);
+
+$text = SomeNameSpace\PartTwo\PartThree\functionName($en, 'comma', 'Jane',);
+
+$foo = new Foo( 'constructor', 'bar', );
+
+$foo->bar(
+  'method',
+  'bar',
+);
+
+$foo( 'invoke','bar' , );
+
+MyNamespace\Foo::bar('method','bar',);
+
+$bar = function(...$args) {};
+$bar('arg1', 'arg2',);
+
+/*
+ * Still not allowed.
+ */
+// Trailing comma in function declaration.
+function bar($a, $b,) {} // Parse error, but not our concern.
+$closure = function ($a, $b,) {} // Parse error, but not our concern.
+
+// Free-standing comma.
+foo(,); // Parse error, but throw an error anyway.
+
+// Multiple trailing comma's.
+foo('function', 'bar',,); // Parse error, but throw an error anyway.
+
+// Leading comma.
+foo(, 'function', 'bar'); // Parse error, but not our concern.
+
+// List with trailing comma.
+list($drink, $color, $power, ) = $info; // Parse error, but not our concern.


### PR DESCRIPTION
Trailing comma's in function calls, method calls, `isset()` and `unset()` will be allowed as of PHP 7.3.

Refs:
* https://wiki.php.net/rfc/trailing-comma-function-calls
* https://github.com/php/php-src/commit/b591c329ee3129adbdc35141bb1542d119f7a2a1

I've kept the name of the sniff generic to allow for adding more constructs in the future in case trailing comma's will start to be allowed in, for instance, `list()`.

Includes unit tests which are largely based on the example code in the RFC/unit tests in PHP core.