### PR TITLE
Sniff: Add new `isShortList()` utility function

### DIFF
--- a/PHPCompatibility/Tests/BaseClass/IsShortListTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsShortListTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Is short list syntax ? test file
+ *
+ * @package PHPCompatibility
+ */
+
+namespace PHPCompatibility\Tests\BaseClass;
+
+/**
+ * isShortList() function tests
+ *
+ * @group utilityIsShortList
+ * @group utilityFunctions
+ *
+ * @uses    \PHPCompatibility\Tests\BaseClass\MethodTestFrame
+ * @package PHPCompatibility
+ * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ */
+class IsShortListTest extends MethodTestFrame
+{
+
+    /**
+     * The file name for the file containing the test cases within the
+     * `sniff-examples/utility-functions/` directory.
+     *
+     * @var string
+     */
+    protected $filename = 'is_short_list.php';
+
+    /**
+     * testIsShortList
+     *
+     * @dataProvider dataIsShortList
+     *
+     * @covers \PHPCompatibility\Sniff::isShortList
+     *
+     * @param string    $commentString The comment which prefaces the target token in the test file.
+     * @param string    $expected      The expected boolean return value.
+     * @param int|array $targetToken   The token(s) to test with.
+     *
+     * @return void
+     */
+    public function testIsShortList($commentString, $expected, $targetToken = T_OPEN_SHORT_ARRAY)
+    {
+        $stackPtr = $this->getTargetToken($commentString, $targetToken);
+        $result   = $this->helperClass->isShortList($this->phpcsFile, $stackPtr);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * dataIsShortList
+     *
+     * @see testIsShortList()
+     *
+     * @return array
+     */
+    public function dataIsShortList()
+    {
+        return array(
+            array('/* Case 1 */', false, T_ARRAY),
+            array('/* Case 2 */', false, T_LIST),
+            array('/* Case 3 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 4 */', true),
+            array('/* Case 5 */', true, T_CLOSE_SHORT_ARRAY),
+            array('/* Case 6 */', true),
+            array('/* Case 7 */', true),
+            array('/* Case 8 */', true),
+            array('/* Case 9 */', true),
+            array('/* Case 10 */', true),
+            array('/* Case 11 */', true, T_CLOSE_SHORT_ARRAY),
+            array('/* Case 12 */', true),
+            array('/* Case 13 */', true),
+            array('/* Case 14 */', true),
+            array('/* Case 15 */', true),
+            array('/* Case 16 */', true),
+            array('/* Case 17 */', true),
+            array('/* Case 18 */', true),
+            array('/* Case 19 */', true),
+            array('/* Case 20 */', true),
+            array('/* Case 21 */', true),
+            array('/* Case 22 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 23 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 24 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 25 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case 26 */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+            array('/* Case final */', false, array(T_OPEN_SHORT_ARRAY, T_OPEN_SQUARE_BRACKET)),
+        );
+    }
+}

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_short_list.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_short_list.php
@@ -1,0 +1,76 @@
+<?php
+
+/* Case 1 */
+array() = $b;
+
+/* Case 2 */
+list( $a ) = $b;
+
+/* Case 3 */
+$b[] = $c;
+
+/* Case 4 */
+[$b] = $c;
+
+/* Case 5 */
+[$a, $b] = $c;
+
+/* Case 6 */
+[$a, /* Case 7 */ [$b]] = array(new stdclass, array(new stdclass));
+
+/* Case 8 */
+foreach ($data as [$id, $name]) {}
+
+/* Case 9 */
+$foo = [$baz, $bat] = [$a, $b];
+
+/* Case 10 */
+["id" => $id1, "name" => $name1] = $data[0];
+
+/* Case 11 */
+foreach ($data as ["id" => $id, "name" => $name]) {}
+
+// Nested short list syntaxes.
+[$x, /* Case 12 */ [], $y] = $a;
+
+[$x, [ $y, /* Case 13 */ [$z]], $q] = $a;
+
+/* Case 14 */
+[$a, /* Case 15 */ [$b]] = $array;
+
+/* Case 16 */
+[
+	/* Case 17 */
+	["x" => $x1, "y" => $y1],
+	/* Case 18 */
+	["x" => $x2, "y" => $y2],
+	/* Case 19 */
+	["x" => $x3, "y" => $y3],
+] = $points;
+
+/* Case 20 */
+// Invalid list as it doesn't contain variables, but it is short list syntax.
+[42] = [1];
+
+/* Case 21 */
+// Invalid list as mixing short list syntax with list() is not allowed, but it is short list syntax.
+[list($a, $b), list($c, $d)] = [[1, 2], [3, 4]];
+
+/* Case 22 */
+// Parse error, but not short list syntax.
+use Something as [$a];
+
+/* Case 23 */
+$var[$x] = $a;
+
+/* Case 24 */
+$var->prop[$x] = $a;
+
+/* Case 25 */
+${$var}[$x] = $a;
+
+/* Case 26 */
+$var[][$x] = $a;
+
+/* Case final */
+[$a, $b


### PR DESCRIPTION
... to determine whether a short array is in actual fact a short list syntax.

The utility method also accounts for two different PHPCS tokenizer bugs, one which affects PHPCS 1.5.x and the other which affects PHPCS 2.0 - 2.7.x.
There may be more tokenizer bugs we need to account for, but these are the ones I've found so far.

Includes dedicated unit tests.

This new utility function is needed for ~~three~~ five new sniffs + one existing sniff, which all deal with, or at least have to be able to recognize, short `list` constructs.