### PR TITLE
NewClosure: report usage of self/parent/static for PHP < 5.4 + prevent double notices

### DIFF
--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -236,6 +236,75 @@ class NewClosureSniffTest extends BaseSniffTest
         );
     }
 
+
+    /**
+     * Test using self/parent/static in closures.
+     *
+     * @dataProvider dataClassRefInClosure
+     *
+     * @param int    $line The line number.
+     * @param string $ref  The class reference encountered.
+     *
+     * @return void
+     */
+    public function testClassRefInClosure($line, $ref)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertError($file, $line, 'Closures / anonymous functions could not use "' . $ref . '::" in PHP 5.3 or earlier');
+
+        $file = $this->sniffFile(self::TEST_FILE, '5.4');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testClassRefInClosure()
+     *
+     * @return array
+     */
+    public function dataClassRefInClosure()
+    {
+        return array(
+            array(83, 'self'),
+            array(84, 'self'),
+            array(85, 'parent'),
+            array(86, 'static'),
+        );
+    }
+
+
+    /**
+     * Test no false positives for other uses of static within closures.
+     *
+     * @dataProvider dataNoFalsePositivesClassRefInClosure
+     *
+     * @param int $line The line number.
+     *
+     * @return void
+     */
+    public function testNoFalsePositivesClassRefInClosure($line)
+    {
+        $file = $this->sniffFile(self::TEST_FILE, '5.3');
+        $this->assertNoViolation($file, $line);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @see testNoFalsePositivesClassRefInClosure()
+     *
+     * @return array
+     */
+    public function dataNoFalsePositivesClassRefInClosure()
+    {
+        return array(
+            array(88),
+            array(90),
+        );
+    }
+
+
     /*
      * `testNoViolationsInFileOnValidVersion` test omitted as this sniff will throw warnings/errors
      * about the use of closures in PHP < 5.3 and about invalid usage of $this in closures for PHP 5.4+.

--- a/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
+++ b/PHPCompatibility/Tests/Sniffs/PHP/NewClosureSniffTest.php
@@ -146,6 +146,7 @@ class NewClosureSniffTest extends BaseSniffTest
             array(32, false),
             array(33, false),
             array(53, false),
+            array(68),
         );
     }
 

--- a/PHPCompatibility/Tests/sniff-examples/new_closure.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_closure.php
@@ -5,7 +5,7 @@ spl_autoload_register( function ( $class ) {
 
 function something() {}
 
-// PHP 5.4+,
+// PHP 5.4+.
 class Test
 {
     // PHP 5.4+: Static closures.
@@ -71,3 +71,22 @@ class NestedClosures {
 	}
 }
 
+// More PHP 5.4+: using self/parent/static in class context.
+class SelfTest
+{
+	const ABC = '';
+
+    // PHP 5.4+: Using self/parent/static in a class context.
+    public function testThis()
+    {
+        return function() {
+            var_dump(SELF::ABC);
+            var_dump(self::ABC); // Let's make sure we get an error for each line using self.
+            var_dump(parent::ABC);
+            var_dump(static::ABC);
+            
+            static $a = 'abc';
+            static function() {};
+        };
+    }
+}

--- a/PHPCompatibility/Tests/sniff-examples/new_closure.php
+++ b/PHPCompatibility/Tests/sniff-examples/new_closure.php
@@ -59,3 +59,15 @@ $closure = $closure->bindTo($foo);
 function() {
    var_dump($something);
 }
+
+// Make sure $this in nested closures does not get reported twice.
+class NestedClosures {
+	public function testIt() {
+		$a = function() {
+			return function() {
+				return $this;
+			};
+		}
+	}
+}
+


### PR DESCRIPTION
### NewClosure: prevent double reporting for nested closures

As pointed out by @moorscode, closures can be nested within closures. As the sniff was, that would result in the notices for the inner closure being thrown twice.

The first commit fixes this.

Includes unit test, though this can not be automatically tested with the unit test framework as is.
The unit test is there so manual testing will pick up on it.

### PHP 5.4: NewClosure: report on `self/parent/static::` being used in PHP < 5.4

Not mentioned in the manual, but both the test sample provided by @asadkn as well as further tests I ran confirmed that this was changed in PHP 5.4

Includes unit tests.

Fixes #668

