### PR TITLE
`getReturnTypeHintToken()`: bug fix

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -983,7 +983,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         $tokens = $phpcsFile->getTokens();
 
         if (defined('T_RETURN_TYPE') && $tokens[$stackPtr]['code'] === T_RETURN_TYPE) {
-            return $tokens[$stackPtr]['code'];
+            return $stackPtr;
         }
 
         if ($tokens[$stackPtr]['code'] !== T_FUNCTION && $tokens[$stackPtr]['code'] !== T_CLOSURE) {


### PR DESCRIPTION
The return is expected to be an `int` `$stackPtr`, not a token code.