### PR TITLE
Travis: add build to test against minimum supported PHPCS 3.x version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,11 @@ matrix:
     - php: 5.4
       env: PHPCS_VERSION="dev-master" LINT=1 COVERALLS_VERSION="^1.0"
 
-    # Test against a variation of PHPCS 2.x versions.
+    # Test against a variation of PHPCS 2.x versions and the lowest supported PHPCS 3.x version.
     - php: 5.5
       env: PHPCS_VERSION="2.4.*"
+    - php: 5.5
+      env: PHPCS_VERSION="3.0.2"
     - php: 5.6
       env: PHPCS_VERSION="2.8.*"
     - php: 7.0


### PR DESCRIPTION
Since PHPCS 3 came out a number of minor versions have been released.
Currently, the builds were only tested for the PHPCS 3.x range against `dev-master` ( currently `3.3.0-alpha`), while PHPCS 3.0.2 is the minimum supported PHPCS 3.x version.

As there have been numerous changes to the tokenizer between 3.0.2 and `master` which could influence the accuracy of the sniff results, there should be at least one build running the tests against the minimum supported PHPCS 3.x version.