### PR TITLE
PHPCS: add some PHPCS 3.x options to the PHPCompatibility native ruleset

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,6 +13,13 @@
     <!-- Exclude Composer vendor directory. -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
+
     <!--
         PHP cross version compatibility ;-).
     -->


### PR DESCRIPTION
As the PHPCompatibility own check for consistent code style is run on PHPCS 3.x, we may as well take advantage of some of the new features.

* Clean up the report by only showing the relevant part of the path to the scanned file.
* Whenever possible scan files in parallel for speed improvement.