### PR TITLE
Add is_countable to Joomla ruleset

### DIFF
--- a/framework-rulesets/joomla.xml
+++ b/framework-rulesets/joomla.xml
@@ -169,6 +169,9 @@
         <!-- Via `symfony/polyfill-php56` -->
         <exclude name="PHPCompatibility.PHP.NewFunctions.hash_equalsFound"/>
         <exclude name="PHPCompatibility.PHP.NewFunctions.ldap_escapeFound"/>
+
+        <!-- Via `symfony/polyfill-php73` -->
+        <exclude name="PHPCompatibility.PHP.NewFunctions.is_countableFound"/>
     </rule>
 
 </ruleset>


### PR DESCRIPTION
We added Symfony's PHP 7.3 polyfill and support `is_countable()` through it.