### PR TITLE
PHP 7.3/NewFunctions: add new `is_countable()` function

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewFunctionsSniff.php
@@ -1685,6 +1685,11 @@ class NewFunctionsSniff extends AbstractNewFeatureSniff
             '7.1' => false,
             '7.2' => true,
         ),
+
+        'is_countable' => array(
+            '7.2' => false,
+            '7.3' => true,
+        ),
     );
 
 

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewFunctionsSniffTest.php
@@ -487,6 +487,8 @@ class NewFunctionsSniffTest extends BaseSniffTest
             array('spl_object_id', '7.1', array(419), '7.2'),
 
             array('pg_lo_truncate', '5.5', array(420), '5.6'),
+
+            array('is_countable', '7.2', array(433), '7.3'),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_functions.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_functions.php
@@ -430,3 +430,4 @@ sodium_crypto_secretstream_xchacha20poly1305_keygen();
 sodium_crypto_secretstream_xchacha20poly1305_pull();
 sodium_crypto_secretstream_xchacha20poly1305_push();
 sodium_crypto_secretstream_xchacha20poly1305_rekey();
+is_countable();


### PR DESCRIPTION
Ref:
* https://wiki.php.net/rfc/is-countable
* https://github.com/php/php-src/commit/d0ee2a8254c69546c7191ac26cdc0499eba27acf

I expect that lots of userland `is_countable()` functions will be/have been added since PHP 7.2 added the "counting non-countable" warning.

This should give people plenty of warning that they'll need to wrap that function within a `if (function_exists() === false ) {}` wrapper.

---
P.S.: build failure is unrelated to this PR, see #639