### PR TITLE
NewScalarTypeDeclarations: minor message text change

### DIFF
--- a/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
+++ b/PHPCompatibility/Sniffs/PHP/NewScalarTypeDeclarationsSniff.php
@@ -131,7 +131,7 @@ class NewScalarTypeDeclarationsSniff extends AbstractNewFeatureSniff
 
             if ($supportsPHP4 === true) {
                 $phpcsFile->addError(
-                    'Type hints were not present in PHP 4.4 or earlier.',
+                    'Type declarations were not present in PHP 4.4 or earlier.',
                     $param['token'],
                     'TypeHintFound'
                 );
@@ -164,7 +164,6 @@ class NewScalarTypeDeclarationsSniff extends AbstractNewFeatureSniff
                 );
 
                 $phpcsFile->addError($error, $param['token'], 'InvalidTypeHintFound', $data);
-
             }
         }
     }//end process()

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewScalarTypeDeclarationsSniffTest.php
@@ -167,7 +167,7 @@ class NewScalarTypeDeclarationsSniffTest extends BaseSniffTest
     public function testTypeDeclaration($line, $testNoViolation = false)
     {
         $file = $this->sniffFile(self::TEST_FILE, '4.4');
-        $this->assertError($file, $line, 'Type hints were not present in PHP 4.4 or earlier');
+        $this->assertError($file, $line, 'Type declarations were not present in PHP 4.4 or earlier');
 
         if ($testNoViolation === true) {
             $file = $this->sniffFile(self::TEST_FILE, '5.0');


### PR DESCRIPTION
While in PHP 5 "type hints" were introduced, the name of these have since been changed to "type declarations" to better cover their usage.

This brings the error message text in line with the changed terminology.