### PR TITLE
Fix `getReturnTypeHintToken()` and `getReturnTypeHintName()` to deal with PHPCS 3.3.0 tokenizer changes

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewClassesSniff.php
@@ -593,7 +593,8 @@ class NewClassesSniff extends AbstractNewFeatureSniff
             case 'T_CLOSURE':
                 $this->processFunctionToken($phpcsFile, $stackPtr);
 
-                // Deal with older PHPCS version which don't recognize return type hints.
+                // Deal with older PHPCS version which don't recognize return type hints
+                // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
                 $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
                 if ($returnTypeHint !== false) {
                     $this->processReturnTypeToken($phpcsFile, $returnTypeHint);

--- a/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewInterfacesSniff.php
@@ -156,7 +156,8 @@ class NewInterfacesSniff extends AbstractNewFeatureSniff
             case 'T_CLOSURE':
                 $this->processFunctionToken($phpcsFile, $stackPtr);
 
-                // Deal with older PHPCS versions which don't recognize return type hints.
+                // Deal with older PHPCS versions which don't recognize return type hints
+                // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
                 $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
                 if ($returnTypeHint !== false) {
                     $this->processReturnTypeToken($phpcsFile, $returnTypeHint);

--- a/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewNullableTypesSniff.php
@@ -73,7 +73,8 @@ class NewNullableTypesSniff extends Sniff
         if ($tokenCode === T_FUNCTION || $tokenCode === T_CLOSURE) {
             $this->processFunctionDeclaration($phpcsFile, $stackPtr);
 
-            // Deal with older PHPCS version which don't recognize return type hints.
+            // Deal with older PHPCS version which don't recognize return type hints
+            // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
             $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
             if ($returnTypeHint !== false) {
                 $this->processReturnType($phpcsFile, $returnTypeHint);

--- a/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewReturnTypeDeclarationsSniff.php
@@ -120,7 +120,8 @@ class NewReturnTypeDeclarationsSniff extends AbstractNewFeatureSniff
     {
         $tokens = $phpcsFile->getTokens();
 
-        // Deal with older PHPCS version which don't recognize return type hints.
+        // Deal with older PHPCS version which don't recognize return type hints
+        // as well as newer PHPCS versions (3.3.0+) where the tokenization has changed.
         if ($tokens[$stackPtr]['code'] === T_FUNCTION || $tokens[$stackPtr]['code'] === T_CLOSURE) {
             $returnTypeHint = $this->getReturnTypeHintToken($phpcsFile, $stackPtr);
             if ($returnTypeHint !== false) {


### PR DESCRIPTION
The `T_RETURN_TYPE` and `T_ARRAY_HINT` tokens which were introduced in PHPCS 2.4.0 and 2.3.3 respectively, have both been deprecated in PHPCS 3.3.0 and will be removed in PHPCS 4.0.

The changes in this PR should provide the necessary support for cross-version PHPCS type declaration recognition, including PHPCS 3.3.0+.

Fixes #639