### PR TITLE
Utility `isNumber()`: various improvements

### DIFF
--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1532,13 +1532,13 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         }
 
         $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, $start, $searchEnd, true);
-        if ($nextNonEmpty !== false
+        while ($nextNonEmpty !== false
             && ($tokens[$nextNonEmpty]['code'] === T_PLUS
             || $tokens[$nextNonEmpty]['code'] === T_MINUS)
         ) {
 
             if ($tokens[$nextNonEmpty]['code'] === T_MINUS) {
-                $negativeNumber = true;
+                $negativeNumber = ($negativeNumber === false ) ? true : false;
             }
 
             $nextNonEmpty = $phpcsFile->findNext(\PHP_CodeSniffer_Tokens::$emptyTokens, ($nextNonEmpty + 1), $searchEnd, true);

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1606,17 +1606,21 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             // Does the text string start with a number ? If so, PHP would juggle it and use it as a number.
             if ($allowFloats === false) {
                 if ($intString !== 1 || $floatString === 1) {
-                    // Found non-numeric start or float. Only integers targetted.
-                    return false;
-                }
+                    if ($floatString === 1) {
+                        // Found float. Only integers targetted.
+                        return false;
+                    }
 
-                $content = (float) trim($intMatch[0]);
+                    $content = 0.0;
+                } else {
+                    $content = (float) trim($intMatch[0]);
+                }
             } else {
                 if ($intString !== 1 && $floatString !== 1) {
-                    return false;
+                    $content = 0.0;
+                } else {
+                    $content = ($floatString === 1) ? (float) trim($floatMatch[0]) : (float) trim($intMatch[0]);
                 }
-
-                $content = ($floatString === 1) ? (float) trim($floatMatch[0]) : (float) trim($intMatch[0]);
             }
 
             // Allow for different behaviour for hex numeric strings between PHP 5 vs PHP 7.

--- a/PHPCompatibility/Sniff.php
+++ b/PHPCompatibility/Sniff.php
@@ -1515,6 +1515,7 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
         $validTokens[T_LNUMBER] = true;
         $validTokens[T_TRUE]    = true; // Evaluates to int 1.
         $validTokens[T_FALSE]   = true; // Evaluates to int 0.
+        $validTokens[T_NULL]    = true; // Evaluates to int 0.
 
         if ($allowFloats === true) {
             $validTokens[T_DNUMBER] = true;
@@ -1554,7 +1555,9 @@ abstract class Sniff implements \PHP_CodeSniffer_Sniff
             $content = (float) $tokens[$nextNonEmpty]['content'];
         } elseif ($tokens[$nextNonEmpty]['code'] === T_TRUE) {
             $content = 1.0;
-        } elseif ($tokens[$nextNonEmpty]['code'] === T_FALSE) {
+        } elseif ($tokens[$nextNonEmpty]['code'] === T_FALSE
+            || $tokens[$nextNonEmpty]['code'] === T_NULL
+        ) {
             $content = 0.0;
         } elseif (isset($stringTokens[$tokens[$nextNonEmpty]['code']]) === true) {
 

--- a/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
@@ -121,6 +121,7 @@ class IsNumberTest extends MethodTestFrame
             array('/* Case I12 */', false, 10, true, false),
             array('/* Case I14 */', false, -1, false, true),
             array('/* Case I15 */', false, 123, true, false),
+            array('/* Case I16 */', false, 10, true, false),
 
             array('/* Case I1 */', true, 1.0, true, false),
             array('/* Case I2 */', true, -10.0, false, true),
@@ -136,6 +137,7 @@ class IsNumberTest extends MethodTestFrame
             array('/* Case I12 */', true, 10.0, true, false),
             array('/* Case I14 */', true, -1.0, false, true),
             array('/* Case I15 */', true, 123.0, true, false),
+            array('/* Case I16 */', true, 10.0, true, false),
 
             array('/* Case F1 */', false, false, false, false),
             array('/* Case F2 */', false, false, false, false),

--- a/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
@@ -77,7 +77,6 @@ class IsNumberTest extends MethodTestFrame
         return array(
             array('/* Case 1 */', true, false, false, false),
             array('/* Case 2 */', true, false, false, false),
-            array('/* Case 3 */', true, false, false, false),
             array('/* Case 4 */', true, false, false, false),
             array('/* Case 5 */', true, false, false, false),
             array('/* Case 6 */', true, false, false, false),
@@ -92,6 +91,7 @@ class IsNumberTest extends MethodTestFrame
             array('/* Case ZI4 */', false, 0, false, false),
             array('/* Case ZI5 */', false, -0, false, false),
             array('/* Case ZI6 */', false, 0, false, false),
+            array('/* Case ZI7 */', false, 0, false, false),
 
             array('/* Case ZI1 */', true, 0.0, false, false),
             array('/* Case ZI2 */', true, 0.0, false, false),
@@ -99,6 +99,7 @@ class IsNumberTest extends MethodTestFrame
             array('/* Case ZI4 */', true, 0.0, false, false),
             array('/* Case ZI5 */', true, -0.0, false, false),
             array('/* Case ZI6 */', true, 0.0, false, false),
+            array('/* Case ZI7 */', true, 0.0, false, false),
 
             array('/* Case ZF1 */', false, false, false, false),
             array('/* Case ZF2 */', false, false, false, false),

--- a/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
+++ b/PHPCompatibility/Tests/BaseClass/IsNumberTest.php
@@ -91,12 +91,14 @@ class IsNumberTest extends MethodTestFrame
             array('/* Case ZI3 */', false, -0, false, false),
             array('/* Case ZI4 */', false, 0, false, false),
             array('/* Case ZI5 */', false, -0, false, false),
+            array('/* Case ZI6 */', false, 0, false, false),
 
             array('/* Case ZI1 */', true, 0.0, false, false),
             array('/* Case ZI2 */', true, 0.0, false, false),
             array('/* Case ZI3 */', true, -0.0, false, false),
             array('/* Case ZI4 */', true, 0.0, false, false),
             array('/* Case ZI5 */', true, -0.0, false, false),
+            array('/* Case ZI6 */', true, 0.0, false, false),
 
             array('/* Case ZF1 */', false, false, false, false),
             array('/* Case ZF2 */', false, false, false, false),

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
@@ -12,9 +12,6 @@ $a = [];
 /* Case 2 */
 $a = - $b;
 
-/* Case 3 */
-$a = - 'not a numeric string';
-
 /* Case 4 */
 $a = +;
 
@@ -59,6 +56,10 @@ $a = - '        0 things';
 
 /* Case ZI6 */
 $a = null;
+
+/* Case ZI7 */
+$a = - 'not a numeric string';
+
 
 /*
  * Make sure that zero numbers are correctly identified.

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
@@ -57,6 +57,9 @@ $a = '0';
 /* Case ZI5 */
 $a = - '        0 things';
 
+/* Case ZI6 */
+$a = null;
+
 /*
  * Make sure that zero numbers are correctly identified.
  *

--- a/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
+++ b/PHPCompatibility/Tests/sniff-examples/utility-functions/is_number.php
@@ -134,6 +134,8 @@ $a = - true;
 /* Case I15 */
 $a = + '  0123 things';
 
+/* Case I16 */
+$a = -+-+10;
 
 /*
  * Make sure that numbers are correctly identified.


### PR DESCRIPTION
I originally wrote the utility function just to recognize negative numbers. At a later point, I changed it around to also recognize positive numbers and zero and moved the positive/negative check to separate functions.

However, I must have been distracted while doing this as there are two cases which would evaluate to zero which I had not yet adapted the function for.

The first two commits fix these two bugs and adds unit tests for them.

The last commit improves the handling of numbers which are preceded by multiple signs, i.e `-+-+- 10`.
Includes unit test as well.

Related to #610